### PR TITLE
Fix #33: route raw fetch() through apiFetch wrapper

### DIFF
--- a/static/js/app/init.js
+++ b/static/js/app/init.js
@@ -17,3 +17,53 @@ document.addEventListener('htmx:configRequest', function(event) {
         event.detail.headers['X-CSRF-Token'] = meta.getAttribute('content');
     }
 });
+
+// apiFetch wraps fetch() for calls to our own mutation endpoints.
+// It matches the HTMX request profile so raw fetch() callers behave
+// consistently with HTMX-boosted forms:
+//
+//   * Injects X-CSRF-Token from the meta tag (parallel to the HTMX
+//     configRequest listener above). Harmless under the current
+//     header-based CSRF scheme (filippo.io/csrf/gorilla uses
+//     Sec-Fetch-Site); future-proofing if the middleware ever
+//     reverts to a token-based scheme.
+//   * Sets credentials: 'same-origin' so the session cookie travels.
+//   * Rejects non-2xx responses so callers can't silently treat a
+//     403 CSRF failure or 500 as a success. (#33)
+//
+// Callers receive the parsed JSON body on success, or a rejected
+// promise carrying the response status + best-effort error message
+// on failure.
+window.apiFetch = function(url, options) {
+    options = options || {};
+    var headers = {};
+    // Copy caller-provided headers first so our additions don't
+    // clobber caller intent unless we explicitly override.
+    if (options.headers) {
+        Object.keys(options.headers).forEach(function(k) { headers[k] = options.headers[k]; });
+    }
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    if (meta && !headers['X-CSRF-Token']) {
+        headers['X-CSRF-Token'] = meta.getAttribute('content');
+    }
+    options.headers = headers;
+    if (options.credentials === undefined) {
+        options.credentials = 'same-origin';
+    }
+    return fetch(url, options).then(function(response) {
+        return response.json().catch(function() {
+            // Non-JSON body; synthesize a minimal error payload so
+            // the subsequent .ok check still has something to work with.
+            return { error: 'Unexpected response (HTTP ' + response.status + ')' };
+        }).then(function(body) {
+            if (!response.ok) {
+                var msg = (body && body.error) ? body.error : ('Request failed: HTTP ' + response.status);
+                var err = new Error(msg);
+                err.status = response.status;
+                err.body = body;
+                throw err;
+            }
+            return body;
+        });
+    });
+};

