### PR TITLE
Fix #28: atomic invite acceptance

### DIFF
--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"log"
 	"net/http"
 	"strings"
@@ -164,11 +165,16 @@ func (h *InviteHandler) InviteRegister(w http.ResponseWriter, r *http.Request) {
 	// leave a user account with no org membership and a half-consumed
 	// invitation. The session is created only after Commit succeeds. (#28)
 	user, err := h.db.AcceptInviteTx(r.Context(), inv.Email, hash, name, auth.RoleClient, inv.ID, inv.OrgID, inv.OrgRole)
-	if err != nil {
-		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
-			renderErr("An account with this email already exists. Please log in.")
-			return
-		}
+	switch {
+	case err == nil:
+		// fallthrough to session creation
+	case errors.Is(err, models.ErrInvitationNotAcceptable):
+		renderErr("This invitation link is invalid or has expired.")
+		return
+	case strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique"):
+		renderErr("An account with this email already exists. Please log in.")
+		return
+	default:
 		log.Printf("accepting invite: %v", err)
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 		return

--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -159,23 +159,19 @@ func (h *InviteHandler) InviteRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.db.CreateUser(r.Context(), inv.Email, hash, name, auth.RoleClient)
+	// Create user, mark invitation accepted, and add org membership
+	// atomically so a transient failure on any downstream write cannot
+	// leave a user account with no org membership and a half-consumed
+	// invitation. The session is created only after Commit succeeds. (#28)
+	user, err := h.db.AcceptInviteTx(r.Context(), inv.Email, hash, name, auth.RoleClient, inv.ID, inv.OrgID, inv.OrgRole)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
 			renderErr("An account with this email already exists. Please log in.")
 			return
 		}
-		log.Printf("creating user from invite: %v", err)
+		log.Printf("accepting invite: %v", err)
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 		return
-	}
-
-	// Accept invitation and add org membership
-	if statusErr := h.db.UpdateInvitationStatus(r.Context(), inv.ID, "accepted"); statusErr != nil {
-		log.Printf("accepting invitation: %v", statusErr)
-	}
-	if memberErr := h.db.AddOrgMember(r.Context(), user.ID, inv.OrgID, inv.OrgRole); memberErr != nil {
-		log.Printf("adding org member from invite: %v", memberErr)
 	}
 
 	// Create session

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -15,6 +15,11 @@ type DB struct {
 	Pool *pgxpool.Pool
 }
 
+// OrgRoleOwner is the "owner" org-membership role value used in
+// org_memberships.role. Centralized here so goconst stops flagging
+// the string literal.
+const OrgRoleOwner = "owner"
+
 func NewDB(pool *pgxpool.Pool) *DB {
 	return &DB{Pool: pool}
 }
@@ -34,11 +39,23 @@ func (db *DB) CreateUser(ctx context.Context, email, passwordHash, name, role st
 	return u, nil
 }
 
+// ErrInvitationNotAcceptable is returned by AcceptInviteTx when the
+// target invitation cannot be consumed — either it never existed,
+// was already accepted, or is no longer pending. Keeps this case
+// distinct from infrastructure failures so handlers can surface a
+// dedicated error without masking 5xxs. (#28 — review feedback)
+var ErrInvitationNotAcceptable = errors.New("invitation not acceptable")
+
 // AcceptInviteTx atomically creates a user from an invitation, marks
 // the invitation accepted, and adds the user to the target org with
 // the invitation's role. If any step fails the entire operation is
 // rolled back, so we never end up with a user account that has no
 // membership and a half-consumed invitation. (#28)
