### PR TITLE
feat(ai): OpenAIRefiner adapter (debate v1 task 6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/pquerna/otp v1.5.0
+	github.com/sashabaranov/go-openai v1.41.2
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/yuin/goldmark v1.7.16
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
+github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -1,0 +1,122 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// OpenAIClient is a thin wrapper around the sashabaranov/go-openai SDK.
+// Shape mirrors AnthropicClient so future non-debate uses can plug in
+// without architectural churn.
+type OpenAIClient struct {
+	client *openai.Client
+	model  string
+}
+
+// NewOpenAIClient constructs a client bound to a specific model. The
+// model is stored on the wrapper so callers don't need to pass it to
+// every request; model-per-request callers can simply build multiple
+// clients.
+func NewOpenAIClient(apiKey, model string) *OpenAIClient {
+	return &OpenAIClient{
+		client: openai.NewClient(apiKey),
+		model:  model,
+	}
+}
+
+// OpenAIRefiner adapts OpenAIClient to the debate Refiner interface.
+// The third of three providers backing the debate's AI-picker buttons.
+type OpenAIRefiner struct{ c *OpenAIClient }
+
+// NewOpenAIRefiner wraps an OpenAIClient as a Refiner. The wrapper
+// exists so the Name() returns "openai" regardless of which specific
+// model is configured — the handler uses Name() for the button label
+// and Model() for the audit trail.
+func NewOpenAIRefiner(c *OpenAIClient) *OpenAIRefiner { return &OpenAIRefiner{c: c} }
+
+func (r *OpenAIRefiner) Name() string { return "openai" }
+func (r *OpenAIRefiner) Model() string {
+	if r.c == nil {
+		return ""
+	}
+	return r.c.model
+}
+
+// Refine sends one ChatCompletion request and returns the normalized
+// RefineOutput. Same adapter-layer guards as the other two providers:
+// empty/whitespace-only output is rejected here so a silent "" can't
+// slip past even if the handler's MinOutputLen check regresses.
+func (r *OpenAIRefiner) Refine(ctx context.Context, in RefineInput) (RefineOutput, error) {
+	if r.c == nil || r.c.client == nil {
+		return RefineOutput{}, fmt.Errorf("openai refiner: client not configured")
+	}
+
+	resp, err := r.c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: r.c.model,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: resolveSystemPrompt(in.SystemPrompt)},
+			{Role: openai.ChatMessageRoleUser, Content: buildRefineUserPrompt(in.CurrentText, in.Feedback)},
+		},
+		MaxTokens:   4096,
+		Temperature: 0.3,
+	})
+	if err != nil {
+		return RefineOutput{}, fmt.Errorf("openai refine: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return RefineOutput{}, fmt.Errorf("openai refine: no choices returned for model %s", r.c.model)
+	}
+
+	choice := resp.Choices[0]
+	text := strings.TrimSpace(choice.Message.Content)
+	if text == "" {
+		return RefineOutput{}, fmt.Errorf("openai refine: empty response from model %s", r.c.model)
+	}
+
+	return RefineOutput{
+		Text:         text,
+		FinishReason: mapOpenAIFinishReason(choice.FinishReason),
+		Usage: RefineUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+			CostMicros:   ComputeCostMicros(r.c.model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens),
+			Model:        r.c.model,
+		},
+	}, nil
+}
+
+// mapOpenAIFinishReason normalizes the OpenAI SDK's FinishReason to
+// the Refiner contract. OpenAI's vocabulary already overlaps heavily
+// with ours (the identity mapping covers "stop", "length", "content_
+// filter", "tool_calls"), so this is mostly a typed pass-through.
+// function_call is merged into tool_calls since the debate UI treats
+// them identically.
+func mapOpenAIFinishReason(reason openai.FinishReason) string {
+	switch reason {
+	case openai.FinishReasonStop:
+		return FinishReasonStop
+	case openai.FinishReasonLength:
+		return FinishReasonLength
+	case openai.FinishReasonContentFilter:
+		return FinishReasonContentFilter
+	case openai.FinishReasonToolCalls, openai.FinishReasonFunctionCall:
+		return FinishReasonToolCalls
+	case openai.FinishReasonNull, "":
+		// "null" / empty happens mid-stream and in edge cases; treat as
+		// stop-equivalent since our handler only acts on explicit
+		// truncation/filter signals.
+		return FinishReasonStop
+	default:
+		raw := strings.ToLower(string(reason))
+		if strings.Contains(raw, "max") ||
+			strings.Contains(raw, "length") ||
+			strings.Contains(raw, "exceeded") ||
+			strings.Contains(raw, "truncat") {
+			return FinishReasonLength
+		}
+		return string(reason)
+	}
+}

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -54,15 +54,28 @@ func (r *OpenAIRefiner) Refine(ctx context.Context, in RefineInput) (RefineOutpu
 		return RefineOutput{}, fmt.Errorf("openai refiner: client not configured")
 	}
 
