### PR TITLE
Fix #35: standardize on 'cancelled' spelling across the stack

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,6 +124,13 @@ linters:
 
     misspell:
       locale: US
+      # "cancelled" is the canonical spelling throughout this codebase.
+      # The DB CHECK constraint on tickets.status uses two l's (see
+      # migrations/000006_create_tickets.up.sql), as does the template
+      # dropdown. Standardizing on US "canceled" would require a
+      # data migration over existing production rows. See #35.
+      ignore-rules:
+        - cancelled
 
   exclusions:
     # Don't lint test files as strictly

--- a/internal/ai/gemini.go
+++ b/internal/ai/gemini.go
@@ -65,6 +65,16 @@ func NewGeminiClient(ctx context.Context, apiKey string, models GeminiModels) (*
 	}, nil
 }
 
+// ticketStatusEnum lists the status values declared in the DB CHECK
+// constraint on tickets.status (migrations/000006_create_tickets.up.sql).
+// Centralized here so drift between the three tool declarations
+// below cannot reintroduce the cancelled/canceled bug (#35). The
+// British "cancelled" spelling is intentional — see .golangci.yml.
+var ticketStatusEnum = []string{
+	"backlog", "ready", "planning", "plan_review",
+	"implementing", "testing", "review", "done", "cancelled",
+}
+
 // toolDeclarations returns the function declarations available to the assistant.
 func toolDeclarations() []*genai.FunctionDeclaration {
 	return []*genai.FunctionDeclaration{
@@ -76,7 +86,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 				Properties: map[string]*genai.Schema{
 					"query":  {Type: genai.TypeString, Description: "Search query to match against ticket titles and descriptions"},
 					"type":   {Type: genai.TypeString, Description: "Filter by ticket type", Enum: []string{"feature", "task", "subtask", "bug"}},
-					"status": {Type: genai.TypeString, Description: "Filter by ticket status", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "cancelled"}},
+					"status": {Type: genai.TypeString, Description: "Filter by ticket status", Enum: ticketStatusEnum},
 				},
 				Required: []string{"query"},
 			},
@@ -117,7 +127,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 				Type: genai.TypeObject,
 				Properties: map[string]*genai.Schema{
 					"ticket_id":  {Type: genai.TypeString, Description: "UUID of the ticket"},
-					"new_status": {Type: genai.TypeString, Description: "New status", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "cancelled"}},
+					"new_status": {Type: genai.TypeString, Description: "New status", Enum: ticketStatusEnum},
 				},
 				Required: []string{"ticket_id", "new_status"},
 			},
@@ -136,7 +146,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 		},
 		{
 			Name:        "update_ticket",
-			Description: "Update fields on an existing ticket (title, description, priority, dates, status). Use when the user asks to edit or modify a ticket's details. Only provided fields will be updated.",
+			Description: "Update fields on an existing ticket (title, description, priority, dates). Use when the user asks to edit or modify a ticket's details. Only provided fields will be updated. To change a ticket's status, use update_ticket_status instead.",
 			Parameters: &genai.Schema{
 				Type: genai.TypeObject,
 				Properties: map[string]*genai.Schema{
@@ -144,7 +154,6 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 					"title":       {Type: genai.TypeString, Description: "New title (optional)"},
 					"description": {Type: genai.TypeString, Description: "New description in markdown (optional)"},
 					"priority":    {Type: genai.TypeString, Description: "New priority (optional)", Enum: []string{"low", "medium", "high", "critical"}},
-					"status":      {Type: genai.TypeString, Description: "New status (optional)", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "cancelled"}},
 					"date_start":  {Type: genai.TypeString, Description: "Start date in YYYY-MM-DD format (optional)"},
 					"date_end":    {Type: genai.TypeString, Description: "End date in YYYY-MM-DD format (optional)"},
 				},

--- a/internal/ai/gemini.go
+++ b/internal/ai/gemini.go
@@ -76,7 +76,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 				Properties: map[string]*genai.Schema{
 					"query":  {Type: genai.TypeString, Description: "Search query to match against ticket titles and descriptions"},
 					"type":   {Type: genai.TypeString, Description: "Filter by ticket type", Enum: []string{"feature", "task", "subtask", "bug"}},
-					"status": {Type: genai.TypeString, Description: "Filter by ticket status", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "canceled"}},
+					"status": {Type: genai.TypeString, Description: "Filter by ticket status", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "cancelled"}},
 				},
 				Required: []string{"query"},
 			},
