### PR TITLE
Fix #27: eliminate concurrent panics in WebSocket hub

### DIFF
--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"log"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -23,6 +24,8 @@ type Client struct {
 	Hub       *Hub
 	Conn      *websocket.Conn
 	send      chan []byte
+	done      chan struct{}
+	closeOnce sync.Once
 	User      *models.User
 	OnMessage MessageHandler
 	ProjectID string
@@ -36,6 +39,7 @@ func NewClient(hub *Hub, conn *websocket.Conn, projectID, userID, userName strin
 		Hub:       hub,
 		Conn:      conn,
 		send:      make(chan []byte, 256),
+		done:      make(chan struct{}),
 		ProjectID: projectID,
 		UserID:    userID,
 		UserName:  userName,
@@ -44,12 +48,34 @@ func NewClient(hub *Hub, conn *websocket.Conn, projectID, userID, userName strin
 	}
 }
 
+// Close signals the client to shut down. Safe to call multiple times.
+func (c *Client) Close() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
+}
+
+// Done returns a channel that is closed when the client shuts down.
+func (c *Client) Done() <-chan struct{} {
+	return c.done
+}
+
 // Send queues a message for sending to this client.
-func (c *Client) Send(data []byte) {
+// Returns false if the client is closed or the buffer is full.
+func (c *Client) Send(data []byte) bool {
+	select {
+	case <-c.done:
+		return false
+	default:
+	}
 	select {
 	case c.send <- data:
+		return true
+	case <-c.done:
+		return false
 	default:
 		log.Printf("ws: client send buffer full, dropping message for user %s", c.UserID)
+		return false
 	}
 }
 
@@ -93,16 +119,15 @@ func (c *Client) WritePump() {
 
 	for {
 		select {
-		case message, ok := <-c.send:
+		case message := <-c.send:
 			_ = c.Conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if !ok {
-				// Hub closed the channel
-				_ = c.Conn.WriteMessage(websocket.CloseMessage, []byte{})
-				return
-			}
 			if err := c.Conn.WriteMessage(websocket.TextMessage, message); err != nil {
 				return
 			}
+
+		case <-c.done:
+			_ = c.Conn.WriteMessage(websocket.CloseMessage, []byte{})
+			return
 
 		case <-ticker.C:
 			_ = c.Conn.SetWriteDeadline(time.Now().Add(writeWait))

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -42,7 +42,7 @@ func (h *Hub) Run() {
 			if room, ok := h.rooms[client.ProjectID]; ok {
 				if _, exists := room[client]; exists {
 					delete(room, client)
-					close(client.send)
+					client.Close()
 					if len(room) == 0 {
 						delete(h.rooms, client.ProjectID)
 					}
@@ -67,17 +67,16 @@ func (h *Hub) Unregister(client *Client) {
 func (h *Hub) Broadcast(projectID string, data []byte, exclude *Client) {
 	h.mu.RLock()
 	room := h.rooms[projectID]
+	targets := make([]*Client, 0, len(room))
+	for client := range room {
+		if client != exclude {
+			targets = append(targets, client)
+		}
+	}
 	h.mu.RUnlock()
 
-	for client := range room {
-		if client == exclude {
-			continue
-		}
-		select {
-		case client.send <- data:
-		default:
-			// Client buffer full — drop message to avoid blocking
-		}
+	for _, client := range targets {
+		client.Send(data)
 	}
 }
 

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -32,7 +32,7 @@ func TestRegisterAddsClientToRoom(t *testing.T) {
 	}
 }
 
-func TestUnregisterRemovesClientAndClosesSend(t *testing.T) {
+func TestUnregisterRemovesClientAndSignalsDone(t *testing.T) {
 	hub := NewHub()
 	go hub.Run()
 
@@ -43,10 +43,12 @@ func TestUnregisterRemovesClientAndClosesSend(t *testing.T) {
 	hub.Unregister(c)
 	time.Sleep(settle)
 
-	// send channel should be closed
-	_, open := <-c.send
-	if open {
-		t.Fatal("send channel was not closed")
+	// done channel should be closed
+	select {
+	case <-c.Done():
+		// expected
+	default:
+		t.Fatal("done channel was not closed after unregister")
 	}
 }
 
@@ -260,6 +262,50 @@ func TestMultipleRoomsAreIndependent(t *testing.T) {
 		t.Fatalf("client in proj-b received proj-a message: %q", msg)
 	case <-time.After(50 * time.Millisecond):
 		// expected
+	}
+}
+
+func TestConcurrentBroadcastAndUnregister(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	const numClients = 50
+	clients := make([]*Client, numClients)
+	for i := range clients {
+		clients[i] = NewClient(hub, nil, "proj-race", "user-"+string(rune('A'+i)), "U", nil, nil)
+		hub.Register(clients[i])
+	}
+	time.Sleep(settle)
+
+	var wg sync.WaitGroup
+
+	// Broadcast concurrently while unregistering clients
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			hub.Broadcast("proj-race", []byte("msg"), nil)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for _, c := range clients {
+			hub.Unregister(c)
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+	// If we get here without a panic, the race is fixed
+}
+
+func TestSendAfterCloseReturnsFalse(t *testing.T) {
+	hub := NewHub()
+	c := newTestClient(hub, "proj-1")
+	c.Close()
+
+	if c.Send([]byte("late")) {
+		t.Fatal("Send should return false after Close")
 	}
 }
 

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -283,7 +283,7 @@ func TestConcurrentBroadcastAndUnregister(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 200; i++ {
+		for range 200 {
 			hub.Broadcast("proj-race", []byte("msg"), nil)
 		}
 	}()


### PR DESCRIPTION
## Summary

- **Snapshot recipients under RLock** in `Broadcast()` before sending — fixes concurrent map iteration + deletion panic
- **Replace `close(send)` with a `done` channel** on `Client` — eliminates send-on-closed-channel panic  
- **Add `TestConcurrentBroadcastAndUnregister`** — 50 clients, 200 broadcasts racing against unregisters, passes with `-race`

## What changed

| File | Change |
|------|--------|
| `internal/ws/client.go` | Add `done` channel + `sync.Once`, `Close()`/`Done()`/`Send()` methods; `WritePump` selects on `done` |
| `internal/ws/hub.go` | `Broadcast` snapshots clients under lock; `Run` calls `client.Close()` instead of `close(client.send)` |
| `internal/ws/hub_test.go` | New concurrency test + `TestSendAfterCloseReturnsFalse`; updated existing test for `done` signal |

## Test plan

- [x] All 13 ws tests pass with `-race -count=1`
- [x] New `TestConcurrentBroadcastAndUnregister` stresses the exact race path
- [x] `go build ./...` succeeds
- [ ] Manual: open multiple browser tabs on the same project, rapidly close/reopen tabs while chat messages are sent


🤖 Generated with [Claude Code](https://claude.com/claude-code)