-	resp, err := r.c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+	// Reasoning-model branch: go-openai's ReasoningValidator rejects
+	// MaxTokens on gpt-5*/o1*/o3*/o4* and requires Temperature to be 0
+	// or exactly 1. For those models we set MaxCompletionTokens and
+	// leave Temperature unset (SDK default: 1). Legacy chat models
+	// (gpt-4*) keep the MaxTokens + low-temperature shape that
+	// matches the Anthropic/Gemini adapters' deterministic-refactor
+	// posture.
+	req := openai.ChatCompletionRequest{
 		Model: r.c.model,
 		Messages: []openai.ChatCompletionMessage{
 			{Role: openai.ChatMessageRoleSystem, Content: resolveSystemPrompt(in.SystemPrompt)},
 			{Role: openai.ChatMessageRoleUser, Content: buildRefineUserPrompt(in.CurrentText, in.Feedback)},
 		},
-		MaxTokens:   refinerMaxTokens,
-		Temperature: refinerTemperature,
-	})
+	}
+	if isReasoningOpenAIModel(r.c.model) {
+		req.MaxCompletionTokens = refinerMaxTokens
+		// Temperature left at zero-value; SDK omits it (default 1).
+	} else {
+		req.MaxTokens = refinerMaxTokens
+		req.Temperature = refinerTemperature
+	}
+	resp, err := r.c.client.CreateChatCompletion(ctx, req)
 	if err != nil {
 		return RefineOutput{}, fmt.Errorf("openai refine: %w", err)
 	}
@@ -86,6 +99,23 @@ func (r *OpenAIRefiner) Refine(ctx context.Context, in RefineInput) (RefineOutpu
 			Model:        r.c.model,
 		},
 	}, nil
+}
+
+// isReasoningOpenAIModel reports whether the given model ID is an
+// OpenAI reasoning model (gpt-5*, o1*, o3*, o4*). These models use
+// a different request shape: MaxCompletionTokens instead of MaxTokens,
+// and Temperature fixed at 1 (the SDK's default when unset).
+//
+// The SDK enforces these rules via its internal ReasoningValidator;
+// getting the request shape wrong for a reasoning model produces a
+// client-side validation error before the request ever hits the API.
+// See reasoning_validator.go in github.com/sashabaranov/go-openai for
+// the canonical list.
+func isReasoningOpenAIModel(model string) bool {
+	return strings.HasPrefix(model, "gpt-5") ||
+		strings.HasPrefix(model, "o1") ||
+		strings.HasPrefix(model, "o3") ||
+		strings.HasPrefix(model, "o4")
 }
 
 // mapOpenAIFinishReason normalizes the OpenAI SDK's FinishReason to

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -60,8 +60,8 @@ func (r *OpenAIRefiner) Refine(ctx context.Context, in RefineInput) (RefineOutpu
 			{Role: openai.ChatMessageRoleSystem, Content: resolveSystemPrompt(in.SystemPrompt)},
 			{Role: openai.ChatMessageRoleUser, Content: buildRefineUserPrompt(in.CurrentText, in.Feedback)},
 		},
