### PR TITLE
feat(ai): Refiner/Scorer interfaces + pricing (debate v1 task 3)

### DIFF
--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -1,5 +1,17 @@
 package ai
 
+// Model identifier constants. Centralized here so pricing, adapters, and
+// handler wiring all reference the same strings — typos become compile
+// errors instead of silent cost-lookup misses.
+const (
+	ModelClaudeSonnet46 = "claude-sonnet-4-6"
+	ModelClaudeOpus46   = "claude-opus-4-6"
+	ModelGPT5Mini       = "gpt-5-mini"
+	ModelGPT5           = "gpt-5"
+	ModelGeminiFlash    = "gemini-2.5-flash"
+	ModelGeminiPro      = "gemini-2.5-pro"
+)
+
 // pricingRate expresses a per-1k-token rate in micros (millionths of USD).
 type pricingRate struct {
 	inputMicrosPer1k  int64
@@ -11,31 +23,41 @@ type pricingRate struct {
 // of "we were paying $X per 1k tokens during period Y".
 //
 // Rates are the public list prices as of the spec date (2026-04-14). If a
-// model the handler asks about is absent from this table, computeCostMicros
+// model the handler asks about is absent from this table, ComputeCostMicros
 // returns 0 — the round still records successfully, just without cost data
 // (safer than failing the round on a pricing lookup miss).
 var pricingTable = map[string]pricingRate{
-	"claude-sonnet-4-6": {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
-	"claude-opus-4-6":   {inputMicrosPer1k: 15000, outputMicrosPer1k: 75000},
-	"gpt-5-mini":        {inputMicrosPer1k: 500, outputMicrosPer1k: 2000},
-	"gpt-5":             {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
-	"gemini-2.5-flash":  {inputMicrosPer1k: 350, outputMicrosPer1k: 2800},
-	"gemini-2.5-pro":    {inputMicrosPer1k: 2500, outputMicrosPer1k: 15000},
+	ModelClaudeSonnet46: {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
+	ModelClaudeOpus46:   {inputMicrosPer1k: 15000, outputMicrosPer1k: 75000},
+	ModelGPT5Mini:       {inputMicrosPer1k: 500, outputMicrosPer1k: 2000},
+	ModelGPT5:           {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
+	ModelGeminiFlash:    {inputMicrosPer1k: 350, outputMicrosPer1k: 2800},
+	ModelGeminiPro:      {inputMicrosPer1k: 2500, outputMicrosPer1k: 15000},
 }
 
-// computeCostMicros returns the cost in micros (millionths of USD) for the
+// ComputeCostMicros returns the cost in micros (millionths of USD) for the
 // given input/output token pair against the named model. Unknown models
 // return 0 — callers still record the round, they just can't price it.
-func computeCostMicros(model string, inputTokens, outputTokens int) int64 {
+//
+// Implementation sums the input+output products BEFORE dividing by 1000
+// (rather than dividing each separately), which is equivalent for exact
+// arithmetic but avoids dropping fractional micros on each leg when the
+// token counts are small. The difference is at most 1 micro per call, but
+// it compounds across many rounds if not handled this way.
+//
+// Exported for cross-package consumption: the debate handler in
+// internal/handlers uses this to compute refiner / scorer costs before
+// handing them off to CostCentsDelta.
+func ComputeCostMicros(model string, inputTokens, outputTokens int) int64 {
 	rate, ok := pricingTable[model]
 	if !ok {
 		return 0
 	}
-	return rate.inputMicrosPer1k*int64(inputTokens)/1000 +
-		rate.outputMicrosPer1k*int64(outputTokens)/1000
+	return (rate.inputMicrosPer1k*int64(inputTokens) +
+		rate.outputMicrosPer1k*int64(outputTokens)) / 1000
 }
 
-// costCentsDelta returns the number of cents (i.e. amount_cents units in
+// CostCentsDelta returns the number of cents (i.e. amount_cents units in
 // project_costs) to add after a round of AI cost accrual. It computes the
 // delta of floor(totalMicros / 10000) before and after adding this round's
 // cost, so rounding error is bounded to <1 cent PER DEBATE rather than
@@ -45,9 +67,9 @@ func computeCostMicros(model string, inputTokens, outputTokens int) int64 {
 // with per-round ceiling semantics) that pre-date the §6 decision to
 // switch to cumulative-floor. The authoritative behavior is this
 // function's implementation; §7.3 test names reference an earlier
-// revision's helper that was renamed to costCentsDelta. Our actual test
-// (pricing_test.go:TestCostCentsDelta + TestCostCentsDelta_Accumulates
-// ToBoundedError) pins the correct cumulative-floor semantics.
+// revision's helper that was renamed. Our actual test (pricing_test.go:
+// TestCostCentsDelta + TestCostCentsDelta_AccumulatesToBoundedError)
+// pins the correct cumulative-floor semantics.
 //
 // Arguments:
 //   - oldTotalMicros: feature_debates.total_cost_micros BEFORE this round
@@ -59,7 +81,9 @@ func computeCostMicros(model string, inputTokens, outputTokens int) int64 {
 // Implementation uses integer truncation (floor for non-negative values).
 // Caller is responsible for updating feature_debates.total_cost_micros to
 // oldTotalMicros + addedMicros under the debate row's lock.
-func costCentsDelta(oldTotalMicros, addedMicros int64) int64 {
+//
+// Exported for cross-package consumption by the debate handler.
+func CostCentsDelta(oldTotalMicros, addedMicros int64) int64 {
 	newTotal := oldTotalMicros + addedMicros
 	return newTotal/10000 - oldTotalMicros/10000
 }

--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -1,0 +1,57 @@
+package ai
+
+// pricingRate expresses a per-1k-token rate in micros (millionths of USD).
+type pricingRate struct {
+	inputMicrosPer1k  int64
+	outputMicrosPer1k int64
+}
+
+// pricingTable is the single source of truth for debate-mode AI rates.
+// Update when vendors change prices; git history preserves the audit trail
+// of "we were paying $X per 1k tokens during period Y".
+//
+// Rates are the public list prices as of the spec date (2026-04-14). If a
+// model the handler asks about is absent from this table, computeCostMicros
+// returns 0 — the round still records successfully, just without cost data
+// (safer than failing the round on a pricing lookup miss).
+var pricingTable = map[string]pricingRate{
+	"claude-sonnet-4-6": {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
+	"claude-opus-4-6":   {inputMicrosPer1k: 15000, outputMicrosPer1k: 75000},
+	"gpt-5-mini":        {inputMicrosPer1k: 500, outputMicrosPer1k: 2000},
+	"gpt-5":             {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
+	"gemini-2.5-flash":  {inputMicrosPer1k: 350, outputMicrosPer1k: 2800},
+	"gemini-2.5-pro":    {inputMicrosPer1k: 2500, outputMicrosPer1k: 15000},
+}
+
+// computeCostMicros returns the cost in micros (millionths of USD) for the
+// given input/output token pair against the named model. Unknown models
+// return 0 — callers still record the round, they just can't price it.
+func computeCostMicros(model string, inputTokens, outputTokens int) int64 {
+	rate, ok := pricingTable[model]
+	if !ok {
+		return 0
+	}
+	return rate.inputMicrosPer1k*int64(inputTokens)/1000 +
+		rate.outputMicrosPer1k*int64(outputTokens)/1000
+}
+
+// costCentsDelta returns the number of cents (i.e. amount_cents units in
+// project_costs) to add after a round of AI cost accrual. It computes the
+// delta of floor(totalMicros / 10000) before and after adding this round's
+// cost, so rounding error is bounded to <1 cent per debate rather than
+// <1 cent per round (spec §6).
+//
+// Arguments:
+//   - oldTotalMicros: feature_debates.total_cost_micros BEFORE this round
+//   - addedMicros:    the round's cost_micros (refiner or scorer)
+//
+// Returns the integer cents to increment project_costs by. Typically 0 or
+// 1 per round; occasionally 2+ for large models or long outputs.
+//
+// Implementation uses integer truncation (floor for non-negative values).
+// Caller is responsible for updating feature_debates.total_cost_micros to
+// oldTotalMicros + addedMicros under the debate row's lock.
+func costCentsDelta(oldTotalMicros, addedMicros int64) int64 {
+	newTotal := oldTotalMicros + addedMicros
+	return newTotal/10000 - oldTotalMicros/10000
+}

--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -38,8 +38,16 @@ func computeCostMicros(model string, inputTokens, outputTokens int) int64 {
 // costCentsDelta returns the number of cents (i.e. amount_cents units in
 // project_costs) to add after a round of AI cost accrual. It computes the
 // delta of floor(totalMicros / 10000) before and after adding this round's
-// cost, so rounding error is bounded to <1 cent per debate rather than
-// <1 cent per round (spec §6).
+// cost, so rounding error is bounded to <1 cent PER DEBATE rather than
+// <1 cent per round. This is the §6 "cumulative floor" design.
+//
+// Note: spec §7.3 contains stale test examples (TestCostMicrosToAddCents
+// with per-round ceiling semantics) that pre-date the §6 decision to
+// switch to cumulative-floor. The authoritative behavior is this
+// function's implementation; §7.3 test names reference an earlier
+// revision's helper that was renamed to costCentsDelta. Our actual test
+// (pricing_test.go:TestCostCentsDelta + TestCostCentsDelta_Accumulates
+// ToBoundedError) pins the correct cumulative-floor semantics.
 //
 // Arguments:
 //   - oldTotalMicros: feature_debates.total_cost_micros BEFORE this round

--- a/internal/ai/pricing_test.go
+++ b/internal/ai/pricing_test.go
@@ -1,0 +1,79 @@
+package ai
+
+import "testing"
+
+func TestComputeCostMicros_KnownModels(t *testing.T) {
+	cases := []struct {
+		name     string
+		model    string
+		inputTok int
+		outTok   int
+		want     int64
+	}{
+		{"gemini flash 1k/1k", "gemini-2.5-flash", 1000, 1000, 350 + 2800},
+		{"claude sonnet 2k in / 500 out", "claude-sonnet-4-6", 2000, 500, 6000 + 7500},
+		{"gpt-5-mini 500 in / 200 out", "gpt-5-mini", 500, 200, 250 + 400},
+		{"zero tokens", "gemini-2.5-flash", 0, 0, 0},
+	}
+	for _, c := range cases {
+		got := computeCostMicros(c.model, c.inputTok, c.outTok)
+		if got != c.want {
+			t.Errorf("%s: computeCostMicros(%q, %d, %d) = %d, want %d",
+				c.name, c.model, c.inputTok, c.outTok, got, c.want)
+		}
+	}
+}
+
+func TestComputeCostMicros_UnknownModelReturnsZero(t *testing.T) {
+	if got := computeCostMicros("not-a-real-model", 1000, 1000); got != 0 {
+		t.Errorf("unknown model should return 0, got %d", got)
+	}
+}
+
+func TestCostCentsDelta(t *testing.T) {
+	cases := []struct {
+		name       string
+		old, added int64
+		want       int64
+	}{
+		{"0 → 0c under 1c", 0, 9999, 0},
+		{"0 → 1c exactly", 0, 10000, 1},
+		{"0 → 1c one over", 0, 10001, 1},
+		{"crosses 0→1 boundary", 9000, 1000, 1},
+		{"already at 1c, stays 1c", 10000, 100, 0},
+		{"1c → 1c just under 2c", 10000, 9999, 0},
+		{"1c → 2c exactly", 10000, 10000, 1},
+		{"big jump across multiple cents", 0, 1234567, 123},
+	}
+	for _, c := range cases {
+		got := costCentsDelta(c.old, c.added)
+		if got != c.want {
+			t.Errorf("%s: costCentsDelta(%d, %d) = %d, want %d",
+				c.name, c.old, c.added, got, c.want)
+		}
+	}
+}
+
+// TestCostCentsDelta_AccumulatesToBoundedError is the core property of the
+// cumulative-floor conversion: across N rounds with small per-round costs,
+// total error vs the ideal cent value is strictly less than 1 cent.
+// Contrast with a naive per-round ceiling which would over-report by ~N
+// cents in the same scenario — see spec §6.
+func TestCostCentsDelta_AccumulatesToBoundedError(t *testing.T) {
+	total := int64(0) // accumulated project_costs cents
+	totalMicros := int64(0)
+
+	// 100 rounds at 100 micros each. Ideal total: 10_000 micros = 1 cent.
+	for range 100 {
+		delta := costCentsDelta(totalMicros, 100)
+		total += delta
+		totalMicros += 100
+	}
+
+	// totalMicros = 10_000 exactly, cents should be 1.
+	if total != 1 {
+		t.Errorf("expected 1 cent accumulated after 100 rounds of 100 micros, got %d", total)
+	}
+	// Property: no matter where we stop, |total - totalMicros/10000| < 1
+	// (guaranteed by the delta formula: each delta = floor(new) - floor(old)).
+}

--- a/internal/ai/pricing_test.go
+++ b/internal/ai/pricing_test.go
@@ -10,23 +10,44 @@ func TestComputeCostMicros_KnownModels(t *testing.T) {
 		outTok   int
 		want     int64
 	}{
-		{"gemini flash 1k/1k", "gemini-2.5-flash", 1000, 1000, 350 + 2800},
-		{"claude sonnet 2k in / 500 out", "claude-sonnet-4-6", 2000, 500, 6000 + 7500},
-		{"gpt-5-mini 500 in / 200 out", "gpt-5-mini", 500, 200, 250 + 400},
-		{"zero tokens", "gemini-2.5-flash", 0, 0, 0},
+		{"gemini flash 1k/1k", ModelGeminiFlash, 1000, 1000, 350 + 2800},
+		{"claude sonnet 2k in / 500 out", ModelClaudeSonnet46, 2000, 500, 6000 + 7500},
+		{"gpt-5-mini 500 in / 200 out", ModelGPT5Mini, 500, 200, 250 + 400},
+		{"zero tokens", ModelGeminiFlash, 0, 0, 0},
 	}
 	for _, c := range cases {
-		got := computeCostMicros(c.model, c.inputTok, c.outTok)
+		got := ComputeCostMicros(c.model, c.inputTok, c.outTok)
 		if got != c.want {
-			t.Errorf("%s: computeCostMicros(%q, %d, %d) = %d, want %d",
+			t.Errorf("%s: ComputeCostMicros(%q, %d, %d) = %d, want %d",
 				c.name, c.model, c.inputTok, c.outTok, got, c.want)
 		}
 	}
 }
 
 func TestComputeCostMicros_UnknownModelReturnsZero(t *testing.T) {
-	if got := computeCostMicros("not-a-real-model", 1000, 1000); got != 0 {
+	if got := ComputeCostMicros("not-a-real-model", 1000, 1000); got != 0 {
 		t.Errorf("unknown model should return 0, got %d", got)
+	}
+}
+
+// TestComputeCostMicros_SumBeforeDividePreservesPrecision verifies the
+// sum-then-divide ordering. With 1 input token and 1 output token at
+// 500+2000 micros/1k, naive (500*1/1000)+(2000*1/1000) = 0+2 = 2, while
+// the correct (500+2000)/1000 = 2500/1000 = 2. The difference shows up
+// at sub-1k token counts; the sum-first form is strictly ≥ per-leg form.
+func TestComputeCostMicros_SumBeforeDividePreservesPrecision(t *testing.T) {
+	// 1 input @ 500 micros/1k, 1 output @ 2000 micros/1k.
+	// Per-leg naive:   500*1/1000 + 2000*1/1000 = 0 + 2 = 2
+	// Sum-first:       (500*1 + 2000*1) / 1000 = 2500/1000 = 2
+	// Both agree on 2 here. A tighter case:
+	// 1 in @ 350, 1 out @ 350.  Sum: 700/1000 = 0.  Per-leg: 0+0 = 0. Both 0.
+	// A case where they DIFFER: 999 in @ 350, 1 out @ 2800.
+	//   Per-leg: 999*350/1000 + 1*2800/1000 = 349 + 2 = 351.
+	//   Sum:    (999*350 + 1*2800)/1000    = (349650 + 2800)/1000 = 352.
+	got := ComputeCostMicros(ModelGeminiFlash, 999, 1)
+	want := int64(352)
+	if got != want {
+		t.Errorf("sum-then-divide ordering lost precision: got %d, want %d", got, want)
 	}
 }
 
@@ -46,9 +67,9 @@ func TestCostCentsDelta(t *testing.T) {
 		{"big jump across multiple cents", 0, 1234567, 123},
 	}
 	for _, c := range cases {
-		got := costCentsDelta(c.old, c.added)
+		got := CostCentsDelta(c.old, c.added)
 		if got != c.want {
-			t.Errorf("%s: costCentsDelta(%d, %d) = %d, want %d",
+			t.Errorf("%s: CostCentsDelta(%d, %d) = %d, want %d",
 				c.name, c.old, c.added, got, c.want)
 		}
 	}
@@ -65,7 +86,7 @@ func TestCostCentsDelta_AccumulatesToBoundedError(t *testing.T) {
 
 	// 100 rounds at 100 micros each. Ideal total: 10_000 micros = 1 cent.
 	for range 100 {
-		delta := costCentsDelta(totalMicros, 100)
+		delta := CostCentsDelta(totalMicros, 100)
 		total += delta
 		totalMicros += 100
 	}

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -26,25 +26,35 @@ type RefineInput struct {
 	SystemPrompt string
 }
 
-// RefineOutput is the normalized response shape returned by every refiner.
+// FinishReason constants. Adapters MUST map provider-specific stop
+// reasons onto this set; the handler checks FinishReason == FinishReasonLength
+// as a single equality to decide truncation rejections.
 //
-// FinishReason MUST be one of the normalized values below. Adapters are
-// responsible for mapping provider-specific stop reasons onto this set:
-//
-//	"stop"           — model completed normally
-//	"length"         — output truncated by token limit (maps from OpenAI's
-//	                   "length", Anthropic's "max_tokens", Gemini's
-//	                   FinishReasonMaxTokens). The CreateRound handler
-//	                   rejects these rounds (spec §3.2) to prevent
-//	                   truncated output from silently overwriting a
-//	                   ticket description on approve.
-//	"content_filter" — output blocked by safety filter
-//	"tool_calls"     — model requested tool invocation (not used in debate
-//	                   mode but reserved so the vocabulary is stable)
+//   - FinishReasonStop          — model completed normally
+//   - FinishReasonLength        — output truncated by token limit
+//     (adapters map OpenAI's "length",
+//     Anthropic's "max_tokens",
+//     Gemini's FinishReasonMaxTokens to this)
+//   - FinishReasonContentFilter — output blocked by safety filter
+//   - FinishReasonToolCalls     — model requested tool invocation
+//     (not used in debate mode but reserved
+//     so the vocabulary is stable)
 //
 // Any provider-specific reason not in this set may be surfaced raw; the
 // handler treats unknown FinishReason values as "stop-equivalent" and
 // accepts the round (provided other validation passes).
+const (
+	FinishReasonStop          = "stop"
+	FinishReasonLength        = "length"
+	FinishReasonContentFilter = "content_filter"
+	FinishReasonToolCalls     = "tool_calls"
+)
+
+// RefineOutput is the normalized response shape returned by every refiner.
+// FinishReason uses the normalized vocabulary above; the CreateRound
+// handler rejects rounds whose FinishReason == FinishReasonLength
+// (spec §3.2) to prevent truncated AI output from silently overwriting a
+// ticket description on approve.
 type RefineOutput struct {
 	Text         string
 	Usage        RefineUsage

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -1,0 +1,68 @@
+package ai
+
+import "context"
+
+// Refiner refactors a feature description for one round of debate mode.
+// Implementations MUST be safe to call concurrently.
+//
+// This interface is deliberately tiny — we do not abstract over the full
+// vendor SDK surface here. Each adapter (Anthropic, Gemini, OpenAI) converts
+// its provider-specific response into the shared RefineOutput, including
+// a normalized FinishReason so the handler can detect truncation uniformly.
+//
+// See docs/superpowers/specs/2026-04-14-feature-debate-mode-design.md §3.2
+// for the design rationale.
+type Refiner interface {
+	Name() string  // "claude" | "gemini" | "openai"
+	Model() string // specific model ID used, for per-round audit
+	Refine(ctx context.Context, in RefineInput) (RefineOutput, error)
+}
+
+// RefineInput is the per-round input a refiner operates on.
+// SystemPrompt is optional; adapters fall back to their embedded default if empty.
+type RefineInput struct {
+	CurrentText  string
+	Feedback     string
+	SystemPrompt string
+}
+
+// RefineOutput is the normalized response shape returned by every refiner.
+// FinishReason uses a small normalized vocabulary: "stop" | "length" |
+// "content_filter" | "tool_calls", or a provider-specific string for
+// anything outside that set. The CreateRound handler rejects rounds whose
+// FinishReason is "length" or "max_tokens" (spec §3.2) to prevent truncated
+// AI output from silently overwriting a ticket description on approve.
+type RefineOutput struct {
+	Text         string
+	Usage        RefineUsage
+	FinishReason string
+}
+
+// RefineUsage normalizes token counts and cost across vendors.
+// CostMicros is in millionths of USD (1 cent = 10_000 micros) — see
+// pricing.go's costCentsDelta for the cent-boundary conversion that bounds
+// rounding error to <1 cent per debate.
+type RefineUsage struct {
+	InputTokens  int
+	OutputTokens int
+	CostMicros   int64
+	Model        string
+}
+
+// Scorer judges the complexity of a feature description.
+// v1 uses GeminiScorer with structured output so the JSON shape is
+// schema-enforced; defensive clamps in the adapter guarantee
+// out-of-range values never reach the UI.
+type Scorer interface {
+	Score(ctx context.Context, text string) (ScoreResult, error)
+}
+
+// ScoreResult is the structured scorer output consumed by the accept flow
+// (spec §4.3). Score is 1..10, Hours is total human-hours estimate,
+// Reasoning is one sentence describing the biggest risk or scope driver.
+type ScoreResult struct {
+	Score     int
+	Hours     int
+	Reasoning string
+	Usage     RefineUsage
+}

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -27,11 +27,24 @@ type RefineInput struct {
 }
 
 // RefineOutput is the normalized response shape returned by every refiner.
-// FinishReason uses a small normalized vocabulary: "stop" | "length" |
-// "content_filter" | "tool_calls", or a provider-specific string for
-// anything outside that set. The CreateRound handler rejects rounds whose
-// FinishReason is "length" or "max_tokens" (spec §3.2) to prevent truncated
-// AI output from silently overwriting a ticket description on approve.
+//
+// FinishReason MUST be one of the normalized values below. Adapters are
+// responsible for mapping provider-specific stop reasons onto this set:
+//
+//	"stop"           — model completed normally
+//	"length"         — output truncated by token limit (maps from OpenAI's
+//	                   "length", Anthropic's "max_tokens", Gemini's
+//	                   FinishReasonMaxTokens). The CreateRound handler
+//	                   rejects these rounds (spec §3.2) to prevent
+//	                   truncated output from silently overwriting a
+//	                   ticket description on approve.
+//	"content_filter" — output blocked by safety filter
+//	"tool_calls"     — model requested tool invocation (not used in debate
+//	                   mode but reserved so the vocabulary is stable)
+//
+// Any provider-specific reason not in this set may be surfaced raw; the
+// handler treats unknown FinishReason values as "stop-equivalent" and
+// accepts the round (provided other validation passes).
 type RefineOutput struct {
 	Text         string
 	Usage        RefineUsage

--- a/internal/ai/refiner_fake.go
+++ b/internal/ai/refiner_fake.go
@@ -42,7 +42,7 @@ func (f *FakeRefiner) Refine(_ context.Context, in RefineInput) (RefineOutput, e
 		Usage: RefineUsage{
 			InputTokens:  inputTok,
 			OutputTokens: outputTok,
-			CostMicros:   computeCostMicros(f.ModelVal, inputTok, outputTok),
+			CostMicros:   ComputeCostMicros(f.ModelVal, inputTok, outputTok),
 			Model:        f.ModelVal,
 		},
 	}, nil

--- a/internal/ai/refiner_fake.go
+++ b/internal/ai/refiner_fake.go
@@ -6,9 +6,11 @@ import "context"
 // to exercise the full round lifecycle without burning real AI API calls.
 // Configure NameVal, ModelVal, and OutputFunc; CallCount tracks invocations.
 //
-// Lives in a _test.go file but in the ai package (not ai_test) so handler
-// tests in a different package can import it via a typed alias. This mirrors
-// how gemini_test.go sets up its fixtures.
+// This file intentionally has NO _test.go suffix: Go restricts test-only
+// files to their own package, so putting the fakes in refiner_fake_test.go
+// would make them inaccessible to handler tests in internal/handlers_test.
+// Shipping ~60 lines of test doubles in the production binary is
+// negligible; this matches how net/http/httptest exposes its fakes.
 type FakeRefiner struct {
 	NameVal, ModelVal string
 	// OutputFunc returns (text, finishReason, err). Callers drive behavior

--- a/internal/ai/refiner_fake_test.go
+++ b/internal/ai/refiner_fake_test.go
@@ -1,0 +1,76 @@
+package ai
+
+import "context"
+
+// FakeRefiner is a test double used by the debate handler tests (tasks 7–9)
+// to exercise the full round lifecycle without burning real AI API calls.
+// Configure NameVal, ModelVal, and OutputFunc; CallCount tracks invocations.
+//
+// Lives in a _test.go file but in the ai package (not ai_test) so handler
+// tests in a different package can import it via a typed alias. This mirrors
+// how gemini_test.go sets up its fixtures.
+type FakeRefiner struct {
+	NameVal, ModelVal string
+	// OutputFunc returns (text, finishReason, err). Callers drive behavior
+	// by setting this: return an empty text to simulate empty output, set
+	// finishReason to "length" to simulate truncation, return err to
+	// simulate provider failure.
+	OutputFunc func(in RefineInput) (text, finishReason string, err error)
+	CallCount  int
+}
+
+func (f *FakeRefiner) Name() string  { return f.NameVal }
+func (f *FakeRefiner) Model() string { return f.ModelVal }
+
+// Refine invokes OutputFunc and wraps the result in a RefineOutput with
+// fake-but-reasonable token counts (~4 chars per token) and cost_micros
+// computed via the real pricingTable so cost-accumulator tests exercise
+// the production conversion path.
+func (f *FakeRefiner) Refine(_ context.Context, in RefineInput) (RefineOutput, error) {
+	f.CallCount++
+	text, finish, err := f.OutputFunc(in)
+	if err != nil {
+		return RefineOutput{}, err
+	}
+	inputTok := len(in.CurrentText) / 4
+	outputTok := len(text) / 4
+	return RefineOutput{
+		Text:         text,
+		FinishReason: finish,
+		Usage: RefineUsage{
+			InputTokens:  inputTok,
+			OutputTokens: outputTok,
+			CostMicros:   computeCostMicros(f.ModelVal, inputTok, outputTok),
+			Model:        f.ModelVal,
+		},
+	}, nil
+}
+
+// FakeScorer is a test double for the Scorer interface. Set Result for
+// the success path, Err for the failure path. Delay (optional) is called
+// inside Score before returning — use it to simulate a slow scorer in
+// out-of-order race tests.
+type FakeScorer struct {
+	Result    ScoreResult
+	Err       error
+	Delay     func()
+	CallCount int
+}
+
+func (f *FakeScorer) Score(_ context.Context, _ string) (ScoreResult, error) {
+	f.CallCount++
+	if f.Delay != nil {
+		f.Delay()
+	}
+	if f.Err != nil {
+		return ScoreResult{}, f.Err
+	}
+	return f.Result, nil
+}
+
+// Compile-time interface assertions. If a signature ever drifts these
+// fail to build, catching the regression before any test runs.
+var (
+	_ Refiner = (*FakeRefiner)(nil)
+	_ Scorer  = (*FakeScorer)(nil)
+)


### PR DESCRIPTION
Closes #55 once merged.

## Summary

Implements [Task 3 from the plan](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/plans/2026-04-14-feature-debate-mode.md#task-3-featai--refinerscorer-interfaces--refineusage--pricing-table) — the provider contract that Tasks 4–6 will implement, and the handler in Task 7 will consume.

- `internal/ai/refiner.go` — Refiner + Scorer interfaces, RefineInput/Output/Usage, ScoreResult, FinishReason vocabulary
- `internal/ai/pricing.go` — pricingTable, computeCostMicros, costCentsDelta (cumulative-floor conversion per spec §6)
- `internal/ai/pricing_test.go` — 4 test functions including accumulator boundedness property
- `internal/ai/refiner_fake_test.go` — FakeRefiner + FakeScorer for handler tests, with compile-time interface assertions

No adapters yet — Task 4 (Anthropic), Task 5 (Gemini refiner+scorer), Task 6 (OpenAI) will implement this interface.

## Test plan

- [x] `go test ./internal/ai -count=1` — new tests pass (pre-existing TestToolDeclarations_* fail, out of scope)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Compile-time `_ Refiner = (*FakeRefiner)(nil)` + `_ Scorer = (*FakeScorer)(nil)` assertions catch any future signature drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)