+//
+// The invitation UPDATE is guarded with AND status = 'pending' so
+// double-acceptance and stale-invitation acceptance both surface as
+// ErrInvitationNotAcceptable via the RowsAffected == 0 branch,
+// rather than silently committing a no-op.
 func (db *DB) AcceptInviteTx(ctx context.Context, email, passwordHash, name, role, invitationID, orgID, orgRole string) (*User, error) {
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
@@ -47,18 +64,23 @@ func (db *DB) AcceptInviteTx(ctx context.Context, email, passwordHash, name, rol
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	u := &User{}
-	if err := tx.QueryRow(ctx,
+	if scanErr := tx.QueryRow(ctx,
 		`INSERT INTO users (email, password_hash, name, role) VALUES ($1, $2, $3, $4)
 		 RETURNING id, email, password_hash, name, role, totp_secret, totp_verified, recovery_codes, must_setup_2fa, preferred_2fa_method, created_at, updated_at`,
 		email, passwordHash, name, role,
-	).Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Name, &u.Role, &u.TOTPSecret, &u.TOTPVerified, &u.RecoveryCodes, &u.MustSetup2FA, &u.Preferred2FAMethod, &u.CreatedAt, &u.UpdatedAt); err != nil {
-		return nil, fmt.Errorf("creating user: %w", err)
+	).Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Name, &u.Role, &u.TOTPSecret, &u.TOTPVerified, &u.RecoveryCodes, &u.MustSetup2FA, &u.Preferred2FAMethod, &u.CreatedAt, &u.UpdatedAt); scanErr != nil {
+		return nil, fmt.Errorf("creating user: %w", scanErr)
 	}
 
-	if _, err := tx.Exec(ctx,
-		`UPDATE invitations SET status = 'accepted', updated_at = now() WHERE id = $1`,
-		invitationID); err != nil {
+	tag, err := tx.Exec(ctx,
+		`UPDATE invitations SET status = 'accepted', updated_at = now()
+		 WHERE id = $1 AND status = 'pending'`,
+		invitationID)
+	if err != nil {
 		return nil, fmt.Errorf("marking invitation accepted: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, ErrInvitationNotAcceptable
 	}
 
 	if _, err := tx.Exec(ctx,
@@ -706,7 +728,7 @@ func (db *DB) UpdateOrgMemberRoleGuarded(ctx context.Context, userID, orgID, new
 
 	// Demoting to non-owner is the only mutation that can violate
 	// the invariant. Promoting or keeping role='owner' is safe.
-	if newRole != "owner" && len(owners) == 1 && owners[0] == userID {
+	if newRole != OrgRoleOwner && len(owners) == 1 && owners[0] == userID {
 		return ErrLastOwner
 	}
 

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -34,6 +34,46 @@ func (db *DB) CreateUser(ctx context.Context, email, passwordHash, name, role st
 	return u, nil
 }
 
+// AcceptInviteTx atomically creates a user from an invitation, marks
+// the invitation accepted, and adds the user to the target org with
+// the invitation's role. If any step fails the entire operation is
+// rolled back, so we never end up with a user account that has no
+// membership and a half-consumed invitation. (#28)
+func (db *DB) AcceptInviteTx(ctx context.Context, email, passwordHash, name, role, invitationID, orgID, orgRole string) (*User, error) {
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	u := &User{}
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, name, role) VALUES ($1, $2, $3, $4)
+		 RETURNING id, email, password_hash, name, role, totp_secret, totp_verified, recovery_codes, must_setup_2fa, preferred_2fa_method, created_at, updated_at`,
+		email, passwordHash, name, role,
+	).Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Name, &u.Role, &u.TOTPSecret, &u.TOTPVerified, &u.RecoveryCodes, &u.MustSetup2FA, &u.Preferred2FAMethod, &u.CreatedAt, &u.UpdatedAt); err != nil {
+		return nil, fmt.Errorf("creating user: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE invitations SET status = 'accepted', updated_at = now() WHERE id = $1`,
+		invitationID); err != nil {
+		return nil, fmt.Errorf("marking invitation accepted: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1, $2, $3)
+		 ON CONFLICT (user_id, org_id) DO UPDATE SET role = $3`,
+		u.ID, orgID, orgRole); err != nil {
+		return nil, fmt.Errorf("adding org membership: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing accept invite transaction: %w", err)
+	}
+	return u, nil
+}
+
 func (db *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 	u := &User{}
 	err := db.Pool.QueryRow(ctx,

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -1455,3 +1455,100 @@ func TestUpdateOrgMemberRoleGuardedAllowsPromotion(t *testing.T) {
 		t.Fatalf("expected success for owner→owner no-op, got %v", err)
 	}
 }
+
+// ── AcceptInviteTx (Issue #28) ──────────────────────────────────
+
+// TestAcceptInviteTxHappyPath verifies the atomic variant creates
+// the user, marks the invitation accepted, and adds org membership
+// in one transaction.
+func TestAcceptInviteTxHappyPath(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	inviter := createTestUser(t, db, "accept-inviter")
+	org, err := db.CreateOrgWithOwnerTx(ctx, inviter.ID, "Accept Org", "accept-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	inv, err := db.CreateInvitation(ctx,
+		"invitee@test.com", org.ID, "member", "token-hash-happy", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	user, err := db.AcceptInviteTx(ctx,
+		inv.Email, "hash", "Invitee", "client",
+		inv.ID, org.ID, inv.OrgRole)
+	if err != nil {
+		t.Fatalf("AcceptInviteTx: %v", err)
+	}
+
+	if user.Email != inv.Email {
+		t.Errorf("user email = %q, want %q", user.Email, inv.Email)
+	}
+	if user.Role != "client" {
+		t.Errorf("user role = %q, want client", user.Role)
+	}
+
+	// Invitation must be accepted.
+	got, err := db.GetInvitationByID(ctx, inv.ID)
+	if err != nil {
+		t.Fatalf("GetInvitationByID: %v", err)
+	}
+	if got.Status != "accepted" {
+		t.Errorf("invitation status = %q, want accepted", got.Status)
+	}
+
+	// Org membership must exist with the invited role.
+	m, err := db.GetOrgMembership(ctx, user.ID, org.ID)
+	if err != nil {
+		t.Fatalf("GetOrgMembership: %v", err)
+	}
+	if m.Role != "member" {
+		t.Errorf("membership role = %q, want member", m.Role)
+	}
+}
+
+// TestAcceptInviteTxRollsBackOnInvalidOrg verifies that a failure
+// in the membership INSERT (here: FK violation on a non-existent
+// org) rolls back the user INSERT and leaves no orphaned account.
+func TestAcceptInviteTxRollsBackOnInvalidOrg(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	inviter := createTestUser(t, db, "rollback-inviter")
+	org, err := db.CreateOrgWithOwnerTx(ctx, inviter.ID, "Rollback Org", "rb-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	inv, err := db.CreateInvitation(ctx,
+		"rollback-invitee@test.com", org.ID, "member", "token-hash-rb", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	// Pass a bogus org ID (valid UUID format, not a real row) so the
+	// membership INSERT violates the org_id FK.
+	bogusOrgID := "00000000-0000-0000-0000-000000000099"
+	_, err = db.AcceptInviteTx(ctx,
+		inv.Email, "hash", "Invitee", "client",
+		inv.ID, bogusOrgID, inv.OrgRole)
+	if err == nil {
+		t.Fatal("expected error from invalid org FK, got nil")
+	}
+
+	// User row must NOT exist — the whole Tx should have rolled back.
+	if _, gerr := db.GetUserByEmail(ctx, inv.Email); gerr == nil {
+		t.Fatal("user row was persisted despite membership failure (rollback broken)")
+	}
+	// Invitation must remain pending.
+	got, err := db.GetInvitationByID(ctx, inv.ID)
+	if err != nil {
+		t.Fatalf("GetInvitationByID: %v", err)
+	}
+	if got.Status == "accepted" {
+		t.Error("invitation was marked accepted despite rollback")
+	}
+}

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -1552,3 +1552,43 @@ func TestAcceptInviteTxRollsBackOnInvalidOrg(t *testing.T) {
 		t.Error("invitation was marked accepted despite rollback")
 	}
 }
+
+// TestAcceptInviteTxRejectsAlreadyAcceptedInvitation locks in
+// Gemini's review feedback: the UPDATE guard "AND status = 'pending'"
+// plus the RowsAffected check must surface ErrInvitationNotAcceptable
+// when the invitation has already been consumed. Without the guard
+// the second register attempt would silently no-op and create a
+// duplicate user account racing against the unique-email constraint.
+func TestAcceptInviteTxRejectsAlreadyAcceptedInvitation(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	inviter := createTestUser(t, db, "already-inviter")
+	org, err := db.CreateOrgWithOwnerTx(ctx, inviter.ID, "Already Org", "already-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	inv, err := db.CreateInvitation(ctx,
+		"already-invitee@test.com", org.ID, "member", "token-hash-already", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	// Mark the invitation accepted manually to simulate prior consumption.
+	if err = db.UpdateInvitationStatus(ctx, inv.ID, "accepted"); err != nil {
+		t.Fatalf("pre-accept invitation: %v", err)
+	}
+
+	_, err = db.AcceptInviteTx(ctx,
+		"different@test.com", "hash", "Second", "client",
+		inv.ID, org.ID, inv.OrgRole)
+	if !errors.Is(err, ErrInvitationNotAcceptable) {
+		t.Fatalf("expected ErrInvitationNotAcceptable, got %v", err)
+	}
+
+	// The second user must NOT have been created (Tx rolled back).
+	if _, gerr := db.GetUserByEmail(ctx, "different@test.com"); gerr == nil {
+		t.Fatal("user row was persisted despite invitation not being acceptable")
+	}
+}


### PR DESCRIPTION
## Summary

Fix a data-integrity bug where a transient failure after \`CreateUser\` but before \`AddOrgMember\` created an orphan user account logged into the app with no org membership and a half-consumed invitation. The membership and invitation-status errors were only logged.

## Change

New \`AcceptInviteTx\` wraps user creation + invitation accept + org membership INSERT in a single transaction. The session is created only after \`Commit\` succeeds.

| File | Change |
|------|--------|
| \`internal/models/queries.go\` | New \`AcceptInviteTx\` method |
| \`internal/handlers/invitations.go\` | \`InviteRegister\` replaces the three sequential calls with \`AcceptInviteTx\` |
| \`internal/models/queries_extended_test.go\` | Happy-path + rollback test (invalid org FK → no user persisted) |

## Test plan

- [x] Both new tests pass
- [x] Full test suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)