@@ -117,7 +117,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 				Type: genai.TypeObject,
 				Properties: map[string]*genai.Schema{
 					"ticket_id":  {Type: genai.TypeString, Description: "UUID of the ticket"},
-					"new_status": {Type: genai.TypeString, Description: "New status", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "canceled"}},
+					"new_status": {Type: genai.TypeString, Description: "New status", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "cancelled"}},
 				},
 				Required: []string{"ticket_id", "new_status"},
 			},
@@ -144,7 +144,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 					"title":       {Type: genai.TypeString, Description: "New title (optional)"},
 					"description": {Type: genai.TypeString, Description: "New description in markdown (optional)"},
 					"priority":    {Type: genai.TypeString, Description: "New priority (optional)", Enum: []string{"low", "medium", "high", "critical"}},
-					"status":      {Type: genai.TypeString, Description: "New status (optional)", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "canceled"}},
+					"status":      {Type: genai.TypeString, Description: "New status (optional)", Enum: []string{"backlog", "ready", "planning", "plan_review", "implementing", "testing", "review", "done", "cancelled"}},
 					"date_start":  {Type: genai.TypeString, Description: "Start date in YYYY-MM-DD format (optional)"},
 					"date_end":    {Type: genai.TypeString, Description: "End date in YYYY-MM-DD format (optional)"},
 				},

--- a/internal/handlers/assistant.go
+++ b/internal/handlers/assistant.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
 
