### PR TITLE
Fix #37: HTMX comment partial renders markdown like the full page

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -570,6 +570,55 @@ func TestCreateComment(t *testing.T) {
 	}
 }
 
+// TestCreateCommentRendersMarkdownInPartial locks in #37: the HTMX
+// partial returned by CreateComment must render markdown through
+// the template's markdown helper (and apply the `prose` class) so
+// a freshly-posted comment looks the same as after a full-page
+// reload. Previously the partial emitted raw BodyMarkdown.
+func TestCreateCommentRendersMarkdownInPartial(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	cookie := createAuthenticatedUser(t, db, sessions, "mdcomment@test.com", "superadmin")
+	ctx := context.Background()
+
+	org, _ := db.CreateOrg(ctx, "MD Org", "md-org")
+	proj, _ := db.CreateProject(ctx, org.ID, "MD Proj", "md-proj")
+	user, _ := db.GetUserByEmail(ctx, "mdcomment@test.com")
+	ticket := &models.Ticket{
+		ProjectID: proj.ID, Type: "task", Title: "MD Task",
+		Status: "backlog", Priority: "medium", CreatedBy: user.ID,
+	}
+	db.CreateTicket(ctx, ticket)
+
+	// Post a comment containing markdown syntax — bold + inline code.
+	form := url.Values{"body": {"This is **bold** and `code`."}}
+	req := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/comments", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	// Markdown renderer should convert ** to <strong> and ` to <code>.
+	if !strings.Contains(body, "<strong>bold</strong>") {
+		t.Errorf("partial did not render bold markdown: %q", body)
+	}
+	if !strings.Contains(body, "<code>code</code>") {
+		t.Errorf("partial did not render inline code markdown: %q", body)
+	}
+	// The prose class should be applied (parity with full page).
+	if !strings.Contains(body, `comment-body prose`) {
+		t.Errorf("partial missing 'prose' class: %q", body)
+	}
+	// The raw, un-rendered markdown should NOT appear in the output.
+	if strings.Contains(body, "**bold**") {
+		t.Errorf("partial emitted raw markdown instead of rendered HTML: %q", body)
+	}
+}
+
 func TestAdminPageSuperadminOnly(t *testing.T) {
 	r, db, sessions, _ := setupTestRouter(t)
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -298,13 +298,22 @@ func NewEngine(templatesDir string, manifest *static.Manifest) (*Engine, error) 
 		}
 	}
 
-	// Parse standalone partials (HTMX fragments, no layout)
+	// Parse standalone partials (HTMX fragments, no layout). Each
+	// partial is parsed alongside the full component set so it can
+	// reference sibling components via {{template "other.html" ...}}.
+	// Previously each partial was parsed in isolation; the comment
+	// partial's {{template "reactions.html" ...}} include then
+	// failed at Execute time with "no such template", and since
+	// html/template buffers output until success, the partial
+	// silently emitted nothing — newly posted comments disappeared
+	// until a full page reload re-rendered them. (#37)
 	err = filepath.WalkDir(filepath.Join(templatesDir, "components"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".html") {
 			return err
 		}
 		name := "partial:" + filepath.Base(path)
-		t, err := template.New(filepath.Base(path)).Funcs(funcMap).ParseFiles(path)
+		files := append([]string{path}, componentFiles...)
+		t, err := template.New(filepath.Base(path)).Funcs(funcMap).ParseFiles(files...)
 		if err != nil {
 			return fmt.Errorf("parsing partial %s: %w", path, err)
 		}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html"
 	"html/template"
-	"io/fs"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -298,30 +297,24 @@ func NewEngine(templatesDir string, manifest *static.Manifest) (*Engine, error) 
 		}
 	}
 
