### PR TITLE
Fix #36: reject legacy 'epic' ticket type up front

### DIFF
--- a/internal/handlers/tickets.go
+++ b/internal/handlers/tickets.go
@@ -37,7 +37,12 @@ func NewTicketHandler(db *models.DB, engine *render.Engine, tg titleGenerator, c
 
 // Valid ticket field values for input validation
 var (
-	validTicketTypes      = map[string]bool{"epic": true, "feature": true, "task": true, "subtask": true, "bug": true}
+	// The "epic" type was renamed to "feature" in migration 000017
+	// along with a DB CHECK constraint that rejects "epic". Keeping
+	// it in this allowlist caused request validation to accept epic,
+	// only to have the INSERT fail with a constraint violation that
+	// surfaced as 500. Reject it up front with a clean 400. (#36)
+	validTicketTypes      = map[string]bool{"feature": true, "task": true, "subtask": true, "bug": true}
 	validTicketPriorities = map[string]bool{"low": true, "medium": true, "high": true, "critical": true}
 	validTicketStatuses   = map[string]bool{
 		"backlog": true, "ready": true, "planning": true, "plan_review": true,

--- a/internal/handlers/tickets_authz_test.go
+++ b/internal/handlers/tickets_authz_test.go
@@ -322,6 +322,48 @@ func TestCreateTicketCrossProjectParent(t *testing.T) {
 	}
 }
 
+// TestCreateTicketRejectsLegacyEpicType locks in #36: after
+// migration 000017 renamed "epic" → "feature" and added a DB
+// CHECK constraint that excludes "epic", the handler must
+// reject "epic" up front with a clean 400 rather than letting
+// it reach INSERT and surface as 500.
+func TestCreateTicketRejectsLegacyEpicType(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	org, err := db.CreateOrg(ctx, "Epic Org", "epic-org")
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	proj, err := db.CreateProject(ctx, org.ID, "Epic Proj", "epic-proj")
+	if err != nil {
+		t.Fatalf("create proj: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "epictester@test.com", "client")
+	user, err := db.GetUserByEmail(ctx, "epictester@test.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if err = db.AddOrgMember(ctx, user.ID, org.ID, "member"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	form := url.Values{
+		"project_id": {proj.ID},
+		"title":      {"Legacy"},
+		"type":       {"epic"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/tickets", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for legacy 'epic' type, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestUpdateStatusAcceptsCancelledSpelling locks in #35: the handler,
 // AI schema, template dropdown, and DB CHECK constraint must all
 // agree on the "cancelled" (two l's) spelling, matching the


### PR DESCRIPTION
## Summary

Migration 000017 renamed \`epic\` → \`feature\` and added a DB CHECK constraint that excludes \`epic\`. The handler allowlist still accepted \`epic\`, so direct API callers submitting \`type=epic\` passed validation and then hit a 500 at INSERT.

## Change

Remove \`"epic": true\` from \`validTicketTypes\` so the request is rejected up front with a clean 400 \`Invalid ticket type\`.

## Test plan

- [x] \`TestCreateTicketRejectsLegacyEpicType\` — direct POST with type=epic returns 400
- [x] Full suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues


🤖 Generated with [Claude Code](https://claude.com/claude-code)