### PR TITLE
Fix #32: return 409 instead of 500 on duplicate invitation race

### DIFF
--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -258,6 +258,14 @@ func (h *OrgHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 	expiresAt := time.Now().Add(7 * 24 * time.Hour) // 7 days
 	_, err = h.db.CreateInvitation(r.Context(), email, org.ID, role, tokenHash, user.ID, expiresAt)
 	if err != nil {
+		// Handle the race where the pre-check saw no pending invite
+		// but a concurrent request created one before we INSERTed.
+		// The partial-unique-index violation is idempotent behavior,
+		// not an infrastructure failure — 409, not 500. (#32)
+		if errors.Is(err, models.ErrDuplicatePendingInvitation) {
+			http.Error(w, "An invitation is already pending for this email", http.StatusConflict)
+			return
+		}
 		log.Printf("creating invitation: %v", err)
 		http.Error(w, "Failed to create invitation", http.StatusInternalServerError)
 		return

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -186,6 +187,13 @@ func (db *DB) CountUsers(ctx context.Context) (int, error) {
 
 // ── Invitations ──────────────────────────────────────────────────
 
+// ErrDuplicatePendingInvitation is returned when CreateInvitation
+// hits the partial unique index idx_invitations_email_org_pending
+// on (email, org_id) WHERE status = 'pending'. Distinct from a
+// generic datastore error so handlers can respond with 409 Conflict
+// instead of masking the race as 500. (#32)
+var ErrDuplicatePendingInvitation = errors.New("a pending invitation already exists for this email and org")
+
 func (db *DB) CreateInvitation(ctx context.Context, email, orgID, orgRole, tokenHash, invitedBy string, expiresAt time.Time) (*Invitation, error) {
 	inv := &Invitation{}
 	err := db.Pool.QueryRow(ctx,
@@ -195,6 +203,13 @@ func (db *DB) CreateInvitation(ctx context.Context, email, orgID, orgRole, token
 		email, orgID, orgRole, tokenHash, invitedBy, expiresAt,
 	).Scan(&inv.ID, &inv.Email, &inv.OrgID, &inv.OrgRole, &inv.TokenHash, &inv.Status, &inv.InvitedBy, &inv.ExpiresAt, &inv.CreatedAt, &inv.UpdatedAt)
 	if err != nil {
+		// Translate the partial-unique-index violation into a typed
+		// sentinel so racing duplicate invites surface as 409 not 500.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+			pgErr.ConstraintName == "idx_invitations_email_org_pending" {
+			return nil, ErrDuplicatePendingInvitation
+		}
 		return nil, fmt.Errorf("creating invitation: %w", err)
 	}
 	return inv, nil

--- a/internal/models/queries_extended_test.go
+++ b/internal/models/queries_extended_test.go
@@ -1553,6 +1553,69 @@ func TestAcceptInviteTxRollsBackOnInvalidOrg(t *testing.T) {
 	}
 }
 
+// TestCreateInvitationDuplicatePending locks in #32: the partial
+// unique index on (email, org_id) WHERE status = 'pending' must
+// surface as ErrDuplicatePendingInvitation, not a raw pg error
+// wrapped in fmt.Errorf.
+func TestCreateInvitationDuplicatePending(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	inviter := createTestUser(t, db, "dup-inviter")
+	org, err := db.CreateOrgWithOwnerTx(ctx, inviter.ID, "Dup Org", "dup-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	// First invite succeeds.
+	_, err = db.CreateInvitation(ctx,
+		"dup@test.com", org.ID, "member", "token-hash-dup-1", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("first invite: %v", err)
+	}
+
+	// Second invite for the same (email, org) with another token
+	// must hit the partial unique index and return the typed sentinel.
+	_, err = db.CreateInvitation(ctx,
+		"dup@test.com", org.ID, "member", "token-hash-dup-2", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if !errors.Is(err, ErrDuplicatePendingInvitation) {
+		t.Fatalf("expected ErrDuplicatePendingInvitation, got %v", err)
+	}
+}
+
+// TestCreateInvitationAfterAcceptedAllowsNew confirms the partial
+// index does not block creating a fresh invitation once the prior
+// one has been accepted (partial predicate: status = 'pending').
+func TestCreateInvitationAfterAcceptedAllowsNew(t *testing.T) {
+	db := setupExtendedTestDB(t)
+	ctx := context.Background()
+
+	inviter := createTestUser(t, db, "aa-inviter")
+	org, err := db.CreateOrgWithOwnerTx(ctx, inviter.ID, "AA Org", "aa-org", "owner")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	first, err := db.CreateInvitation(ctx,
+		"aa@test.com", org.ID, "member", "token-hash-aa-1", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("first invite: %v", err)
+	}
+	if err = db.UpdateInvitationStatus(ctx, first.ID, "accepted"); err != nil {
+		t.Fatalf("accept first: %v", err)
+	}
+
+	_, err = db.CreateInvitation(ctx,
+		"aa@test.com", org.ID, "member", "token-hash-aa-2", inviter.ID,
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("second invite after accept should succeed, got %v", err)
+	}
+}
+
 // TestAcceptInviteTxRejectsAlreadyAcceptedInvitation locks in
 // Gemini's review feedback: the UPDATE guard "AND status = 'pending'"
 // plus the RowsAffected check must surface ErrInvitationNotAcceptable


### PR DESCRIPTION
## Summary

Two concurrent \`InviteMember\` requests on the same (email, org) both passed the \`HasPendingInvitation\` pre-check and raced on INSERT. The partial unique index correctly rejected the second insert, but pgx's 23505 violation was surfaced as a 500 rather than the idempotent 409 Conflict the pre-check path already returns.

## Change

- **New sentinel** \`ErrDuplicatePendingInvitation\` in the models package
- **\`CreateInvitation\`** inspects \`*pgconn.PgError\` for \`Code == "23505"\` and \`ConstraintName == "idx_invitations_email_org_pending"\`, returning the typed sentinel instead of wrapping
- **\`InviteMember\` handler** branches on \`errors.Is(err, models.ErrDuplicatePendingInvitation)\` → 409 Conflict with the same message as the pre-check path
- The partial unique index predicate (\`WHERE status = 'pending'\`) means accepted invitations don't block new ones — verified by a test

## Tests

| Test | Verifies |
|------|----------|
| \`TestCreateInvitationDuplicatePending\` | second INSERT returns the typed sentinel |
| \`TestCreateInvitationAfterAcceptedAllowsNew\` | partial index doesn't block re-invite after acceptance |

## Test plan

- [x] Both new tests pass
- [x] Full suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)