### PR TITLE
feat(debate): accept, reject, undo (debate v1 task 8)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -263,11 +263,14 @@ func main() {
 		r.Put("/tickets/{ticketID}", ticketH.UpdateTicket)
 		r.Delete("/tickets/{ticketID}", ticketH.DeleteTicket)
 
-		// Feature Debate Mode (spec §4). Tasks 8-9 extend this block
-		// with accept/reject/undo/approve/abandon.
+		// Feature Debate Mode (spec §4). Task 9 extends this block
+		// with approve/abandon.
 		r.Get("/tickets/{ticketID}/debate", debateH.ShowDebate)
 		r.Post("/tickets/{ticketID}/debate/start", debateH.StartDebate)
 		r.Post("/tickets/{ticketID}/debate/rounds", debateH.CreateRound)
+		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/accept", debateH.AcceptRound)
+		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/reject", debateH.RejectRound)
+		r.Post("/tickets/{ticketID}/debate/undo", debateH.UndoRound)
 
 		// Comments
 		r.Post("/tickets/{ticketID}/comments", commentH.CreateComment)

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -536,8 +536,17 @@ func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
 	// disconnect doesn't cancel the in-flight scorer tx; we still
 	// honor the adapter's own AICallTimeout so the goroutine can't
 	// leak indefinitely.
+	//
+	// Pass round.OutputText directly rather than re-reading
+	// feature_debates.current_text inside the goroutine. Re-reading
+	// would race with subsequent accept/undo operations: a concurrent
+	// undo could shift current_text to an older value before the
+	// goroutine runs, causing the scorer to evaluate stale content
+	// while the result is still associated with this round's ID. The
+	// direct-pass path guarantees scorer input == round output.
 	if h.scorer != nil {
-		go h.scoreAfterAccept(context.WithoutCancel(r.Context()), deb.ID, round.ID, dctx.ticket.ProjectID)
+		go h.scoreAfterAccept(context.WithoutCancel(r.Context()),
+			deb.ID, round.ID, dctx.ticket.ProjectID, round.OutputText)
 	}
 
 	_ = h.engine.RenderPartial(w, "debate_round.html", round)
@@ -577,20 +586,17 @@ func (h *DebateHandler) acceptRoundUnderLock(ctx context.Context, debateID, roun
 }
 
 // writeAcceptError maps accept-path sentinels to the right status.
+// ErrRoundNotInReview surfaces as 409 (stale client view), distinct
+// from pgx.ErrNoRows (404, round doesn't exist) and infra failures.
 func (h *DebateHandler) writeAcceptError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		http.Error(w, "round not found", http.StatusNotFound)
 	case errors.Is(err, models.ErrDebateNotActive):
 		http.Error(w, "debate not active", http.StatusConflict)
+	case errors.Is(err, models.ErrRoundNotInReview):
+		http.Error(w, "round is not in review (stale state)", http.StatusConflict)
 	default:
-		// Includes "round status is X, not in_review" — surface as 409
-		// since the client's view of the round is stale rather than
-		// infra failure.
-		if strings.Contains(err.Error(), "not in_review") {
-			http.Error(w, "round is not in review (stale state)", http.StatusConflict)
-			return
-		}
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }
@@ -607,19 +613,13 @@ func (h *DebateHandler) writeAcceptError(w http.ResponseWriter, err error) {
 // surfaced to the user (the accept already succeeded). The context
 // comes from context.WithoutCancel so client disconnect doesn't
 // abort the billing update.
-func (h *DebateHandler) scoreAfterAccept(ctx context.Context, debateID, roundID, projectID string) {
+func (h *DebateHandler) scoreAfterAccept(ctx context.Context, debateID, roundID, projectID, textToScore string) {
 	// Respect the adapter's own timeout envelope so this goroutine
 	// can't wedge indefinitely on a stuck network call.
 	callCtx, cancel := context.WithTimeout(ctx, h.cfg.AICallTimeout)
 	defer cancel()
 
-	deb, err := h.db.GetDebateByID(callCtx, debateID)
-	if err != nil {
-		log.Printf("debate scoreAfterAccept: GetDebateByID %s: %v", debateID, err)
-		return
-	}
-
-	res, err := h.scorer.Score(callCtx, deb.CurrentText)
+	res, err := h.scorer.Score(callCtx, textToScore)
 	if err != nil {
 		log.Printf("debate scoreAfterAccept: scorer failed for debate %s round %s: %v", debateID, roundID, err)
 		return
@@ -761,12 +761,17 @@ func (h *DebateHandler) UndoRound(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if undoErr := h.undoUnderLock(r.Context(), deb.ID, fromN); undoErr != nil {
-		if errors.Is(undoErr, models.ErrDebateNotActive) {
+		switch {
+		case errors.Is(undoErr, models.ErrDebateNotActive):
 			http.Error(w, "debate not active", http.StatusConflict)
-			return
+		case errors.Is(undoErr, models.ErrNoRoundsToUndo):
+			// ?from=999 on a 3-round debate, etc. Prevents accidental
+			// effort-field wipes on range targets that delete no rows.
+			http.Error(w, "no rounds matched — check the from index", http.StatusNotFound)
+		default:
+			log.Printf("debate UndoRound: %v", undoErr)
+			http.Error(w, "internal error", http.StatusInternalServerError)
 		}
-		log.Printf("debate UndoRound: %v", undoErr)
-		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -488,4 +489,309 @@ func (h *DebateHandler) writeInsertError(w http.ResponseWriter, err error) {
 	default:
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
+}
+
+// ── POST /tickets/{ticketID}/debate/rounds/{roundID}/accept ───────
+
+// AcceptRound marks an in_review round as accepted, updating
+// feature_debates.current_text to the round's output. After the
+// accept tx commits, fires scoreAfterAccept as a fire-and-forget
+// goroutine (spec §4.3 step 7) so the user's request returns
+// immediately instead of waiting on the scorer's 60s AI call.
+//
+// The scorer goroutine uses context.WithoutCancel so the user
+// closing the browser tab doesn't cancel the scorer tx mid-flight —
+// we've already billed for the refiner call that just succeeded;
+// the scorer call is a separate billable event that should either
+// complete cleanly or log a WARN, never leak half-done state.
+func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
+	dctx, code, err := h.requireDebateContext(r)
+	if err != nil {
+		h.engine.RenderError(w, code, err.Error())
+		return
+	}
+	roundID := chi.URLParam(r, "roundID")
+	if roundID == "" {
+		http.Error(w, "missing round id", http.StatusBadRequest)
+		return
+	}
+
+	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "no active debate", http.StatusConflict)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	round, err := h.acceptRoundUnderLock(r.Context(), deb.ID, roundID)
+	if err != nil {
+		h.writeAcceptError(w, err)
+		return
+	}
+
+	// Fire-and-forget scorer. context.WithoutCancel so a client
+	// disconnect doesn't cancel the in-flight scorer tx; we still
+	// honor the adapter's own AICallTimeout so the goroutine can't
+	// leak indefinitely.
+	if h.scorer != nil {
+		go h.scoreAfterAccept(context.WithoutCancel(r.Context()), deb.ID, round.ID, dctx.ticket.ProjectID)
+	}
+
+	_ = h.engine.RenderPartial(w, "debate_round.html", round)
+}
+
+// acceptRoundUnderLock runs the accept transaction: lock debate row,
+// lock round row, verify status == 'active' at the debate level,
+// update round + current_text, commit.
+func (h *DebateHandler) acceptRoundUnderLock(ctx context.Context, debateID, roundID string) (*models.DebateRound, error) {
+	tx, err := h.db.Pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Lock the debate row first. All state-changing operations take
+	// this lock as their first statement (spec §3.3 concurrency model)
+	// so accept / reject / undo / approve / abandon serialize cleanly.
+	var status string
+	if qErr := tx.QueryRow(ctx,
+		`SELECT status FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
+	).Scan(&status); qErr != nil {
+		return nil, qErr
+	}
+	if status != models.DebateStatusActive {
+		return nil, models.ErrDebateNotActive
+	}
+
+	round, err := h.db.AcceptRoundTx(ctx, tx, debateID, roundID)
+	if err != nil {
+		return nil, err
+	}
+	if commitErr := tx.Commit(ctx); commitErr != nil {
+		return nil, commitErr
+	}
+	return round, nil
+}
+
+// writeAcceptError maps accept-path sentinels to the right status.
+func (h *DebateHandler) writeAcceptError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		http.Error(w, "round not found", http.StatusNotFound)
+	case errors.Is(err, models.ErrDebateNotActive):
+		http.Error(w, "debate not active", http.StatusConflict)
+	default:
+		// Includes "round status is X, not in_review" — surface as 409
+		// since the client's view of the round is stale rather than
+		// infra failure.
+		if strings.Contains(err.Error(), "not in_review") {
+			http.Error(w, "round is not in review (stale state)", http.StatusConflict)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+}
+
+// scoreAfterAccept runs the Scorer outside the accept tx (spec §4.3
+// step 7 — holding FOR UPDATE across a 60s AI call would serialize
+// Abandon/Undo behind every accept). On success, applies the score
+// conditionally (UpdateEffortScoreCondTx silently discards out-of-
+// order responses) and persists the scorer cost on the round row.
+// All three updates happen under a fresh debate-row lock to stay
+// consistent with the total_cost_micros accumulator (spec §6).
+//
+// Runs in its own goroutine; errors are logged at WARN and never
+// surfaced to the user (the accept already succeeded). The context
+// comes from context.WithoutCancel so client disconnect doesn't
+// abort the billing update.
+func (h *DebateHandler) scoreAfterAccept(ctx context.Context, debateID, roundID, projectID string) {
+	// Respect the adapter's own timeout envelope so this goroutine
+	// can't wedge indefinitely on a stuck network call.
+	callCtx, cancel := context.WithTimeout(ctx, h.cfg.AICallTimeout)
+	defer cancel()
+
+	deb, err := h.db.GetDebateByID(callCtx, debateID)
+	if err != nil {
+		log.Printf("debate scoreAfterAccept: GetDebateByID %s: %v", debateID, err)
+		return
+	}
+
+	res, err := h.scorer.Score(callCtx, deb.CurrentText)
+	if err != nil {
+		log.Printf("debate scoreAfterAccept: scorer failed for debate %s round %s: %v", debateID, roundID, err)
+		return
+	}
+
+	// Accumulator + conditional score update under a fresh lock.
+	tx, err := h.db.Pool.Begin(ctx)
+	if err != nil {
+		log.Printf("debate scoreAfterAccept: Begin: %v", err)
+		return
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var oldTotal int64
+	if qErr := tx.QueryRow(ctx,
+		`SELECT total_cost_micros FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
+	).Scan(&oldTotal); qErr != nil {
+		log.Printf("debate scoreAfterAccept: lock debate %s: %v", debateID, qErr)
+		return
+	}
+
+	if uErr := h.db.UpdateScorerCostMicros(ctx, tx, roundID, res.Usage.CostMicros); uErr != nil {
+		log.Printf("debate scoreAfterAccept: update scorer cost on round %s: %v", roundID, uErr)
+		return
+	}
+	if uErr := h.db.UpdateEffortScoreCondTx(ctx, tx, debateID, roundID, res.Score, res.Hours, res.Reasoning); uErr != nil {
+		log.Printf("debate scoreAfterAccept: UpdateEffortScoreCondTx debate %s: %v", debateID, uErr)
+		return
+	}
+
+	newTotal := oldTotal + res.Usage.CostMicros
+	if _, uErr := tx.Exec(ctx,
+		`UPDATE feature_debates SET total_cost_micros = $1, updated_at = now() WHERE id = $2`,
+		newTotal, debateID,
+	); uErr != nil {
+		log.Printf("debate scoreAfterAccept: update total_cost_micros debate %s: %v", debateID, uErr)
+		return
+	}
+
+	if commitErr := tx.Commit(ctx); commitErr != nil {
+		log.Printf("debate scoreAfterAccept: Commit debate %s: %v", debateID, commitErr)
+		return
+	}
+
+	centsDelta := newTotal/10000 - oldTotal/10000
+	if incErr := h.db.IncrementProjectCostCents(ctx, projectID, centsDelta); incErr != nil {
+		log.Printf("debate scoreAfterAccept: project_costs rollup for scorer cost: %v", incErr)
+	}
+}
+
+// ── POST /tickets/{ticketID}/debate/rounds/{roundID}/reject ───────
+
+// RejectRound marks an in_review round as rejected without touching
+// current_text. Returns the debate_next_round.html partial so HTMX
+// can replace the in-review card with the feedback+AI-picker form.
+func (h *DebateHandler) RejectRound(w http.ResponseWriter, r *http.Request) {
+	dctx, code, err := h.requireDebateContext(r)
+	if err != nil {
+		h.engine.RenderError(w, code, err.Error())
+		return
+	}
+	roundID := chi.URLParam(r, "roundID")
+	if roundID == "" {
+		http.Error(w, "missing round id", http.StatusBadRequest)
+		return
+	}
+
+	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "no active debate", http.StatusConflict)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if rejectErr := h.rejectRoundUnderLock(r.Context(), deb.ID, roundID); rejectErr != nil {
+		h.writeAcceptError(w, rejectErr) // same sentinel mapping as accept
+		return
+	}
+
+	_ = h.engine.RenderPartial(w, "debate_next_round.html", map[string]any{
+		"Debate":    deb,
+		"Providers": h.providerNames(),
+	})
+}
+
+func (h *DebateHandler) rejectRoundUnderLock(ctx context.Context, debateID, roundID string) error {
+	tx, err := h.db.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var status string
+	if qErr := tx.QueryRow(ctx,
+		`SELECT status FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
+	).Scan(&status); qErr != nil {
+		return qErr
+	}
+	if status != models.DebateStatusActive {
+		return models.ErrDebateNotActive
+	}
+	if rErr := h.db.RejectRoundTx(ctx, tx, debateID, roundID); rErr != nil {
+		return rErr
+	}
+	return tx.Commit(ctx)
+}
+
+// ── POST /tickets/{ticketID}/debate/undo?from=N ───────────────────
+
+// UndoRound cascading-deletes every round with round_number >= N
+// and recomputes current_text. After undo, the client reloads the
+// debate page (via Hx-Redirect) to see the recomputed state —
+// simpler than the per-partial swap dance for timeline re-renders.
+func (h *DebateHandler) UndoRound(w http.ResponseWriter, r *http.Request) {
+	dctx, code, err := h.requireDebateContext(r)
+	if err != nil {
+		h.engine.RenderError(w, code, err.Error())
+		return
+	}
+
+	fromStr := r.URL.Query().Get("from")
+	fromN, err := strconv.Atoi(fromStr)
+	if err != nil || fromN < 1 {
+		http.Error(w, "invalid from parameter", http.StatusBadRequest)
+		return
+	}
+
+	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "no active debate", http.StatusConflict)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if undoErr := h.undoUnderLock(r.Context(), deb.ID, fromN); undoErr != nil {
+		if errors.Is(undoErr, models.ErrDebateNotActive) {
+			http.Error(w, "debate not active", http.StatusConflict)
+			return
+		}
+		log.Printf("debate UndoRound: %v", undoErr)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Hx-Redirect", "/tickets/"+dctx.ticket.ID+"/debate")
+	w.WriteHeader(http.StatusSeeOther)
+}
+
+func (h *DebateHandler) undoUnderLock(ctx context.Context, debateID string, fromN int) error {
+	tx, err := h.db.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var status string
+	if qErr := tx.QueryRow(ctx,
+		`SELECT status FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
+	).Scan(&status); qErr != nil {
+		return qErr
+	}
+	if status != models.DebateStatusActive {
+		return models.ErrDebateNotActive
+	}
+	if uErr := h.db.UndoRoundsFromTx(ctx, tx, debateID, fromN); uErr != nil {
+		return uErr
+	}
+	return tx.Commit(ctx)
 }

--- a/internal/handlers/debate_test.go
+++ b/internal/handlers/debate_test.go
@@ -49,6 +49,9 @@ func setupDebateTestEnv(t *testing.T) (*chi.Mux, *models.DB, *auth.SessionStore)
 		r.Get("/tickets/{ticketID}/debate", h.ShowDebate)
 		r.Post("/tickets/{ticketID}/debate/start", h.StartDebate)
 		r.Post("/tickets/{ticketID}/debate/rounds", h.CreateRound)
+		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/accept", h.AcceptRound)
+		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/reject", h.RejectRound)
+		r.Post("/tickets/{ticketID}/debate/undo", h.UndoRound)
 	})
 	return r, db, sessions
 }
@@ -267,5 +270,247 @@ func TestCreateRound_RejectsUnknownProvider(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "unknown provider") {
 		t.Errorf("expected 'unknown provider', got: %q", rec.Body.String())
+	}
+}
+
+// startAndCreateRounds runs /start and then N round-creation requests
+// via the fake claude refiner, each auto-accepted. Returns the
+// accepted round records in creation order (length N). Used by
+// accept / reject / undo tests below.
+func startAndCreateRounds(t *testing.T, r *chi.Mux, db *models.DB, cookie *http.Cookie, ticketID string, outputs []string) []*models.DebateRound {
+	t.Helper()
+	ctx := context.Background()
+
+	// /start
+	startRec := httptest.NewRecorder()
+	startReq := httptest.NewRequest(http.MethodPost, "/tickets/"+ticketID+"/debate/start", http.NoBody)
+	startReq.AddCookie(cookie)
+	r.ServeHTTP(startRec, startReq)
+	if startRec.Code != http.StatusSeeOther {
+		t.Fatalf("/start: %d %s", startRec.Code, startRec.Body.String())
+	}
+
+	deb, err := db.GetActiveDebate(ctx, ticketID)
+	if err != nil {
+		t.Fatalf("GetActiveDebate: %v", err)
+	}
+
+	// The default fake refiner returns a constant string; we need to
+	// vary output per round so cascading-undo tests can distinguish
+	// rounds. Reach into the handler's refiner registry via the env
+	// we built in setupDebateTestEnv — but the test doesn't expose
+	// it. Instead: create rounds one at a time, manually updating the
+	// FakeRefiner's OutputFunc between calls via a closure variable.
+	// Simpler: use db-level shortcuts since the fake refiner's input
+	// doesn't vary meaningfully per round in these tests.
+	//
+	// For tests that DO need unique output per round, skip the HTTP
+	// /rounds path and insert rounds + accept them directly via
+	// AcceptRoundTx. That's what this helper does — it's an
+	// internal/testing-only shortcut, not a reflection of production
+	// flow (where the only way to create a round is through /rounds).
+	var accepted []*models.DebateRound
+	for i, out := range outputs {
+		currentText := deb.SeedDescription
+		if i > 0 {
+			currentText = outputs[i-1]
+		}
+		// Insert an in_review round under a short tx (re-using
+		// InsertDebateRoundTx against a fresh tx lock).
+		tx, err := db.Pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		round, _, err := db.InsertDebateRoundTx(ctx, tx, models.InsertDebateRoundInput{
+			DebateID:    deb.ID,
+			Provider:    "claude",
+			Model:       ai.ModelClaudeSonnet46,
+			TriggeredBy: deb.StartedBy,
+			InputText:   currentText,
+			OutputText:  out,
+			CostMicros:  0,
+		}, currentText)
+		if err != nil {
+			_ = tx.Rollback(ctx)
+			t.Fatalf("InsertDebateRoundTx: %v", err)
+		}
+		if commitErr := tx.Commit(ctx); commitErr != nil {
+			t.Fatalf("Commit: %v", commitErr)
+		}
+
+		// Accept via the HTTP handler so we exercise the production
+		// tx path including the FOR UPDATE status check.
+		acceptRec := httptest.NewRecorder()
+		acceptReq := httptest.NewRequest(http.MethodPost,
+			"/tickets/"+ticketID+"/debate/rounds/"+round.ID+"/accept", http.NoBody)
+		acceptReq.AddCookie(cookie)
+		r.ServeHTTP(acceptRec, acceptReq)
+		if acceptRec.Code != http.StatusOK {
+			t.Fatalf("/accept round %d: %d %s", i+1, acceptRec.Code, acceptRec.Body.String())
+		}
+		// Re-fetch the round to get its updated (accepted) state.
+		rounds, err := db.GetDebateRounds(ctx, deb.ID)
+		if err != nil {
+			t.Fatalf("GetDebateRounds: %v", err)
+		}
+		for j := range rounds {
+			if rounds[j].ID == round.ID {
+				accepted = append(accepted, &rounds[j])
+				break
+			}
+		}
+	}
+	return accepted
+}
+
+func TestAcceptRound_UpdatesCurrentText(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	startAndCreateRounds(t, r, db, cookie, ticket.ID, []string{"round 1 output"})
+
+	deb, err := db.GetActiveDebate(context.Background(), ticket.ID)
+	if err != nil {
+		t.Fatalf("GetActiveDebate: %v", err)
+	}
+	if deb.CurrentText != "round 1 output" {
+		t.Errorf("current_text = %q, want %q", deb.CurrentText, "round 1 output")
+	}
+}
+
+func TestRejectRound_LeavesCurrentTextUnchanged(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	// /start to open a debate.
+	startRec := httptest.NewRecorder()
+	startReq := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/start", http.NoBody)
+	startReq.AddCookie(cookie)
+	r.ServeHTTP(startRec, startReq)
+
+	deb, _ := db.GetActiveDebate(ctx, ticket.ID)
+	originalText := deb.CurrentText
+
+	// Manually insert an in_review round.
+	tx, _ := db.Pool.Begin(ctx)
+	round, _, err := db.InsertDebateRoundTx(ctx, tx, models.InsertDebateRoundInput{
+		DebateID:    deb.ID,
+		Provider:    "claude",
+		Model:       ai.ModelClaudeSonnet46,
+		TriggeredBy: deb.StartedBy,
+		InputText:   originalText,
+		OutputText:  "a rejected draft",
+	}, originalText)
+	if err != nil {
+		t.Fatalf("InsertDebateRoundTx: %v", err)
+	}
+	_ = tx.Commit(ctx)
+
+	rejectRec := httptest.NewRecorder()
+	rejectReq := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/rounds/"+round.ID+"/reject", http.NoBody)
+	rejectReq.AddCookie(cookie)
+	r.ServeHTTP(rejectRec, rejectReq)
+
+	if rejectRec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body = %q", rejectRec.Code, rejectRec.Body.String())
+	}
+	debReloaded, _ := db.GetActiveDebate(ctx, ticket.ID)
+	if debReloaded.CurrentText != originalText {
+		t.Errorf("reject changed current_text: %q → %q", originalText, debReloaded.CurrentText)
+	}
+}
+
+func TestUndoRound_CascadesLaterRoundsAndResetsEffort(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	// 3 accepted rounds.
+	rounds := startAndCreateRounds(t, r, db, cookie, ticket.ID,
+		[]string{"round 1 out", "round 2 out", "round 3 out"})
+	if len(rounds) != 3 {
+		t.Fatalf("expected 3 accepted rounds, got %d", len(rounds))
+	}
+
+	// Manually set effort fields so we can verify they get cleared.
+	_, err := db.Pool.Exec(ctx, `
+		UPDATE feature_debates
+		   SET effort_score = 7, effort_hours = 10, effort_reasoning = 'test',
+		       effort_scored_at = now(), last_scored_round_id = $1
+		 WHERE ticket_id = $2`, rounds[2].ID, ticket.ID)
+	if err != nil {
+		t.Fatalf("seeding effort fields: %v", err)
+	}
+
+	// Undo from round 2 — should delete rounds 2 and 3, leave round 1.
+	undoRec := httptest.NewRecorder()
+	undoReq := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/undo?from=2", http.NoBody)
+	undoReq.AddCookie(cookie)
+	r.ServeHTTP(undoRec, undoReq)
+
+	if undoRec.Code != http.StatusSeeOther {
+		t.Errorf("undo status = %d, want %d", undoRec.Code, http.StatusSeeOther)
+	}
+
+	deb, _ := db.GetActiveDebate(ctx, ticket.ID)
+	if deb.CurrentText != "round 1 out" {
+		t.Errorf("current_text = %q, want 'round 1 out'", deb.CurrentText)
+	}
+	remaining, _ := db.GetDebateRounds(ctx, deb.ID)
+	if len(remaining) != 1 {
+		t.Errorf("remaining rounds = %d, want 1", len(remaining))
+	}
+	if deb.EffortScore != nil {
+		t.Errorf("effort_score should be nil after undo, got %d", *deb.EffortScore)
+	}
+	if deb.LastScoredRoundID != nil {
+		t.Errorf("last_scored_round_id should be nil after undo")
+	}
+}
+
+func TestUndoRound_AllRoundsFallsBackToSeed(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	startAndCreateRounds(t, r, db, cookie, ticket.ID,
+		[]string{"round 1", "round 2"})
+
+	undoRec := httptest.NewRecorder()
+	undoReq := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/undo?from=1", http.NoBody)
+	undoReq.AddCookie(cookie)
+	r.ServeHTTP(undoRec, undoReq)
+
+	if undoRec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want 303; body = %q", undoRec.Code, undoRec.Body.String())
+	}
+	deb, _ := db.GetActiveDebate(context.Background(), ticket.ID)
+	if deb.CurrentText != deb.SeedDescription {
+		t.Errorf("current_text should fall back to seed after full undo: got %q, want %q",
+			deb.CurrentText, deb.SeedDescription)
+	}
+}
+
+func TestUndoRound_RejectsInvalidFrom(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	// Start a debate first so the /undo handler reaches its query-param check.
+	startReq := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/start", http.NoBody)
+	startReq.AddCookie(cookie)
+	r.ServeHTTP(httptest.NewRecorder(), startReq)
+
+	for _, qs := range []string{"", "from=0", "from=abc"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost,
+			"/tickets/"+ticket.ID+"/debate/undo?"+qs, http.NoBody)
+		req.AddCookie(cookie)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("qs=%q: status = %d, want 400", qs, rec.Code)
+		}
 	}
 }

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -27,6 +27,8 @@ var (
 	ErrStaleAIInput        = errors.New("current_text changed during AI call")
 	ErrInReviewRoundExists = errors.New("an in-review round already exists")
 	ErrDescriptionLocked   = errors.New("ticket description locked: active debate exists")
+	ErrRoundNotInReview    = errors.New("round is not in review state")
+	ErrNoRoundsToUndo      = errors.New("undo matched no rounds")
 )
 
 type DB struct {
@@ -2377,10 +2379,14 @@ func (db *DB) getRoundWithTx(ctx context.Context, tx pgx.Tx, roundID string) (*D
 // baseline. Returns the refreshed round.
 //
 // Caller MUST have opened the tx and already locked the debate row
-// with FOR UPDATE. This method re-locks both the debate and the round
-// being accepted to defend against future code paths that forget.
+// with FOR UPDATE. This method locks the specific round being
+// accepted (FOR UPDATE on feature_debate_rounds) to defend against
+// concurrent mutations of the same round, but relies on the caller's
+// debate-row lock for the broader state invariants.
+//
 // Returns pgx.ErrNoRows if the round doesn't exist under this debate,
-// or a wrapped fmt.Errorf if the round is not in_review.
+// ErrRoundNotInReview if the round is not in_review (already accepted
+// or rejected — stale client view).
 func (db *DB) AcceptRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID string) (*DebateRound, error) {
 	var status, outputText string
 	err := tx.QueryRow(ctx, `
@@ -2395,7 +2401,7 @@ func (db *DB) AcceptRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID st
 		return nil, err
 	}
 	if status != "in_review" {
-		return nil, fmt.Errorf("round status is %q, not in_review", status)
+		return nil, ErrRoundNotInReview
 	}
 
 	if _, err = tx.Exec(ctx, `
@@ -2434,7 +2440,7 @@ func (db *DB) RejectRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID st
 		return err
 	}
 	if status != "in_review" {
-		return fmt.Errorf("round status is %q, not in_review", status)
+		return ErrRoundNotInReview
 	}
 	_, err = tx.Exec(ctx, `
 		UPDATE feature_debate_rounds
@@ -2457,12 +2463,20 @@ func (db *DB) RejectRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID st
 // for the case where the referenced round survives the delete
 // (fromRoundNumber > last_scored_round).
 func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, fromRoundNumber int) error {
-	if _, err := tx.Exec(ctx,
+	tag, err := tx.Exec(ctx,
 		`DELETE FROM feature_debate_rounds
 		  WHERE debate_id = $1 AND round_number >= $2`,
 		debateID, fromRoundNumber,
-	); err != nil {
+	)
+	if err != nil {
 		return err
+	}
+	// Guard against "?from=999 on a 3-round debate" — a request that
+	// targets a non-existent round range should be rejected, not
+	// silently clear effort_* + current_text unchanged. Return a
+	// sentinel the handler maps to 404.
+	if tag.RowsAffected() == 0 {
+		return ErrNoRoundsToUndo
 	}
 
 	// Recompute current_text from the largest remaining accepted
@@ -2470,18 +2484,18 @@ func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, 
 	// remain. Rejected rounds are explicitly excluded — they never
 	// modified current_text.
 	var newCurrentText string
-	if err := tx.QueryRow(ctx, `
+	if scanErr := tx.QueryRow(ctx, `
 		SELECT COALESCE(
 			(SELECT output_text FROM feature_debate_rounds
 			  WHERE debate_id = $1 AND status = 'accepted'
 			  ORDER BY round_number DESC LIMIT 1),
 			(SELECT seed_description FROM feature_debates WHERE id = $1)
 		)`, debateID,
-	).Scan(&newCurrentText); err != nil {
-		return err
+	).Scan(&newCurrentText); scanErr != nil {
+		return scanErr
 	}
 
-	_, err := tx.Exec(ctx, `
+	_, err = tx.Exec(ctx, `
 		UPDATE feature_debates
 		   SET current_text = $1,
 		       effort_score = NULL,

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -2351,6 +2351,192 @@ func (db *DB) InsertDebateRoundTx(
 	return r, centsDelta, nil
 }
 
+// getRoundWithTx re-fetches a round after mutation so the caller
+// receives the updated status/decided_at without a second round-trip.
+// Internal helper used by AcceptRoundTx below.
+func (db *DB) getRoundWithTx(ctx context.Context, tx pgx.Tx, roundID string) (*DebateRound, error) {
+	r := &DebateRound{}
+	err := tx.QueryRow(ctx, `
+		SELECT id, debate_id, round_number, provider, model, triggered_by,
+		       feedback, input_text, output_text, diff_unified, status,
+		       input_tokens, output_tokens, cost_micros, scorer_cost_micros,
+		       created_at, decided_at
+		  FROM feature_debate_rounds WHERE id = $1`, roundID,
+	).Scan(
+		&r.ID, &r.DebateID, &r.RoundNumber, &r.Provider, &r.Model, &r.TriggeredBy,
+		&r.Feedback, &r.InputText, &r.OutputText, &r.DiffUnified, &r.Status,
+		&r.InputTokens, &r.OutputTokens, &r.CostMicros, &r.ScorerCostMicros,
+		&r.CreatedAt, &r.DecidedAt,
+	)
+	return r, err
+}
+
+// AcceptRoundTx transitions an in_review round to accepted under the
+// debate row's lock. Updates feature_debates.current_text to the
+// round's output_text so subsequent round-creation sees the new
+// baseline. Returns the refreshed round.
+//
+// Caller MUST have opened the tx and already locked the debate row
+// with FOR UPDATE. This method re-locks both the debate and the round
+// being accepted to defend against future code paths that forget.
+// Returns pgx.ErrNoRows if the round doesn't exist under this debate,
+// or a wrapped fmt.Errorf if the round is not in_review.
+func (db *DB) AcceptRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID string) (*DebateRound, error) {
+	var status, outputText string
+	err := tx.QueryRow(ctx, `
+		SELECT status, output_text FROM feature_debate_rounds
+		 WHERE id = $1 AND debate_id = $2 FOR UPDATE`,
+		roundID, debateID,
+	).Scan(&status, &outputText)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, pgx.ErrNoRows
+	}
+	if err != nil {
+		return nil, err
+	}
+	if status != "in_review" {
+		return nil, fmt.Errorf("round status is %q, not in_review", status)
+	}
+
+	if _, err = tx.Exec(ctx, `
+		UPDATE feature_debate_rounds
+		   SET status = 'accepted', decided_at = now()
+		 WHERE id = $1`, roundID,
+	); err != nil {
+		return nil, err
+	}
+
+	if _, err = tx.Exec(ctx, `
+		UPDATE feature_debates
+		   SET current_text = $1, updated_at = now()
+		 WHERE id = $2`, outputText, debateID,
+	); err != nil {
+		return nil, err
+	}
+
+	return db.getRoundWithTx(ctx, tx, roundID)
+}
+
+// RejectRoundTx transitions an in_review round to rejected. Does NOT
+// touch feature_debates.current_text — rejected rounds never
+// contributed to the accepted text chain.
+func (db *DB) RejectRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID string) error {
+	var status string
+	err := tx.QueryRow(ctx, `
+		SELECT status FROM feature_debate_rounds
+		 WHERE id = $1 AND debate_id = $2 FOR UPDATE`,
+		roundID, debateID,
+	).Scan(&status)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return pgx.ErrNoRows
+	}
+	if err != nil {
+		return err
+	}
+	if status != "in_review" {
+		return fmt.Errorf("round status is %q, not in_review", status)
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE feature_debate_rounds
+		   SET status = 'rejected', decided_at = now()
+		 WHERE id = $1`, roundID,
+	)
+	return err
+}
+
+// UndoRoundsFromTx deletes every round with round_number >=
+// fromRoundNumber (cascading undo per spec §4.4), recomputes
+// current_text from the largest remaining accepted round (or the
+// seed description if none remain), and resets the effort_* fields
+// so the next accept re-scores from scratch.
+//
+// Caller MUST have opened the tx and already locked the debate row
+// with FOR UPDATE. last_scored_round_id is cleared via ON DELETE SET
+// NULL on the cyclic FK when the targeted round is deleted; the
+// explicit nulling of effort_* in this UPDATE is belt-and-suspenders
+// for the case where the referenced round survives the delete
+// (fromRoundNumber > last_scored_round).
+func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, fromRoundNumber int) error {
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM feature_debate_rounds
+		  WHERE debate_id = $1 AND round_number >= $2`,
+		debateID, fromRoundNumber,
+	); err != nil {
+		return err
+	}
+
+	// Recompute current_text from the largest remaining accepted
+	// round, falling back to the debate's seed when no accepted rounds
+	// remain. Rejected rounds are explicitly excluded — they never
+	// modified current_text.
+	var newCurrentText string
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE(
+			(SELECT output_text FROM feature_debate_rounds
+			  WHERE debate_id = $1 AND status = 'accepted'
+			  ORDER BY round_number DESC LIMIT 1),
+			(SELECT seed_description FROM feature_debates WHERE id = $1)
+		)`, debateID,
+	).Scan(&newCurrentText); err != nil {
+		return err
+	}
+
+	_, err := tx.Exec(ctx, `
+		UPDATE feature_debates
+		   SET current_text = $1,
+		       effort_score = NULL,
+		       effort_hours = NULL,
+		       effort_reasoning = NULL,
+		       effort_scored_at = NULL,
+		       last_scored_round_id = NULL,
+		       updated_at = now()
+		 WHERE id = $2`, newCurrentText, debateID,
+	)
+	return err
+}
+
+// UpdateEffortScoreCondTx writes a scorer result conditionally, only
+// if the debate is still active-or-approved AND the scored round is
+// fresher than whatever the last_scored_round_id already points to.
+// Out-of-order scorer responses (scorer for round N finishes after
+// scorer for round N+1) are silently discarded — the freshest
+// accepted round's score always wins. See spec §4.3 step 8.
+func (db *DB) UpdateEffortScoreCondTx(
+	ctx context.Context, tx pgx.Tx,
+	debateID, scoredRoundID string,
+	score, hours int, reasoning string,
+) error {
+	_, err := tx.Exec(ctx, `
+		UPDATE feature_debates
+		   SET effort_score = $1,
+		       effort_hours = $2,
+		       effort_reasoning = $3,
+		       effort_scored_at = now(),
+		       last_scored_round_id = $4,
+		       updated_at = now()
+		 WHERE id = $5
+		   AND status IN ('active','approved')
+		   AND (last_scored_round_id IS NULL
+		     OR (SELECT round_number FROM feature_debate_rounds WHERE id = last_scored_round_id)
+		      < (SELECT round_number FROM feature_debate_rounds WHERE id = $4))`,
+		score, hours, reasoning, scoredRoundID, debateID,
+	)
+	return err
+}
+
+// UpdateScorerCostMicros persists the scorer call's cost on the
+// round row, independent of whether the effort_* score update ran
+// (the score might be discarded as out-of-order but we still billed
+// for the call, and the canonical per-round audit trail must reflect
+// that).
+func (db *DB) UpdateScorerCostMicros(ctx context.Context, tx pgx.Tx, roundID string, cost int64) error {
+	_, err := tx.Exec(ctx,
+		`UPDATE feature_debate_rounds SET scorer_cost_micros = $1 WHERE id = $2`,
+		cost, roundID,
+	)
+	return err
+}
+
 // IncrementProjectCostCents adds the given delta to the project_costs
 // row for category='debate' in the current month, creating the row if
 // absent. Non-fatal at the handler layer — cost rollups are


### PR DESCRIPTION
Closes #60 once merged.

## Summary

Implements [Task 8 from the plan](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/plans/2026-04-14-feature-debate-mode.md#task-8-featdebate--accept-reject-undo--cascading-invariant). Extends the handler from #74 with three more endpoints + supporting queries + scorer fire-and-forget goroutine + 5 new regression tests.

+742 LOC across 4 files. Full go test ./internal/handlers green (12/12), golangci-lint run ./... → 0 issues.

## Highlights

- **Scorer runs outside the accept tx** (spec §4.3 step 7) as a `go` routine with `context.WithoutCancel`; the accept response returns immediately rather than waiting on a 60s AI call.
- **Conditional effort-score update** via `UpdateEffortScoreCondTx` silently discards out-of-order scorer responses using `last_scored_round_id` ordering (spec §4.3 step 8).
- **Cascading undo** with effort-field reset — `TestUndoRound_CascadesLaterRoundsAndResetsEffort` seeds 3 rounds + manual effort fields, undoes from round 2, verifies the full state transition.
- **All three state-changing endpoints take debate-row FOR UPDATE first** per spec §3.3 concurrency model.
- **Stale-state distinguished from not-found** — trying to accept a round that's already decided returns 409 "stale state", not 404.

## Test plan

- [x] `go test ./internal/handlers -run "TestAccept|TestReject|TestUndo|TestStartDebate|TestShowDebate_No|TestDebate_Rejects|TestCreateRound_Rejects"` — 12 pass
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)