-	// Parse standalone partials (HTMX fragments, no layout). Each
-	// partial is parsed alongside the full component set so it can
-	// reference sibling components via {{template "other.html" ...}}.
-	// Previously each partial was parsed in isolation; the comment
-	// partial's {{template "reactions.html" ...}} include then
-	// failed at Execute time with "no such template", and since
-	// html/template buffers output until success, the partial
-	// silently emitted nothing — newly posted comments disappeared
-	// until a full page reload re-rendered them. (#37)
-	err = filepath.WalkDir(filepath.Join(templatesDir, "components"), func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".html") {
-			return err
+	// Standalone partials (HTMX fragments, no layout) are parsed
+	// once into a shared template set so each partial can reference
+	// sibling components via {{template "other.html" ...}} without
+	// O(N^2) re-parsing at startup. Previously each partial was
+	// parsed in isolation; the comment partial's {{template
+	// "reactions.html" ...}} include then failed at Execute time
+	// with "no such template", and since html/template buffers
+	// output until success, the partial silently emitted nothing —
+	// newly posted comments disappeared until a full page reload
+	// re-rendered them. (#37)
+	if len(componentFiles) > 0 {
+		partialSet, parseErr := template.New("partials").Funcs(funcMap).ParseFiles(componentFiles...)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parsing component partials: %w", parseErr)
 		}
-		name := "partial:" + filepath.Base(path)
-		files := append([]string{path}, componentFiles...)
-		t, err := template.New(filepath.Base(path)).Funcs(funcMap).ParseFiles(files...)
-		if err != nil {
-			return fmt.Errorf("parsing partial %s: %w", path, err)
+		for _, path := range componentFiles {
+			e.templates["partial:"+filepath.Base(path)] = partialSet
 		}
-		e.templates[name] = t
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	return e, nil
@@ -378,18 +371,24 @@ func (e *Engine) Render(w http.ResponseWriter, r *http.Request, name string, dat
 }
 
 // RenderPartial renders an HTMX partial (no layout).
+// All partial keys share one template set parsed from the components/
+// directory (see Engine construction), so we execute by base-name
+// rather than relying on the set's default template.
 func (e *Engine) RenderPartial(w http.ResponseWriter, name string, data any) error {
 	key := "partial:" + name
 	t, ok := e.templates[key]
 	if !ok {
-		// Fall back to direct template name
+		// Fall back to direct template name (for tests that register
+		// custom templates outside the components/ walk).
 		t, ok = e.templates[name]
 		if !ok {
 			return fmt.Errorf("partial template %q not found", name)
 		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		return t.Execute(w, data)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	return t.Execute(w, data)
+	return t.ExecuteTemplate(w, name, data)
 }
 
 // RenderError renders an error page.

--- a/templates/components/comment.html
+++ b/templates/components/comment.html
@@ -3,6 +3,11 @@
         <span class="comment-author">{{.UserName}}</span>
         <span class="comment-time">{{formatDateTime .Comment.CreatedAt}}</span>
     </div>
-    <div class="comment-body">{{.Comment.BodyMarkdown}}</div>
+    <!-- Render markdown + prose to match the full-page rendering in
+         pages/ticket_detail.html. Previously this partial emitted
+         raw BodyMarkdown, so a newly-posted comment showed escaped
+         markdown until reload when the full page re-rendered it
+         properly. (#37) -->
+    <div class="comment-body prose">{{markdown .Comment.BodyMarkdown}}</div>
     {{template "reactions.html" dict "TargetType" "comment" "TargetID" .Comment.ID "Groups" .CommentReactions}}
 </div>


### PR DESCRIPTION
## Summary

Two bugs hid under the "rendering diverges" label:

1. The partial emitted raw \`{{.Comment.BodyMarkdown}}\` while the full-page iterator passed it through \`{{markdown ...}}\` with the \`prose\` class.
2. **Worse** — the partial's \`{{template "reactions.html" ...}}\` include failed at Execute time because standalone partials were parsed in isolation, without their sibling component files. \`html/template\` buffers output until success, so the partial **actually emitted nothing at all**. Newly posted comments disappeared until a full page reload.

## Change

| File | Change |
|------|--------|
| \`templates/components/comment.html\` | Render \`{{markdown .Comment.BodyMarkdown}}\` + \`prose\` class, matching full page |
| \`internal/render/render.go\` | Parse each partial alongside the full \`componentFiles\` set so cross-includes resolve |
| \`internal/handlers/handlers_test.go\` | Regression test covers rendering + partial visibility |

## Test plan

- [x] \`TestCreateCommentRendersMarkdownInPartial\` — posts \`**bold**\` + \`\`\`code\`\`\`, asserts \`<strong>\`, \`<code>\`, \`prose\` class, and absence of raw markdown in body
- [x] Full suite passes (2 pre-existing \`internal/ai\` failures unrelated)
- [x] \`golangci-lint run --timeout=5m\` → 0 issues
- [x] \`go build ./...\` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)