### PR TITLE
Fix #30: serialize last-owner mutations with SELECT FOR UPDATE

### DIFF
--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"regexp"
@@ -316,21 +317,14 @@ func (h *OrgHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if target is the last owner
-	targetMembership, err := h.db.GetOrgMembership(r.Context(), targetID, org.ID)
-	if err != nil {
-		http.Error(w, "Member not found", http.StatusNotFound)
-		return
-	}
-	if targetMembership.Role == auth.OrgRoleOwner {
-		count, err := h.db.CountOrgOwners(r.Context(), org.ID)
-		if err != nil || count <= 1 {
+	// Guarded delete serializes against concurrent owner mutations so
+	// two requests on a two-owner org cannot both pass the last-owner
+	// check and leave the org with zero owners. (#30)
+	if err := h.db.RemoveOrgMemberGuarded(r.Context(), targetID, org.ID); err != nil {
+		if errors.Is(err, models.ErrLastOwner) {
 			http.Error(w, "Cannot remove the last owner", http.StatusBadRequest)
 			return
 		}
-	}
-
-	if err := h.db.RemoveOrgMember(r.Context(), targetID, org.ID); err != nil {
 		log.Printf("removing org member: %v", err)
 		http.Error(w, "Failed to remove member", http.StatusInternalServerError)
 		return
@@ -376,21 +370,14 @@ func (h *OrgHandler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prevent demoting the last owner
-	currentMembership, err := h.db.GetOrgMembership(r.Context(), targetID, org.ID)
-	if err != nil {
-		http.Error(w, "Member not found", http.StatusNotFound)
-		return
-	}
-	if currentMembership.Role == auth.OrgRoleOwner && newRole != auth.OrgRoleOwner {
-		count, err := h.db.CountOrgOwners(r.Context(), org.ID)
-		if err != nil || count <= 1 {
+	// Guarded update serializes against concurrent owner mutations to
+	// prevent the last-owner invariant from being bypassed by two
+	// concurrent demotion requests. (#30)
+	if err := h.db.UpdateOrgMemberRoleGuarded(r.Context(), targetID, org.ID, newRole); err != nil {
+		if errors.Is(err, models.ErrLastOwner) {
 			http.Error(w, "Cannot demote the last owner", http.StatusBadRequest)
 			return
 		}
-	}
-
-	if err := h.db.UpdateOrgMemberRole(r.Context(), targetID, org.ID, newRole); err != nil {
 		log.Printf("updating org member role: %v", err)
 		http.Error(w, "Failed to update role", http.StatusInternalServerError)
 		return

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -320,11 +320,16 @@ func (h *OrgHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 	// Guarded delete serializes against concurrent owner mutations so
 	// two requests on a two-owner org cannot both pass the last-owner
 	// check and leave the org with zero owners. (#30)
-	if err := h.db.RemoveOrgMemberGuarded(r.Context(), targetID, org.ID); err != nil {
-		if errors.Is(err, models.ErrLastOwner) {
-			http.Error(w, "Cannot remove the last owner", http.StatusBadRequest)
-			return
-		}
+	switch err := h.db.RemoveOrgMemberGuarded(r.Context(), targetID, org.ID); {
+	case err == nil:
+		// fallthrough to render
+	case errors.Is(err, models.ErrMemberNotFound):
+		http.Error(w, "Member not found", http.StatusNotFound)
+		return
+	case errors.Is(err, models.ErrLastOwner):
+		http.Error(w, "Cannot remove the last owner", http.StatusBadRequest)
+		return
+	default:
 		log.Printf("removing org member: %v", err)
 		http.Error(w, "Failed to remove member", http.StatusInternalServerError)
 		return
@@ -373,11 +378,16 @@ func (h *OrgHandler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
 	// Guarded update serializes against concurrent owner mutations to
 	// prevent the last-owner invariant from being bypassed by two
 	// concurrent demotion requests. (#30)
-	if err := h.db.UpdateOrgMemberRoleGuarded(r.Context(), targetID, org.ID, newRole); err != nil {
-		if errors.Is(err, models.ErrLastOwner) {
-			http.Error(w, "Cannot demote the last owner", http.StatusBadRequest)
-			return
-		}
+	switch err := h.db.UpdateOrgMemberRoleGuarded(r.Context(), targetID, org.ID, newRole); {
+	case err == nil:
+		// fallthrough to render
+	case errors.Is(err, models.ErrMemberNotFound):
+		http.Error(w, "Member not found", http.StatusNotFound)
+		return
+	case errors.Is(err, models.ErrLastOwner):
+		http.Error(w, "Cannot demote the last owner", http.StatusBadRequest)
+		return
+	default:
 		log.Printf("updating org member role: %v", err)
 		http.Error(w, "Failed to update role", http.StatusInternalServerError)
 		return

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -575,16 +575,25 @@ func (db *DB) UpdateOrgMemberRole(ctx context.Context, userID, orgID, role strin
 // Handlers should translate this to a 400 response.
 var ErrLastOwner = errors.New("cannot remove or demote the last owner")
 
+// ErrMemberNotFound is returned when a guarded mutation targets a
+// membership row that does not exist. Distinct from infrastructure
+// errors so handlers can translate it to a 404.
+var ErrMemberNotFound = errors.New("org membership not found")
+
 // lockOrgOwners holds an exclusive row-level lock on every owner row
 // for the given org_id within the current transaction. It is the
 // serialization point for the last-owner invariant (#30): two
 // concurrent owner-mutation transactions serialize because the
 // second one blocks on the SELECT FOR UPDATE until the first commits.
 // Returns the user_ids of the currently-locked owners.
+//
+// ORDER BY user_id ensures concurrent transactions acquire the row
+// locks in the same sequence, avoiding lock-ordering deadlocks.
 func lockOrgOwners(ctx context.Context, tx pgx.Tx, orgID string) ([]string, error) {
 	rows, err := tx.Query(ctx,
 		`SELECT user_id FROM org_memberships
 		 WHERE org_id = $1 AND role = 'owner'
+		 ORDER BY user_id
 		 FOR UPDATE`, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("locking org owners: %w", err)
@@ -622,10 +631,17 @@ func (db *DB) RemoveOrgMemberGuarded(ctx context.Context, userID, orgID string) 
 		return ErrLastOwner
 	}
 
-	if _, err := tx.Exec(ctx,
+	tag, err := tx.Exec(ctx,
 		`DELETE FROM org_memberships WHERE user_id = $1 AND org_id = $2`,
-		userID, orgID); err != nil {
+		userID, orgID)
+	if err != nil {
 		return fmt.Errorf("removing org member: %w", err)
+	}
+	// A 0-row DELETE means the target was never a member of this org;
+	// surface ErrMemberNotFound so the handler can return 404 instead
+	// of silently reporting success.
+	if tag.RowsAffected() == 0 {
+		return ErrMemberNotFound
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("committing remove org member transaction: %w", err)
@@ -654,10 +670,17 @@ func (db *DB) UpdateOrgMemberRoleGuarded(ctx context.Context, userID, orgID, new
 		return ErrLastOwner
 	}
 
-	if _, err := tx.Exec(ctx,
+	tag, err := tx.Exec(ctx,
 		`UPDATE org_memberships SET role = $1 WHERE user_id = $2 AND org_id = $3`,
-		newRole, userID, orgID); err != nil {
+		newRole, userID, orgID)
+	if err != nil {
 		return fmt.Errorf("updating org member role: %w", err)
+	}
+	// A 0-row UPDATE means no matching membership row; surface
+	// ErrMemberNotFound so the handler returns 404 instead of
+	// silently reporting success.
+	if tag.RowsAffected() == 0 {
+		return ErrMemberNotFound
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("committing update org member role transaction: %w", err)

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -565,6 +566,101 @@ func (db *DB) UpdateOrgMemberRole(ctx context.Context, userID, orgID, role strin
 		role, userID, orgID)
 	if err != nil {
 		return fmt.Errorf("updating org member role: %w", err)
+	}
+	return nil
+}
+
+// ErrLastOwner is returned by the guarded owner-mutation helpers when
+// the requested change would leave an organization with zero owners.
+// Handlers should translate this to a 400 response.
+var ErrLastOwner = errors.New("cannot remove or demote the last owner")
+
+// lockOrgOwners holds an exclusive row-level lock on every owner row
+// for the given org_id within the current transaction. It is the
+// serialization point for the last-owner invariant (#30): two
+// concurrent owner-mutation transactions serialize because the
+// second one blocks on the SELECT FOR UPDATE until the first commits.
+// Returns the user_ids of the currently-locked owners.
+func lockOrgOwners(ctx context.Context, tx pgx.Tx, orgID string) ([]string, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT user_id FROM org_memberships
+		 WHERE org_id = $1 AND role = 'owner'
+		 FOR UPDATE`, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("locking org owners: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var u string
+		if err := rows.Scan(&u); err != nil {
+			return nil, fmt.Errorf("scanning owner: %w", err)
+		}
+		ids = append(ids, u)
+	}
+	return ids, rows.Err()
+}
+
+// RemoveOrgMemberGuarded deletes the given membership atomically and
+// returns ErrLastOwner if the deletion would leave the org with zero
+// owners. Fixes #30: two concurrent RemoveMember requests on a
+// two-owner org can no longer both pass the last-owner check.
+func (db *DB) RemoveOrgMemberGuarded(ctx context.Context, userID, orgID string) error {
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	owners, err := lockOrgOwners(ctx, tx, orgID)
+	if err != nil {
+		return err
+	}
+
+	// Deletion leaves 0 owners iff the target is the sole owner.
+	if len(owners) == 1 && owners[0] == userID {
+		return ErrLastOwner
+	}
+
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM org_memberships WHERE user_id = $1 AND org_id = $2`,
+		userID, orgID); err != nil {
+		return fmt.Errorf("removing org member: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing remove org member transaction: %w", err)
+	}
+	return nil
+}
+
+// UpdateOrgMemberRoleGuarded updates the given membership's role
+// atomically and returns ErrLastOwner if demoting the target would
+// leave the org with zero owners. Fixes #30 for the demotion path.
+func (db *DB) UpdateOrgMemberRoleGuarded(ctx context.Context, userID, orgID, newRole string) error {
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	owners, err := lockOrgOwners(ctx, tx, orgID)
+	if err != nil {
+		return err
+	}
+
+	// Demoting to non-owner is the only mutation that can violate
+	// the invariant. Promoting or keeping role='owner' is safe.
+	if newRole != "owner" && len(owners) == 1 && owners[0] == userID {
+		return ErrLastOwner
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE org_memberships SET role = $1 WHERE user_id = $2 AND org_id = $3`,
+		newRole, userID, orgID); err != nil {
+		return fmt.Errorf("updating org member role: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing update org member role transaction: %w", err)
 	}
 	return nil
 }

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -1256,5 +1258,160 @@ func TestCreateOrgWithOwnerTxRollsBackOnMembershipFailure(t *testing.T) {
 	// The org row must NOT exist — the whole transaction should have rolled back.
 	if _, err := db.GetOrgBySlug(ctx, "rollback-org"); err == nil {
 		t.Fatal("org row was persisted despite membership failure (rollback broken)")
+	}
+}
+
+// ── Last-Owner Guards (Issue #30) ───────────────────────────────
+
+// TestRemoveOrgMemberGuardedBlocksLastOwner verifies the guarded
+// delete refuses to remove the sole owner of an organization.
+func TestRemoveOrgMemberGuardedBlocksLastOwner(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	owner := createTestUser(t, db, "sole-owner")
+	org, err := db.CreateOrgWithOwnerTx(ctx, owner.ID, "Sole Org", "sole-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	err = db.RemoveOrgMemberGuarded(ctx, owner.ID, org.ID)
+	if !errors.Is(err, ErrLastOwner) {
+		t.Fatalf("expected ErrLastOwner, got %v", err)
+	}
+
+	// Owner must still exist — transaction should have rolled back.
+	if _, err := db.GetOrgMembership(ctx, owner.ID, org.ID); err != nil {
+		t.Fatalf("owner membership was removed despite guard: %v", err)
+	}
+}
+
+// TestRemoveOrgMemberGuardedAllowsWhenAnotherOwnerExists confirms
+// the happy path still works with two owners.
+func TestRemoveOrgMemberGuardedAllowsWhenAnotherOwnerExists(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	alice := createTestUser(t, db, "alice-rem")
+	bob := createTestUser(t, db, "bob-rem")
+	org, err := db.CreateOrgWithOwnerTx(ctx, alice.ID, "Two Org", "two-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	if err = db.AddOrgMember(ctx, bob.ID, org.ID, "owner"); err != nil {
+		t.Fatalf("add bob: %v", err)
+	}
+
+	if err = db.RemoveOrgMemberGuarded(ctx, alice.ID, org.ID); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	// Bob must still be an owner.
+	m, err := db.GetOrgMembership(ctx, bob.ID, org.ID)
+	if err != nil || m.Role != "owner" {
+		t.Fatalf("expected bob to remain owner, got m=%v err=%v", m, err)
+	}
+}
+
+// TestConcurrentRemoveOwnersPreservesInvariant is the regression
+// test for #30: two goroutines concurrently removing each of the
+// two owners of the same org. The SELECT FOR UPDATE serialization
+// in RemoveOrgMemberGuarded must ensure exactly one of the two
+// removals succeeds.
+func TestConcurrentRemoveOwnersPreservesInvariant(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	alice := createTestUser(t, db, "alice-conc")
+	bob := createTestUser(t, db, "bob-conc")
+	org, err := db.CreateOrgWithOwnerTx(ctx, alice.ID, "Race Org", "race-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	if err = db.AddOrgMember(ctx, bob.ID, org.ID, "owner"); err != nil {
+		t.Fatalf("add bob: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs[0] = db.RemoveOrgMemberGuarded(ctx, alice.ID, org.ID)
+	}()
+	go func() {
+		defer wg.Done()
+		errs[1] = db.RemoveOrgMemberGuarded(ctx, bob.ID, org.ID)
+	}()
+	wg.Wait()
+
+	// Exactly one request should succeed, the other should get ErrLastOwner.
+	successes := 0
+	lastOwnerErrs := 0
+	for _, e := range errs {
+		switch {
+		case e == nil:
+			successes++
+		case errors.Is(e, ErrLastOwner):
+			lastOwnerErrs++
+		default:
+			t.Fatalf("unexpected error: %v", e)
+		}
+	}
+	if successes != 1 || lastOwnerErrs != 1 {
+		t.Fatalf("expected 1 success + 1 ErrLastOwner, got %d + %d (%v)", successes, lastOwnerErrs, errs)
+	}
+
+	// Exactly one owner must remain.
+	count, err := db.CountOrgOwners(ctx, org.ID)
+	if err != nil {
+		t.Fatalf("CountOrgOwners: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 owner remaining, got %d", count)
+	}
+}
+
+// TestUpdateOrgMemberRoleGuardedBlocksLastOwnerDemotion verifies
+// the guarded update refuses to demote the sole owner.
+func TestUpdateOrgMemberRoleGuardedBlocksLastOwnerDemotion(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	owner := createTestUser(t, db, "demote-last")
+	org, err := db.CreateOrgWithOwnerTx(ctx, owner.ID, "Demote Org", "demote-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	err = db.UpdateOrgMemberRoleGuarded(ctx, owner.ID, org.ID, "admin")
+	if !errors.Is(err, ErrLastOwner) {
+		t.Fatalf("expected ErrLastOwner, got %v", err)
+	}
+
+	// Role must still be owner.
+	m, err := db.GetOrgMembership(ctx, owner.ID, org.ID)
+	if err != nil || m.Role != "owner" {
+		t.Fatalf("expected role='owner' (rollback), got m=%v err=%v", m, err)
+	}
+}
+
+// TestUpdateOrgMemberRoleGuardedAllowsPromotion confirms a
+// non-demotion update (role stays owner) is not blocked by the
+// invariant check.
+func TestUpdateOrgMemberRoleGuardedAllowsPromotion(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	owner := createTestUser(t, db, "promote-sole")
+	org, err := db.CreateOrgWithOwnerTx(ctx, owner.ID, "Promote Org", "promote-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	// Setting role to the same value "owner" should succeed (no invariant violation).
+	if err := db.UpdateOrgMemberRoleGuarded(ctx, owner.ID, org.ID, "owner"); err != nil {
+		t.Fatalf("expected success for owner→owner no-op, got %v", err)
 	}
 }

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -1397,6 +1397,46 @@ func TestUpdateOrgMemberRoleGuardedBlocksLastOwnerDemotion(t *testing.T) {
 	}
 }
 
+// TestRemoveOrgMemberGuardedReturnsNotFoundForNonMember locks in
+// the Codex P1 fix: removing a user who is not a member of the org
+// must return ErrMemberNotFound, not silently succeed.
+func TestRemoveOrgMemberGuardedReturnsNotFoundForNonMember(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	owner := createTestUser(t, db, "nf-owner")
+	stranger := createTestUser(t, db, "nf-stranger")
+	org, err := db.CreateOrgWithOwnerTx(ctx, owner.ID, "NF Org", "nf-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	// Stranger is a real user but never joined the org.
+	err = db.RemoveOrgMemberGuarded(ctx, stranger.ID, org.ID)
+	if !errors.Is(err, ErrMemberNotFound) {
+		t.Fatalf("expected ErrMemberNotFound, got %v", err)
+	}
+}
+
+// TestUpdateOrgMemberRoleGuardedReturnsNotFoundForNonMember mirrors
+// the above for the role-update path.
+func TestUpdateOrgMemberRoleGuardedReturnsNotFoundForNonMember(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	owner := createTestUser(t, db, "nfu-owner")
+	stranger := createTestUser(t, db, "nfu-stranger")
+	org, err := db.CreateOrgWithOwnerTx(ctx, owner.ID, "NFU Org", "nfu-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	err = db.UpdateOrgMemberRoleGuarded(ctx, stranger.ID, org.ID, "admin")
+	if !errors.Is(err, ErrMemberNotFound) {
+		t.Fatalf("expected ErrMemberNotFound, got %v", err)
+	}
+}
+
 // TestUpdateOrgMemberRoleGuardedAllowsPromotion confirms a
 // non-demotion update (role stays owner) is not blocked by the
 // invariant check.


### PR DESCRIPTION
## Summary

Two concurrent admin requests on a two-owner org could both pass the \`CountOrgOwners\` check and both write, leaving the org with zero owners. Fixed by replacing the read-then-write pattern with a single transaction that locks the whole owner set up front.

## Change

### DB layer (\`internal/models/queries.go\`)
- New sentinel \`ErrLastOwner\`
- Internal helper \`lockOrgOwners\` — \`SELECT ... FOR UPDATE\` on all owner rows for an org, the serialization point for the invariant
- \`RemoveOrgMemberGuarded\` — Tx: lock owners → check if target is sole owner → delete
- \`UpdateOrgMemberRoleGuarded\` — Tx: lock owners → refuse only if demoting the sole owner → update

### Handlers (\`internal/handlers/orgs.go\`)
- \`RemoveMember\` and \`UpdateMemberRole\` now call the guarded variants
- \`errors.Is(err, models.ErrLastOwner)\` → 400; anything else → 500 (keeps DB-error / invariant-violation branches distinct, per feedback)

## Tests

| Test | Verifies |
|------|----------|
| \`TestRemoveOrgMemberGuardedBlocksLastOwner\` | sole-owner remove returns ErrLastOwner + rollback |
| \`TestRemoveOrgMemberGuardedAllowsWhenAnotherOwnerExists\` | happy path |
| \`TestConcurrentRemoveOwnersPreservesInvariant\` | **regression test for the race**: two goroutines, one succeeds, one gets ErrLastOwner, exactly one owner remains |
| \`TestUpdateOrgMemberRoleGuardedBlocksLastOwnerDemotion\` | sole-owner demotion refused + rollback |
| \`TestUpdateOrgMemberRoleGuardedAllowsPromotion\` | owner→owner no-op passes |

## Test plan

- [x] All 5 new tests pass
- [x] Full test suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)