@@ -447,7 +446,7 @@ func (h *AssistantHandler) buildSystemPrompt(ctx context.Context, user *models.U
 	sb.WriteString("- Title is optional when creating tickets — if omitted, it's auto-generated from the description\n")
 	sb.WriteString("- Use the current project ID when creating tickets or searching\n")
 	sb.WriteString("- Use update_project_brief to write or update the project brief. Write well-structured markdown with headings, lists, and sections\n")
-	sb.WriteString("- Use update_ticket to modify any ticket field: title, description, priority, status, dates\n")
+	sb.WriteString("- Use update_ticket to modify a ticket's title, description, priority, or dates. For status changes, use update_ticket_status (which also records activity).\n")
 	sb.WriteString("- Set date_start and date_end (YYYY-MM-DD) on tickets for timeline/Gantt planning\n")
 	sb.WriteString("- Child ticket dates auto-expand the parent's date range, so set dates on children and parents will adjust automatically\n")
 	sb.WriteString("- Confirm destructive actions (archive, delete) with the user before executing\n")
@@ -819,10 +818,10 @@ func (e *toolExecutor) updateTicket(ctx context.Context, args map[string]any) (m
 		ticket.Priority = pri
 		changes = append(changes, "priority")
 	}
-	if status, ok := args["status"].(string); ok && status != "" {
-		ticket.Status = status
-		changes = append(changes, "status")
-	}
+	// Status is intentionally not handled here: the corresponding
+	// "status" field was removed from the update_ticket tool schema
+	// because db.UpdateTicket never writes the status column.
+	// Callers should use the update_ticket_status tool. (#35 review)
 	if ds, ok := args["date_start"].(string); ok && ds != "" {
 		if t, err := time.Parse("2006-01-02", ds); err == nil {
 			ticket.DateStart = &t
@@ -842,12 +841,6 @@ func (e *toolExecutor) updateTicket(ctx context.Context, args map[string]any) (m
 
 	if err := e.db.UpdateTicket(ctx, ticket); err != nil {
 		return nil, fmt.Errorf("updating ticket: %w", err)
-	}
-
-	// Log activity for status changes
-	if slices.Contains(changes, "status") {
-		details, _ := json.Marshal(map[string]string{"new_status": ticket.Status}) //nolint:errchkjson // simple map marshal cannot fail
-		_ = e.db.CreateActivity(ctx, ticketID, &e.userID, nil, "status_change", string(details))
 	}
 
 	// Auto-expand parent dates if dates changed

--- a/internal/handlers/tickets.go
+++ b/internal/handlers/tickets.go
@@ -41,7 +41,7 @@ var (
 	validTicketPriorities = map[string]bool{"low": true, "medium": true, "high": true, "critical": true}
 	validTicketStatuses   = map[string]bool{
 		"backlog": true, "ready": true, "planning": true, "plan_review": true,
-		"implementing": true, "testing": true, "review": true, "done": true, "canceled": true,
+		"implementing": true, "testing": true, "review": true, "done": true, "cancelled": true,
 	}
 )
 

--- a/internal/handlers/tickets_authz_test.go
+++ b/internal/handlers/tickets_authz_test.go
@@ -341,7 +341,10 @@ func TestUpdateStatusAcceptsCancelledSpelling(t *testing.T) {
 		t.Fatalf("create proj: %v", err)
 	}
 	cookie := createAuthenticatedUser(t, db, sessions, "canceler@test.com", "client")
-	user, _ := db.GetUserByEmail(ctx, "canceler@test.com")
+	user, err := db.GetUserByEmail(ctx, "canceler@test.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
 	if err = db.AddOrgMember(ctx, user.ID, org.ID, "member"); err != nil {
 		t.Fatalf("add member: %v", err)
 	}

--- a/internal/handlers/tickets_authz_test.go
+++ b/internal/handlers/tickets_authz_test.go
@@ -321,3 +321,55 @@ func TestCreateTicketCrossProjectParent(t *testing.T) {
 		t.Errorf("body leaked cross-project existence: %q", body)
 	}
 }
+
+// TestUpdateStatusAcceptsCancelledSpelling locks in #35: the handler,
+// AI schema, template dropdown, and DB CHECK constraint must all
+// agree on the "cancelled" (two l's) spelling, matching the
+// migration 000006 constraint. The old code had "canceled" in the
+// handler validation, which rejected the template's "cancelled"
+// POST as "Invalid status".
+func TestUpdateStatusAcceptsCancelledSpelling(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	org, err := db.CreateOrg(ctx, "Cancel Org", "cancel-org")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	proj, err := db.CreateProject(ctx, org.ID, "Cancel Proj", "cancel-proj")
+	if err != nil {
+		t.Fatalf("create proj: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "canceler@test.com", "client")
+	user, _ := db.GetUserByEmail(ctx, "canceler@test.com")
+	if err = db.AddOrgMember(ctx, user.ID, org.ID, "member"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	ticket := &models.Ticket{
+		ProjectID: proj.ID, Type: "task", Title: "Will Cancel",
+		Status: "backlog", Priority: "medium", CreatedBy: user.ID,
+	}
+	if err = db.CreateTicket(ctx, ticket); err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+
+	form := url.Values{"status": {"cancelled"}}
+	req := httptest.NewRequest(http.MethodPatch, "/tickets/"+ticket.ID+"/status", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := db.GetTicket(ctx, ticket.ID)
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if got.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", got.Status)
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -163,7 +163,7 @@ func NewEngine(templatesDir string, manifest *static.Manifest) (*Engine, error) 
 				return "indigo"
 			case "done":
 				return "green"
-			case "canceled":
+			case "cancelled":
 				return "red"
 			default:
 				return colorGray


### PR DESCRIPTION
## Summary

The DB CHECK constraint uses \`cancelled\` (two l's) since migration 000006, and the template dropdown emits \`cancelled\`. Three code paths drifted to US \`canceled\`, creating a broken cancel transition depending on entry point.

## Changes

| File | Drift fixed |
|------|-------------|
| \`internal/handlers/tickets.go\` | \`validTicketStatuses\` rejected template's \`cancelled\` as 400 |
| \`internal/ai/gemini.go\` | 3 function-tool enum entries told Gemini to send \`canceled\` → DB rejected |
| \`internal/render/render.go\` | \`statusColor\` returned gray for \`cancelled\`; only \`canceled\` got red |
| \`.golangci.yml\` | Add \`cancelled\` to misspell \`ignore-rules\` with comment |

## Why British spelling

The DB has \`cancelled\` in the CHECK constraint, production data uses that spelling, and CLAUDE.md's data-model doc matches. Flipping to US \`canceled\` would require a data migration — not worth the churn.

## Test plan

- [x] \`TestUpdateStatusAcceptsCancelledSpelling\` — end-to-end POST with the exact form the template emits
- [x] Full suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)