-		MaxTokens:   4096,
-		Temperature: 0.3,
+		MaxTokens:   refinerMaxTokens,
+		Temperature: refinerTemperature,
 	})
 	if err != nil {
 		return RefineOutput{}, fmt.Errorf("openai refine: %w", err)
@@ -110,13 +110,27 @@ func mapOpenAIFinishReason(reason openai.FinishReason) string {
 		// truncation/filter signals.
 		return FinishReasonStop
 	default:
+		// Tightened unknown-reason heuristic: classify into ContentFilter
+		// before Length so a future "safety_limit_exceeded" doesn't get
+		// mis-recorded as a truncation in the audit trail. Truncation
+		// patterns must contain a token/length/truncat marker — the
+		// standalone "exceeded" substring is too broad and was removed.
 		raw := strings.ToLower(string(reason))
-		if strings.Contains(raw, "max") ||
+		switch {
+		case strings.Contains(raw, "safety") ||
+			strings.Contains(raw, "refus") ||
+			strings.Contains(raw, "filter") ||
+			strings.Contains(raw, "prohibit") ||
+			strings.Contains(raw, "block"):
+			return FinishReasonContentFilter
+		case strings.Contains(raw, "max_tokens") ||
+			strings.Contains(raw, "max_completion") ||
+			strings.Contains(raw, "context_length") ||
 			strings.Contains(raw, "length") ||
-			strings.Contains(raw, "exceeded") ||
-			strings.Contains(raw, "truncat") {
+			strings.Contains(raw, "truncat"):
 			return FinishReasonLength
+		default:
+			return string(reason)
 		}
-		return string(reason)
 	}
 }

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -1,0 +1,66 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// Compile-time interface assertion — catches signature drift at build time.
+var _ Refiner = (*OpenAIRefiner)(nil)
+
+func TestOpenAIRefiner_NameAndModel(t *testing.T) {
+	c := NewOpenAIClient("fake-key", ModelGPT5Mini)
+	r := NewOpenAIRefiner(c)
+	if r.Name() != "openai" {
+		t.Errorf("Name() = %q, want openai", r.Name())
+	}
+	if r.Model() != ModelGPT5Mini {
+		t.Errorf("Model() = %q, want %s", r.Model(), ModelGPT5Mini)
+	}
+}
+
+func TestOpenAIRefiner_ModelEmptyWhenClientNil(t *testing.T) {
+	r := &OpenAIRefiner{c: nil}
+	if r.Model() != "" {
+		t.Errorf("Model() with nil client should be empty, got %q", r.Model())
+	}
+}
+
+func TestOpenAIRefiner_RefineWithoutClientErrors(t *testing.T) {
+	r := &OpenAIRefiner{c: nil}
+	_, err := r.Refine(t.Context(), RefineInput{CurrentText: "x"})
+	if err == nil {
+		t.Fatal("expected error when client is nil")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestMapOpenAIFinishReason(t *testing.T) {
+	cases := []struct {
+		in   openai.FinishReason
+		want string
+	}{
+		{openai.FinishReasonStop, FinishReasonStop},
+		{openai.FinishReasonLength, FinishReasonLength},
+		{openai.FinishReasonContentFilter, FinishReasonContentFilter},
+		{openai.FinishReasonToolCalls, FinishReasonToolCalls},
+		{openai.FinishReasonFunctionCall, FinishReasonToolCalls}, // merged
+		{openai.FinishReasonNull, FinishReasonStop},              // treated as stop
+		{openai.FinishReason(""), FinishReasonStop},              // empty → stop
+		// Future truncation-shaped reasons → FinishReasonLength.
+		{openai.FinishReason("context_length_exceeded"), FinishReasonLength},
+		{openai.FinishReason("max_completion_tokens"), FinishReasonLength},
+		// Truly unknown → surfaced raw.
+		{openai.FinishReason("something_new"), "something_new"},
+	}
+	for _, c := range cases {
+		got := mapOpenAIFinishReason(c.in)
+		if got != c.want {
+			t.Errorf("mapOpenAIFinishReason(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -54,6 +54,13 @@ func TestMapOpenAIFinishReason(t *testing.T) {
 		// Future truncation-shaped reasons → FinishReasonLength.
 		{openai.FinishReason("context_length_exceeded"), FinishReasonLength},
 		{openai.FinishReason("max_completion_tokens"), FinishReasonLength},
+		{openai.FinishReason("output_truncated"), FinishReasonLength},
+		// Future safety-shaped reasons → FinishReasonContentFilter.
+		// Previously "safety_limit_exceeded" would have mis-mapped to
+		// FinishReasonLength via the overly-broad "exceeded" substring.
+		{openai.FinishReason("safety_limit_exceeded"), FinishReasonContentFilter},
+		{openai.FinishReason("prohibited_content"), FinishReasonContentFilter},
+		{openai.FinishReason("refused_by_model"), FinishReasonContentFilter},
 		// Truly unknown → surfaced raw.
 		{openai.FinishReason("something_new"), "something_new"},
 	}

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -39,6 +39,37 @@ func TestOpenAIRefiner_RefineWithoutClientErrors(t *testing.T) {
 	}
 }
 
+func TestIsReasoningOpenAIModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		// Reasoning models per go-openai's ReasoningValidator.
+		{"gpt-5", true},
+		{"gpt-5-mini", true},
+		{"gpt-5-nano", true},
+		{"o1", true},
+		{"o1-mini", true},
+		{"o1-preview", true},
+		{"o3", true},
+		{"o3-mini", true},
+		{"o4-mini", true},
+		// Legacy chat models — the other branch.
+		{"gpt-4", false},
+		{"gpt-4o", false},
+		{"gpt-4o-mini", false},
+		{"gpt-3.5-turbo", false},
+		// Unknown models → false (caller uses legacy branch).
+		{"unknown", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isReasoningOpenAIModel(c.model); got != c.want {
+			t.Errorf("isReasoningOpenAIModel(%q) = %v, want %v", c.model, got, c.want)
+		}
+	}
+}
+
 func TestMapOpenAIFinishReason(t *testing.T) {
 	cases := []struct {
 		in   openai.FinishReason

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -26,6 +26,21 @@ type RefineInput struct {
 	SystemPrompt string
 }
 
+// Refiner request defaults. Centralized so every adapter uses the same
+// Temperature and MaxTokens without drift; if we ever need to tune
+// these for debate mode globally, the change lives in one place.
+//
+// refinerTemperature is low (0.3) — refactoring a spec should be
+// stable, not creative; clicking the same AI button twice on the same
+// seed should produce near-identical output.
+//
+// refinerMaxTokens is generous for any realistic feature description
+// (20k chars ≈ 5k tokens) with headroom for the model to elaborate.
+const (
+	refinerMaxTokens   = 4096
+	refinerTemperature = 0.3
+)
+
 // FinishReason constants. Adapters MUST map provider-specific stop
 // reasons onto this set; the handler checks FinishReason == FinishReasonLength
 // as a single equality to decide truncation rejections.


### PR DESCRIPTION
Closes #58 once merged.

## Summary

Implements [Task 6 from the plan](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/plans/2026-04-14-feature-debate-mode.md#task-6-featai--openairefiner-adapter). Third and final refiner adapter; completes the Refiner trio (Claude + Gemini + OpenAI) consumed by the debate handler in Task 7.

- `internal/ai/openai.go` — OpenAIClient wrapper + OpenAIRefiner + mapOpenAIFinishReason
- `internal/ai/openai_test.go` — 4 tests incl. compile-time interface assertion
- `go.mod` / `go.sum` — adds `github.com/sashabaranov/go-openai v1.41.2`

Same adapter-layer guards as Anthropic (#71) and Gemini (#72):
- resolveSystemPrompt fallback to embedded prompt on empty
- buildRefineUserPrompt delimited-block containment
- Trim-then-check empty guard (rejects whitespace-only too)
- Substring detection for unknown truncation-shaped reasons

## Test plan

- [x] `go test ./internal/ai -run "TestOpenAIRefiner|TestMapOpenAI"` — 4 pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Compile-time `_ Refiner = (*OpenAIRefiner)(nil)` assertion
- [x] `OPENAI_API_KEY` already in cluster Secret (closed #53 earlier)

## Notes

- After this merges, all three Refiners + GeminiScorer are ready. Task 7 wires them into the debate handler in cmd/server/main.go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)