### PR TITLE
Fix #26: enforce same-project ticket parentage and deep cascade

### DIFF
--- a/internal/handlers/assistant.go
+++ b/internal/handlers/assistant.go
@@ -696,11 +696,14 @@ func (e *toolExecutor) createTicket(ctx context.Context, args map[string]any) (m
 
 	if parentID != "" {
 		parent, parentErr := e.db.GetTicket(ctx, parentID)
-		if parentErr != nil {
-			return map[string]any{"error": "parent ticket not found"}, nil //nolint:nilerr // tool result returns error in response map
-		}
-		if parent.ProjectID != projectID {
-			return map[string]any{"error": "parent ticket must belong to the same project"}, nil
+		switch {
+		case isRowMiss(parentErr):
+			return map[string]any{"error": "parent ticket not found"}, nil
+		case parentErr != nil:
+			return nil, fmt.Errorf("looking up parent ticket: %w", parentErr)
+		case parent.ProjectID != projectID:
+			// Same opaque message as not-found to avoid cross-tenant existence leaks.
+			return map[string]any{"error": "parent ticket not found"}, nil
 		}
 	}
 

--- a/internal/handlers/assistant.go
+++ b/internal/handlers/assistant.go
@@ -694,6 +694,16 @@ func (e *toolExecutor) createTicket(ctx context.Context, args map[string]any) (m
 		return map[string]any{"error": ticketType + "s require a parent_id (use search_tickets to find the parent epic/task first)"}, nil
 	}
 
+	if parentID != "" {
+		parent, parentErr := e.db.GetTicket(ctx, parentID)
+		if parentErr != nil {
+			return map[string]any{"error": "parent ticket not found"}, nil //nolint:nilerr // tool result returns error in response map
+		}
+		if parent.ProjectID != projectID {
+			return map[string]any{"error": "parent ticket must belong to the same project"}, nil
+		}
+	}
+
 	ticket := &models.Ticket{
 		ProjectID:           projectID,
 		Type:                ticketType,

--- a/internal/handlers/tickets.go
+++ b/internal/handlers/tickets.go
@@ -160,6 +160,17 @@ func (h *TicketHandler) CreateTicket(w http.ResponseWriter, r *http.Request) {
 	parentID := r.FormValue("parent_id")
 	var parentPtr *string
 	if parentID != "" {
+		// Enforce same-project parentage at the handler level for a
+		// friendlier error than the FK violation we'd otherwise surface.
+		parent, parentErr := h.db.GetTicket(r.Context(), parentID)
+		if parentErr != nil {
+			http.Error(w, "Parent ticket not found", http.StatusBadRequest)
+			return
+		}
+		if parent.ProjectID != projectID {
+			http.Error(w, "Parent ticket must belong to the same project", http.StatusBadRequest)
+			return
+		}
 		parentPtr = &parentID
 	}
 

--- a/internal/handlers/tickets.go
+++ b/internal/handlers/tickets.go
@@ -160,15 +160,26 @@ func (h *TicketHandler) CreateTicket(w http.ResponseWriter, r *http.Request) {
 	parentID := r.FormValue("parent_id")
 	var parentPtr *string
 	if parentID != "" {
-		// Enforce same-project parentage at the handler level for a
-		// friendlier error than the FK violation we'd otherwise surface.
+		// Enforce same-project parentage at the handler level. We keep
+		// three error cases distinct (per Codex/Gemini review feedback):
+		//   * pgx.ErrNoRows           → 404 "Parent ticket not found"
+		//   * parent in another proj → 404 with the SAME message so a
+		//                              client with access to one project
+		//                              cannot probe ticket IDs across
+		//                              tenants (existence leak). (#26)
+		//   * any other DB error      → 500, so infra incidents are not
+		//                              masked as input errors.
 		parent, parentErr := h.db.GetTicket(r.Context(), parentID)
-		if parentErr != nil {
-			http.Error(w, "Parent ticket not found", http.StatusBadRequest)
+		switch {
+		case isRowMiss(parentErr):
+			http.Error(w, "Parent ticket not found", http.StatusNotFound)
 			return
-		}
-		if parent.ProjectID != projectID {
-			http.Error(w, "Parent ticket must belong to the same project", http.StatusBadRequest)
+		case parentErr != nil:
+			log.Printf("looking up parent ticket: %v", parentErr)
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		case parent.ProjectID != projectID:
+			http.Error(w, "Parent ticket not found", http.StatusNotFound)
 			return
 		}
 		parentPtr = &parentID

--- a/internal/handlers/tickets_authz_test.go
+++ b/internal/handlers/tickets_authz_test.go
@@ -264,3 +264,60 @@ func TestClientMemberCanWriteInOwnOrg(t *testing.T) {
 		}
 	})
 }
+
+// TestCreateTicketCrossProjectParent verifies that supplying a parent_id
+// from another project (even one the user also has access to) does not
+// leak existence of the other project's tickets. Per Codex review on #26,
+// the handler must return the same 404 "Parent ticket not found" for
+// both "nonexistent parent" and "parent in different project".
+func TestCreateTicketCrossProjectParent(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	// One org with two projects, one member with access to both.
+	org, err := db.CreateOrg(ctx, "DualProj", "dualproj")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	projA, err := db.CreateProject(ctx, org.ID, "A", "dualproj-a")
+	if err != nil {
+		t.Fatalf("create projA: %v", err)
+	}
+	projB, err := db.CreateProject(ctx, org.ID, "B", "dualproj-b")
+	if err != nil {
+		t.Fatalf("create projB: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "xp@test.com", "client")
+	user, _ := db.GetUserByEmail(ctx, "xp@test.com")
+	if err = db.AddOrgMember(ctx, user.ID, org.ID, "member"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	parentInA := &models.Ticket{
+		ProjectID: projA.ID, Type: "feature", Title: "Parent", Status: "backlog", Priority: "medium", CreatedBy: user.ID,
+	}
+	if err = db.CreateTicket(ctx, parentInA); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	// Attempt to create a child in project B pointing at the parent in project A.
+	form := url.Values{
+		"project_id": {projB.ID},
+		"parent_id":  {parentInA.ID},
+		"title":      {"Child"},
+		"type":       {"task"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/tickets", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 (same as missing parent, no enumeration leak), got %d: %s", rec.Code, rec.Body.String())
+	}
+	// The body must not reveal that the parent exists in another project.
+	if body := rec.Body.String(); strings.Contains(body, "same project") || strings.Contains(body, "different") {
+		t.Errorf("body leaked cross-project existence: %q", body)
+	}
+}

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -919,8 +919,17 @@ func scanTickets(rows pgx.Rows) ([]Ticket, error) {
 // ── Ticket Archive / Delete ───────────────────────────────────────
 
 func (db *DB) ArchiveTicket(ctx context.Context, id string) error {
+	// Recursively archive the whole subtree (ticket + children + grandchildren...).
+	// The old query only reached one level with `parent_id = $1`, leaving
+	// grandchildren visible and orphaned-looking.
 	_, err := db.Pool.Exec(ctx,
-		`UPDATE tickets SET archived_at = now(), updated_at = now() WHERE id = $1 OR parent_id = $1`, id)
+		`WITH RECURSIVE subtree(id) AS (
+			SELECT id FROM tickets WHERE id = $1
+			UNION ALL
+			SELECT t.id FROM tickets t JOIN subtree s ON t.parent_id = s.id
+		)
+		UPDATE tickets SET archived_at = now(), updated_at = now()
+		WHERE id IN (SELECT id FROM subtree)`, id)
 	if err != nil {
 		return fmt.Errorf("archiving ticket: %w", err)
 	}
@@ -928,8 +937,15 @@ func (db *DB) ArchiveTicket(ctx context.Context, id string) error {
 }
 
 func (db *DB) RestoreTicket(ctx context.Context, id string) error {
+	// Recursively restore the whole subtree, mirroring ArchiveTicket.
 	_, err := db.Pool.Exec(ctx,
-		`UPDATE tickets SET archived_at = NULL, updated_at = now() WHERE id = $1 OR parent_id = $1`, id)
+		`WITH RECURSIVE subtree(id) AS (
+			SELECT id FROM tickets WHERE id = $1
+			UNION ALL
+			SELECT t.id FROM tickets t JOIN subtree s ON t.parent_id = s.id
+		)
+		UPDATE tickets SET archived_at = NULL, updated_at = now()
+		WHERE id IN (SELECT id FROM subtree)`, id)
 	if err != nil {
 		return fmt.Errorf("restoring ticket: %w", err)
 	}
@@ -937,12 +953,9 @@ func (db *DB) RestoreTicket(ctx context.Context, id string) error {
 }
 
 func (db *DB) DeleteTicket(ctx context.Context, id string) error {
-	// Delete children first (comments/activities cascade via FK)
-	_, err := db.Pool.Exec(ctx, `DELETE FROM tickets WHERE parent_id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("deleting child tickets: %w", err)
-	}
-	_, err = db.Pool.Exec(ctx, `DELETE FROM tickets WHERE id = $1`, id)
+	// Migration 000031 sets ON DELETE CASCADE on the (project_id, parent_id)
+	// composite FK, so Postgres walks the whole subtree for us.
+	_, err := db.Pool.Exec(ctx, `DELETE FROM tickets WHERE id = $1`, id)
 	if err != nil {
 		return fmt.Errorf("deleting ticket: %w", err)
 	}
@@ -1681,7 +1694,8 @@ func (db *DB) GetAttachmentByID(ctx context.Context, id string) (*TicketAttachme
 	return a, nil
 }
 
-// DeleteTicketTx wraps ticket deletion (children + parent) in a transaction.
+// DeleteTicketTx wraps ticket deletion in a transaction.
+// Descendants cascade automatically via the composite FK (#26).
 func (db *DB) DeleteTicketTx(ctx context.Context, ticketID string) error {
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
@@ -1689,9 +1703,6 @@ func (db *DB) DeleteTicketTx(ctx context.Context, ticketID string) error {
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if _, err := tx.Exec(ctx, `DELETE FROM tickets WHERE parent_id = $1`, ticketID); err != nil {
-		return fmt.Errorf("deleting child tickets: %w", err)
-	}
 	if _, err := tx.Exec(ctx, `DELETE FROM tickets WHERE id = $1`, ticketID); err != nil {
 		return fmt.Errorf("deleting ticket: %w", err)
 	}

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -922,10 +922,14 @@ func (db *DB) ArchiveTicket(ctx context.Context, id string) error {
 	// Recursively archive the whole subtree (ticket + children + grandchildren...).
 	// The old query only reached one level with `parent_id = $1`, leaving
 	// grandchildren visible and orphaned-looking.
+	//
+	// UNION (not UNION ALL) deduplicates against already-visited rows, which
+	// makes the recursion terminate even if a cycle were ever introduced via
+	// direct DB manipulation or a future bug in the parent_id update path.
 	_, err := db.Pool.Exec(ctx,
 		`WITH RECURSIVE subtree(id) AS (
 			SELECT id FROM tickets WHERE id = $1
-			UNION ALL
+			UNION
 			SELECT t.id FROM tickets t JOIN subtree s ON t.parent_id = s.id
 		)
 		UPDATE tickets SET archived_at = now(), updated_at = now()
@@ -938,10 +942,11 @@ func (db *DB) ArchiveTicket(ctx context.Context, id string) error {
 
 func (db *DB) RestoreTicket(ctx context.Context, id string) error {
 	// Recursively restore the whole subtree, mirroring ArchiveTicket.
+	// UNION deduplicates to guarantee termination even on cyclic data.
 	_, err := db.Pool.Exec(ctx,
 		`WITH RECURSIVE subtree(id) AS (
 			SELECT id FROM tickets WHERE id = $1
-			UNION ALL
+			UNION
 			SELECT t.id FROM tickets t JOIN subtree s ON t.parent_id = s.id
 		)
 		UPDATE tickets SET archived_at = NULL, updated_at = now()

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -1066,3 +1066,143 @@ func TestReactionGroupsBatchEmpty(t *testing.T) {
 		t.Errorf("expected empty result map, got %d entries", len(result))
 	}
 }
+
+// ── Ticket Hierarchy (Issue #26) ────────────────────────────────
+
+// TestCrossProjectParentRejected verifies the composite FK added in
+// migration 000031 prevents a ticket in project B from pointing its
+// parent_id at a ticket in project A.
+func TestCrossProjectParentRejected(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, db, "crossproj")
+	org := createTestOrg(t, db, "crossproj")
+	projA := createTestProject(t, db, org.ID, "crossproj-a")
+	projB := createTestProject(t, db, org.ID, "crossproj-b")
+
+	parentInA := createTestTicket(t, db, projA.ID, user.ID, "feature", "Parent in A")
+
+	// Attempt to create a child in project B with parent in project A.
+	child := &Ticket{
+		ProjectID: projB.ID,
+		ParentID:  &parentInA.ID,
+		Type:      "task",
+		Title:     "Should fail",
+		Status:    "backlog",
+		Priority:  "medium",
+		CreatedBy: user.ID,
+	}
+	err := db.CreateTicket(ctx, child)
+	if err == nil {
+		t.Fatal("expected FK violation for cross-project parent, got nil")
+	}
+}
+
+// TestArchiveTicketRecursesToGrandchildren verifies the recursive CTE
+// walks the whole subtree, not just one level.
+func TestArchiveTicketRecursesToGrandchildren(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, db, "archrec")
+	org := createTestOrg(t, db, "archrec")
+	proj := createTestProject(t, db, org.ID, "archrec")
+
+	// Build feature → task → subtask chain (3 levels deep).
+	feature := createTestTicket(t, db, proj.ID, user.ID, "feature", "Feature")
+	task := &Ticket{ProjectID: proj.ID, ParentID: &feature.ID, Type: "task", Title: "Task", Status: "backlog", Priority: "medium", CreatedBy: user.ID}
+	if err := db.CreateTicket(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+	subtask := &Ticket{ProjectID: proj.ID, ParentID: &task.ID, Type: "subtask", Title: "Subtask", Status: "backlog", Priority: "medium", CreatedBy: user.ID}
+	if err := db.CreateTicket(ctx, subtask); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.ArchiveTicket(ctx, feature.ID); err != nil {
+		t.Fatalf("ArchiveTicket: %v", err)
+	}
+
+	// All three levels must now be archived.
+	for _, id := range []string{feature.ID, task.ID, subtask.ID} {
+		tt, err := db.GetTicket(ctx, id)
+		if err != nil {
+			t.Fatalf("GetTicket(%s): %v", id, err)
+		}
+		if tt.ArchivedAt == nil {
+			t.Errorf("ticket %q should be archived but ArchivedAt is nil", tt.Title)
+		}
+	}
+}
+
+// TestRestoreTicketRecursesToGrandchildren mirrors the archive test
+// to ensure restore also walks the whole subtree.
+func TestRestoreTicketRecursesToGrandchildren(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, db, "restorerec")
+	org := createTestOrg(t, db, "restorerec")
+	proj := createTestProject(t, db, org.ID, "restorerec")
+
+	feature := createTestTicket(t, db, proj.ID, user.ID, "feature", "Feature")
+	task := &Ticket{ProjectID: proj.ID, ParentID: &feature.ID, Type: "task", Title: "Task", Status: "backlog", Priority: "medium", CreatedBy: user.ID}
+	if err := db.CreateTicket(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+	subtask := &Ticket{ProjectID: proj.ID, ParentID: &task.ID, Type: "subtask", Title: "Subtask", Status: "backlog", Priority: "medium", CreatedBy: user.ID}
+	if err := db.CreateTicket(ctx, subtask); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.ArchiveTicket(ctx, feature.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.RestoreTicket(ctx, feature.ID); err != nil {
+		t.Fatalf("RestoreTicket: %v", err)
+	}
+
+	for _, id := range []string{feature.ID, task.ID, subtask.ID} {
+		tt, err := db.GetTicket(ctx, id)
+		if err != nil {
+			t.Fatalf("GetTicket(%s): %v", id, err)
+		}
+		if tt.ArchivedAt != nil {
+			t.Errorf("ticket %q should be restored but ArchivedAt = %v", tt.Title, tt.ArchivedAt)
+		}
+	}
+}
+
+// TestDeleteTicketCascadesToGrandchildren verifies the new ON DELETE
+// CASCADE composite FK walks the whole subtree instead of leaving
+// grandchildren orphaned.
+func TestDeleteTicketCascadesToGrandchildren(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, db, "delrec")
+	org := createTestOrg(t, db, "delrec")
+	proj := createTestProject(t, db, org.ID, "delrec")
+
+	feature := createTestTicket(t, db, proj.ID, user.ID, "feature", "Feature")
+	task := &Ticket{ProjectID: proj.ID, ParentID: &feature.ID, Type: "task", Title: "Task", Status: "backlog", Priority: "medium", CreatedBy: user.ID}
+	if err := db.CreateTicket(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+	subtask := &Ticket{ProjectID: proj.ID, ParentID: &task.ID, Type: "subtask", Title: "Subtask", Status: "backlog", Priority: "medium", CreatedBy: user.ID}
+	if err := db.CreateTicket(ctx, subtask); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.DeleteTicket(ctx, feature.ID); err != nil {
+		t.Fatalf("DeleteTicket: %v", err)
+	}
+
+	// All three should be gone.
+	for _, id := range []string{feature.ID, task.ID, subtask.ID} {
+		if _, err := db.GetTicket(ctx, id); err == nil {
+			t.Errorf("ticket %s should be deleted but was still found", id)
+		}
+	}
+}

--- a/migrations/000031_ticket_same_project_parent.down.sql
+++ b/migrations/000031_ticket_same_project_parent.down.sql
@@ -1,5 +1,7 @@
 -- Revert same-project parent enforcement.
 
+DROP INDEX IF EXISTS idx_tickets_project_parent;
+
 ALTER TABLE tickets
     DROP CONSTRAINT tickets_parent_fkey;
 

--- a/migrations/000031_ticket_same_project_parent.down.sql
+++ b/migrations/000031_ticket_same_project_parent.down.sql
@@ -1,0 +1,13 @@
+-- Revert same-project parent enforcement.
+
+ALTER TABLE tickets
+    DROP CONSTRAINT tickets_parent_fkey;
+
+ALTER TABLE tickets
+    DROP CONSTRAINT tickets_project_id_id_key;
+
+ALTER TABLE tickets
+    ADD CONSTRAINT tickets_parent_id_fkey
+    FOREIGN KEY (parent_id)
+    REFERENCES tickets (id)
+    ON DELETE SET NULL;

--- a/migrations/000031_ticket_same_project_parent.up.sql
+++ b/migrations/000031_ticket_same_project_parent.up.sql
@@ -29,3 +29,11 @@ ALTER TABLE tickets
     FOREIGN KEY (project_id, parent_id)
     REFERENCES tickets (project_id, id)
     ON DELETE CASCADE;
+
+-- Postgres auto-indexes the FK parent side (via the UNIQUE constraint)
+-- but NOT the child side. Without this composite index, cascading
+-- deletes and tree traversals (ArchiveTicket/RestoreTicket CTEs) would
+-- need a full table scan per level. The existing idx_tickets_parent_id
+-- (on parent_id alone) is not ideal for the composite FK lookup path.
+CREATE INDEX IF NOT EXISTS idx_tickets_project_parent
+    ON tickets (project_id, parent_id);

--- a/migrations/000031_ticket_same_project_parent.up.sql
+++ b/migrations/000031_ticket_same_project_parent.up.sql
@@ -1,0 +1,31 @@
+-- Fix #26: enforce same-project parentage and cascade deletes recursively.
+--
+-- The old schema let parent_id reference any ticket in any project, and
+-- ON DELETE SET NULL left descendants behind as orphans. We replace the
+-- single-column FK with a composite FK on (project_id, parent_id) so the
+-- database itself rejects cross-project parents, and switch to CASCADE
+-- so DELETE recurses automatically.
+
+-- First, repair any existing cross-project links by nulling them out.
+-- Leaving them in place would make the new FK creation fail.
+UPDATE tickets c
+SET parent_id = NULL
+FROM tickets p
+WHERE c.parent_id = p.id
+  AND c.project_id <> p.project_id;
+
+-- A composite FK needs a matching UNIQUE/PRIMARY KEY on the target.
+-- PK is on (id) alone; add an explicit UNIQUE on (project_id, id).
+ALTER TABLE tickets
+    ADD CONSTRAINT tickets_project_id_id_key UNIQUE (project_id, id);
+
+-- Drop the old single-column FK (pg names it tickets_parent_id_fkey).
+ALTER TABLE tickets
+    DROP CONSTRAINT tickets_parent_id_fkey;
+
+-- Add the composite FK with CASCADE so deletes walk the whole subtree.
+ALTER TABLE tickets
+    ADD CONSTRAINT tickets_parent_fkey
+    FOREIGN KEY (project_id, parent_id)
+    REFERENCES tickets (project_id, id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
## Summary

Three-layer fix for a **high-severity** data-integrity bug where:
1. Tickets in project B could parent to tickets in project A (no FK guard)
2. Archive/delete only recursed one level deep, orphaning grandchildren

## Changes

### Layer 1 — Schema (\`migrations/000031\`)
- Repair existing cross-project links (set parent_id = NULL)
- Add \`UNIQUE (project_id, id)\` 
- Replace single-column FK with composite \`(project_id, parent_id) → (project_id, id) ON DELETE CASCADE\`

### Layer 2 — Handler validation
- \`tickets.CreateTicket\` and \`assistant.CreateTicket\` now verify parent.project_id matches child.project_id before calling the DB (friendly error vs raw FK violation)

### Layer 3 — Recursive soft-delete
- \`ArchiveTicket\` / \`RestoreTicket\` rewritten as \`WITH RECURSIVE\` CTEs that walk the full subtree
- \`DeleteTicket\` / \`DeleteTicketTx\` simplified — the CASCADE FK handles recursion

## Tests (new)

| Test | Verifies |
|------|----------|
| \`TestCrossProjectParentRejected\` | DB rejects FK violation |
| \`TestArchiveTicketRecursesToGrandchildren\` | 3-level archive |
| \`TestRestoreTicketRecursesToGrandchildren\` | 3-level restore |
| \`TestDeleteTicketCascadesToGrandchildren\` | 3-level delete |

## Test plan

- [x] Migration applies cleanly (\`migrate up\` → 31/u ticket_same_project_parent)
- [x] All 4 new tests pass
- [x] Full suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds
- [ ] Manual: create ticket with cross-project parent via UI → 400 error
- [ ] Manual: archive a 3-level hierarchy → all archived, restore → all restored


🤖 Generated with [Claude Code](https://claude.com/claude-code)