### PR TITLE
Fix #34: validate SESSION_SECRET minimum length at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,9 @@ func Load() (*Config, error) {
 	if sessionSecret == "" {
 		return nil, fmt.Errorf("SESSION_SECRET is required")
 	}
+	if len(sessionSecret) < 32 {
+		return nil, fmt.Errorf("SESSION_SECRET must be at least 32 bytes, got %d", len(sessionSecret))
+	}
 
 	listenAddr := os.Getenv("LISTEN_ADDR")
 	if listenAddr == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,8 @@ import (
 func setRequired(t *testing.T) {
 	t.Helper()
 	t.Setenv("DATABASE_URL", "postgres://localhost/testdb")
-	t.Setenv("SESSION_SECRET", "test-secret-key")
+	t.Setenv("SESSION_SECRET", "test-secret-key-that-is-32-bytes!")
+	t.Setenv("AES_ENCRYPTION_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 }
 
 func TestEnvOrDefault(t *testing.T) {
@@ -32,7 +33,7 @@ func TestEnvOrDefault(t *testing.T) {
 func TestLoad_MissingRequired(t *testing.T) {
 	t.Run("fails without DATABASE_URL", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "")
-		t.Setenv("SESSION_SECRET", "some-secret")
+		t.Setenv("SESSION_SECRET", "some-secret-that-is-at-least-32b!")
 
 		cfg, err := Load()
 		if err == nil {
@@ -42,6 +43,22 @@ func TestLoad_MissingRequired(t *testing.T) {
 			t.Fatal("expected nil config on error")
 		}
 		if err.Error() != "DATABASE_URL is required" {
+			t.Errorf("unexpected error message: %s", err)
+		}
+	})
+
+	t.Run("fails with short SESSION_SECRET", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://localhost/db")
+		t.Setenv("SESSION_SECRET", "too-short")
+
+		cfg, err := Load()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if cfg != nil {
+			t.Fatal("expected nil config on error")
+		}
+		if err.Error() != "SESSION_SECRET must be at least 32 bytes, got 9" {
 			t.Errorf("unexpected error message: %s", err)
 		}
 	})
@@ -295,8 +312,8 @@ func TestLoad_DirectEnvPassthrough(t *testing.T) {
 	if cfg.DatabaseURL != "postgres://localhost/testdb" {
 		t.Errorf("DatabaseURL = %q, want %q", cfg.DatabaseURL, "postgres://localhost/testdb")
 	}
-	if cfg.SessionSecret != "test-secret-key" {
-		t.Errorf("SessionSecret = %q, want %q", cfg.SessionSecret, "test-secret-key")
+	if cfg.SessionSecret != "test-secret-key-that-is-32-bytes!" {
+		t.Errorf("SessionSecret = %q, want %q", cfg.SessionSecret, "test-secret-key-that-is-32-bytes!")
 	}
 	if cfg.SMTPHost != "smtp.example.com" {
 		t.Errorf("SMTPHost = %q, want %q", cfg.SMTPHost, "smtp.example.com")


### PR DESCRIPTION
## Summary

- **Add length validation** in `config.Load()` — rejects `SESSION_SECRET` shorter than 32 bytes with a clear error instead of letting `main.go` panic on `SessionSecret[:32]`
- **Fix test helper** — `setRequired()` was missing `AES_ENCRYPTION_KEY`, causing pre-existing test failures in CI

## What changed

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `len(sessionSecret) < 32` check after the emptiness check |
| `internal/config/config_test.go` | Update `setRequired()` with 32+ byte secret + AES key; add `"fails with short SESSION_SECRET"` test |

## Test plan

- [x] All 26 config tests pass
- [x] New test verifies short secret returns descriptive error (not panic)
- [x] `go build ./...` succeeds
- [ ] Manual: set `SESSION_SECRET=short` and verify server prints error and exits cleanly


🤖 Generated with [Claude Code](https://claude.com/claude-code)