### PR TITLE
Fix #29: atomic organization creation with owner membership

### DIFF
--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -114,16 +114,15 @@ func (h *OrgHandler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 
 	slug := slugify(name)
 
-	org, err := h.db.CreateOrg(r.Context(), name, slug)
+	// Create org and owner membership in a single transaction so a
+	// transient failure on the membership INSERT cannot leave behind
+	// an orphan org with no owner and no path for the creator to
+	// manage it. (#29)
+	org, err := h.db.CreateOrgWithOwnerTx(r.Context(), user.ID, name, slug, auth.OrgRoleOwner)
 	if err != nil {
-		log.Printf("creating org: %v", err)
+		log.Printf("creating org with owner: %v", err)
 		http.Error(w, "Failed to create organization", http.StatusInternalServerError)
 		return
-	}
-
-	// Make creator the owner
-	if err := h.db.AddOrgMember(r.Context(), user.ID, org.ID, auth.OrgRoleOwner); err != nil {
-		log.Printf("adding org member: %v", err)
 	}
 
 	http.Redirect(w, r, "/orgs/"+org.Slug, http.StatusSeeOther)

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -308,6 +308,38 @@ func (db *DB) CreateOrg(ctx context.Context, name, slug string) (*Organization, 
 	return o, nil
 }
 
+// CreateOrgWithOwnerTx atomically creates an organization and assigns
+// the given user as its owner. If either the INSERT into organizations
+// or the INSERT into org_memberships fails, the entire operation is
+// rolled back. Prevents orgs from existing without an owner. (#29)
+func (db *DB) CreateOrgWithOwnerTx(ctx context.Context, ownerUserID, name, slug, ownerRole string) (*Organization, error) {
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	o := &Organization{}
+	if err := scanOrg(tx.QueryRow(ctx,
+		`INSERT INTO organizations (name, slug) VALUES ($1, $2) RETURNING `+orgColumns,
+		name, slug,
+	), o); err != nil {
+		return nil, fmt.Errorf("creating org: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1, $2, $3)
+		 ON CONFLICT (user_id, org_id) DO UPDATE SET role = $3`,
+		ownerUserID, o.ID, ownerRole); err != nil {
+		return nil, fmt.Errorf("adding owner membership: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing create org transaction: %w", err)
+	}
+	return o, nil
+}
+
 func (db *DB) GetOrgBySlug(ctx context.Context, slug string) (*Organization, error) {
 	o := &Organization{}
 	err := scanOrg(db.Pool.QueryRow(ctx,

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -1206,3 +1206,55 @@ func TestDeleteTicketCascadesToGrandchildren(t *testing.T) {
 		}
 	}
 }
+
+// ── CreateOrgWithOwnerTx (Issue #29) ────────────────────────────
+
+// TestCreateOrgWithOwnerTxHappyPath verifies the atomic variant
+// creates both the org and the owner membership on success.
+func TestCreateOrgWithOwnerTxHappyPath(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, db, "atomic-happy")
+
+	org, err := db.CreateOrgWithOwnerTx(ctx, user.ID, "Atomic Org", "atomic-org", "owner")
+	if err != nil {
+		t.Fatalf("CreateOrgWithOwnerTx: %v", err)
+	}
+	if org.ID == "" {
+		t.Fatal("expected non-empty org ID")
+	}
+
+	// Owner membership must exist with role "owner".
+	m, err := db.GetOrgMembership(ctx, user.ID, org.ID)
+	if err != nil {
+		t.Fatalf("GetOrgMembership: %v", err)
+	}
+	if m.Role != "owner" {
+		t.Errorf("membership role = %q, want owner", m.Role)
+	}
+}
+
+// TestCreateOrgWithOwnerTxRollsBackOnMembershipFailure verifies that
+// if the membership INSERT fails (here: via an invalid role that
+// violates the CHECK constraint), the org row is also rolled back.
+// This prevents orphan orgs from being created when downstream
+// writes fail transiently.
+func TestCreateOrgWithOwnerTxRollsBackOnMembershipFailure(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, db, "atomic-rollback")
+
+	// "not-a-real-role" violates the org_memberships.role CHECK constraint.
+	// The membership INSERT fails, which must roll back the org INSERT too.
+	_, err := db.CreateOrgWithOwnerTx(ctx, user.ID, "Rollback Org", "rollback-org", "not-a-real-role")
+	if err == nil {
+		t.Fatal("expected error from invalid role, got nil")
+	}
+
+	// The org row must NOT exist — the whole transaction should have rolled back.
+	if _, err := db.GetOrgBySlug(ctx, "rollback-org"); err == nil {
+		t.Fatal("org row was persisted despite membership failure (rollback broken)")
+	}
+}


### PR DESCRIPTION
## Summary

Fix a data-integrity bug where a transient failure on \`AddOrgMember\` after \`CreateOrg\` left an orphan organization with no owner — the error was only logged, so the request still redirected successfully.

## Change

Add \`CreateOrgWithOwnerTx\` which wraps both INSERTs in a single DB transaction. If the membership INSERT fails, the organization INSERT is rolled back via the \`defer tx.Rollback\` path, and the handler surfaces the error as a 500 instead of silently creating an unmanageable org.

| File | Change |
|------|--------|
| \`internal/models/queries.go\` | New \`CreateOrgWithOwnerTx\` method (alongside existing \`CreateOrg\` + \`AddOrgMember\` which remain for other call sites) |
| \`internal/handlers/orgs.go\` | \`CreateOrg\` handler switches to \`CreateOrgWithOwnerTx\`; dead \`log.Printf\` for membership failure removed |
| \`internal/models/queries_extended_test.go\` | Happy-path test + rollback test (invalid role → CHECK violation → org row must not exist) |

## Test plan

- [x] Both new tests pass
- [x] Full test suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)