--- a/static/js/app/init.js
+++ b/static/js/app/init.js
@@ -36,26 +36,42 @@ document.addEventListener('htmx:configRequest', function(event) {
 // on failure.
 window.apiFetch = function(url, options) {
     options = options || {};
+
+    // Collect caller-provided headers. Supports both plain-object
+    // headers and Headers instances (forEach). Per Gemini review
+    // on #33.
     var headers = {};
-    // Copy caller-provided headers first so our additions don't
-    // clobber caller intent unless we explicitly override.
     if (options.headers) {
-        Object.keys(options.headers).forEach(function(k) { headers[k] = options.headers[k]; });
+        if (typeof options.headers.forEach === 'function') {
+            options.headers.forEach(function(v, k) { headers[k] = v; });
+        } else {
+            Object.keys(options.headers).forEach(function(k) { headers[k] = options.headers[k]; });
+        }
     }
     var meta = document.querySelector('meta[name="csrf-token"]');
     if (meta && !headers['X-CSRF-Token']) {
         headers['X-CSRF-Token'] = meta.getAttribute('content');
     }
-    options.headers = headers;
-    if (options.credentials === undefined) {
-        options.credentials = 'same-origin';
+
+    // Build a fresh options object so we don't mutate the caller's
+    // (they may be reusing it for retries / multiple requests).
+    var fetchOptions = {};
+    Object.keys(options).forEach(function(k) { fetchOptions[k] = options[k]; });
+    fetchOptions.headers = headers;
+    if (fetchOptions.credentials === undefined) {
+        fetchOptions.credentials = 'same-origin';
     }
-    return fetch(url, options).then(function(response) {
-        return response.json().catch(function() {
-            // Non-JSON body; synthesize a minimal error payload so
-            // the subsequent .ok check still has something to work with.
-            return { error: 'Unexpected response (HTTP ' + response.status + ')' };
-        }).then(function(body) {
+
+    return fetch(url, fetchOptions).then(function(response) {
+        // 204 No Content (and any other empty success body) must not
+        // be funneled through response.json() — that would throw and
+        // trick callers into thinking the request failed.
+        var bodyPromise = response.status === 204
+            ? Promise.resolve({})
+            : response.json().catch(function() {
+                return { error: 'Unexpected response (HTTP ' + response.status + ')' };
+            });
+        return bodyPromise.then(function(body) {
             if (!response.ok) {
                 var msg = (body && body.error) ? body.error : ('Request failed: HTTP ' + response.status);
                 var err = new Error(msg);

--- a/templates/components/image_modal.html
+++ b/templates/components/image_modal.html
@@ -174,10 +174,11 @@ function imageInsertModal() {
             fd.append('file', this.file);
             fd.append('project_id', this.projectID);
             var self = this;
-            fetch('/api/upload-image', { method: 'POST', body: fd })
-                .then(function(r) { return r.json(); })
+            window.apiFetch('/api/upload-image', { method: 'POST', body: fd })
                 .then(function(j) {
                     self.uploading = false;
+                    // apiFetch rejects non-2xx responses, so we only get here
+                    // on success — j.error is for application-level errors.
                     if (j.error) { self.error = j.error; return; }
                     self.uploadedUrl = j.data.filePath;
                 })
@@ -188,12 +189,11 @@ function imageInsertModal() {
             this.generating = true;
             this.error = '';
             var self = this;
-            fetch('/api/generate-image', {
+            window.apiFetch('/api/generate-image', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ prompt: this.prompt, project_id: this.projectID })
             })
-            .then(function(r) { return r.json(); })
             .then(function(j) {
                 self.generating = false;
                 if (j.error) { self.error = j.error; return; }

--- a/templates/pages/ticket_detail.html
+++ b/templates/pages/ticket_detail.html
@@ -343,8 +343,7 @@ function fileUploader() {
                 fd.append('file', files[i]);
                 fd.append('ticket_id', _ticketID);
                 promises.push(
-                    fetch('/api/upload-file', { method: 'POST', body: fd })
-                        .then(function(r) { return r.json(); })
+                    window.apiFetch('/api/upload-file', { method: 'POST', body: fd })
                 );
             }
             Promise.all(promises)

--- a/templates/pages/ticket_detail.html
+++ b/templates/pages/ticket_detail.html
@@ -346,10 +346,22 @@ function fileUploader() {
                     window.apiFetch('/api/upload-file', { method: 'POST', body: fd })
                 );
             }
-            Promise.all(promises)
-                .then(function() { window.location.reload(); })
-                .catch(function(e) { alert('Upload failed: ' + e.message); })
-                .finally(function() { this.uploading = false; }.bind(this));
+            // Promise.allSettled — wait for every upload to finish
+            // (succeed or fail) before flipping UI state, so a single
+            // failed file can't abort in-flight siblings or leave the
+            // user with "Uploading…" cleared while some are still
+            // running. (#33 review)
+            var self = this;
+            Promise.allSettled(promises).then(function(results) {
+                self.uploading = false;
+                var failures = results.filter(function(r) { return r.status === 'rejected'; });
+                if (failures.length === 0) {
+                    window.location.reload();
+                    return;
+                }
+                alert('Upload failed for ' + failures.length + ' of ' + results.length
+                    + ' file(s): ' + failures[0].reason.message);
+            });
             event.target.value = '';
         }
     };


### PR DESCRIPTION
## Summary

Three mutation endpoints called from Alpine.js components used raw \`fetch()\`, bypassing the HTMX \`configRequest\` listener that injects \`X-CSRF-Token\`. Under the current \`filippo.io/csrf\` middleware (Sec-Fetch-Site based), same-origin fetches work at runtime, but:

1. **Fragility** — a future revert to token-based CSRF would silently break these 3 endpoints
2. **No \`response.ok\` check** — a 403/500 response was parsed as JSON and treated as application data

## Change

New \`window.apiFetch(url, options)\` in \`init.js\`:
- Injects \`X-CSRF-Token\` from \`meta[name="csrf-token"]\` (matches HTMX listener)
- Sets \`credentials: 'same-origin'\` for cookie delivery
- Rejects non-2xx responses with a typed \`Error\` carrying \`.status\` + best-effort \`body.error\` message
- Returns parsed JSON body on success (drop-in for existing \`.then(j => j.error/j.data)\` callers)

Migrated call sites:
| Location | Endpoint |
|---|---|
| \`ticket_detail.html\` upload | \`/api/upload-file\` |
| \`image_modal.html\` upload | \`/api/upload-image\` |
| \`image_modal.html\` generate | \`/api/generate-image\` |

Bundle is regenerated by the Containerfile — \`static/js/bundle.js\` is gitignored.

## Test plan

- [x] \`go build ./...\` succeeds
- [x] Full Go test suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] JS bundle rebuilds (\`bash scripts/bundle.sh\`)
- [ ] Manual: upload file on ticket detail, upload image in modal, generate image — all succeed and show UI state correctly
- [ ] Manual: simulate 500 by killing S3 backend — error surfaces to the UI instead of being silently swallowed


🤖 Generated with [Claude Code](https://claude.com/claude-code)