### PR TITLE
feat(debate): approve, abandon + UpdateTicket split (debate v1 task 9)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -271,6 +271,8 @@ func main() {
 		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/accept", debateH.AcceptRound)
 		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/reject", debateH.RejectRound)
 		r.Post("/tickets/{ticketID}/debate/undo", debateH.UndoRound)
+		r.Post("/tickets/{ticketID}/debate/approve", debateH.ApproveDebate)
+		r.Post("/tickets/{ticketID}/debate/abandon", debateH.AbandonDebate)
 
 		// Comments
 		r.Post("/tickets/{ticketID}/comments", commentH.CreateComment)

--- a/internal/handlers/assistant.go
+++ b/internal/handlers/assistant.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -840,6 +841,17 @@ func (e *toolExecutor) updateTicket(ctx context.Context, args map[string]any) (m
 	}
 
 	if err := e.db.UpdateTicket(ctx, ticket); err != nil {
+		// Surface the debate-mode lockout back to the LLM as a tool
+		// error rather than an infra failure. The chat assistant's
+		// tool-execution path will include this in the model's next
+		// turn context so it can explain the refusal to the user
+		// rather than retrying blindly.
+		if errors.Is(err, models.ErrDescriptionLocked) {
+			return map[string]any{
+				"error":   "description_locked",
+				"message": "The ticket description is locked because a debate is currently active on this feature. Ask the user to finish or abandon the debate, then retry.",
+			}, nil
+		}
 		return nil, fmt.Errorf("updating ticket: %w", err)
 	}
 

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -779,6 +779,132 @@ func (h *DebateHandler) UndoRound(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusSeeOther)
 }
 
+// ── POST /tickets/{ticketID}/debate/approve ──────────────────────
+
+// ApproveDebate writes the debate's current_text to the ticket's
+// description_markdown and marks the debate 'approved'. Guarded by
+// the spec §4.5 compare-and-swap: if the ticket's description no
+// longer equals original_ticket_description (caught for example when
+// a v0.1.0 pod edits it during a rolling upgrade before this PR
+// landed), the approve refuses with 409 so the user is told to
+// Abandon and manually reconcile.
+//
+// On success returns Hx-Redirect to the ticket detail page — the
+// debate is now terminal, the debate page's GET handler would show
+// an empty-state anyway.
+func (h *DebateHandler) ApproveDebate(w http.ResponseWriter, r *http.Request) {
+	dctx, code, err := h.requireDebateContext(r)
+	if err != nil {
+		h.engine.RenderError(w, code, err.Error())
+		return
+	}
+
+	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "no active debate", http.StatusConflict)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if approveErr := h.approveUnderLock(r.Context(), deb.ID, dctx.ticket.ID); approveErr != nil {
+		switch {
+		case errors.Is(approveErr, models.ErrDebateNotActive):
+			http.Error(w, "debate not active", http.StatusConflict)
+		case errors.Is(approveErr, models.ErrExternalDescriptionEdit):
+			// Tell the user exactly how to resolve: Abandon unlocks
+			// the ticket description for manual edit, then they can
+			// start a new debate from the current state.
+			http.Error(w,
+				"description was edited externally since the debate started. To resolve: click Abandon to release the debate lock, then manually merge the external edit with the draft, then start a new debate.",
+				http.StatusConflict)
+		default:
+			log.Printf("debate ApproveDebate: %v", approveErr)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Hx-Redirect", "/tickets/"+dctx.ticket.ID)
+	w.WriteHeader(http.StatusSeeOther)
+}
+
+func (h *DebateHandler) approveUnderLock(ctx context.Context, debateID, ticketID string) error {
+	tx, err := h.db.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Lock the debate row first; all state-changing ops serialize here.
+	if _, qErr := tx.Exec(ctx,
+		`SELECT 1 FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
+	); qErr != nil {
+		return qErr
+	}
+	if aErr := h.db.ApproveDebateTx(ctx, tx, debateID, ticketID); aErr != nil {
+		return aErr
+	}
+	return tx.Commit(ctx)
+}
+
+// ── POST /tickets/{ticketID}/debate/abandon ──────────────────────
+
+// AbandonDebate marks the debate as abandoned without touching the
+// ticket description. Also force-clears any lingering
+// in_flight_request_id as the escape hatch for orphaned reservations
+// whose stale-recovery timer hasn't fired yet.
+func (h *DebateHandler) AbandonDebate(w http.ResponseWriter, r *http.Request) {
+	dctx, code, err := h.requireDebateContext(r)
+	if err != nil {
+		h.engine.RenderError(w, code, err.Error())
+		return
+	}
+
+	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "no active debate", http.StatusConflict)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if abandonErr := h.abandonUnderLock(r.Context(), deb.ID); abandonErr != nil {
+		if errors.Is(abandonErr, models.ErrDebateNotActive) {
+			http.Error(w, "debate not active", http.StatusConflict)
+			return
+		}
+		log.Printf("debate AbandonDebate: %v", abandonErr)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Hx-Redirect", "/tickets/"+dctx.ticket.ID)
+	w.WriteHeader(http.StatusSeeOther)
+}
+
+func (h *DebateHandler) abandonUnderLock(ctx context.Context, debateID string) error {
+	tx, err := h.db.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, qErr := tx.Exec(ctx,
+		`SELECT 1 FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
+	); qErr != nil {
+		return qErr
+	}
+	if aErr := h.db.AbandonDebateTx(ctx, tx, debateID); aErr != nil {
+		return aErr
+	}
+	return tx.Commit(ctx)
+}
+
 func (h *DebateHandler) undoUnderLock(ctx context.Context, debateID string, fromN int) error {
 	tx, err := h.db.Pool.Begin(ctx)
 	if err != nil {

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -799,18 +799,15 @@ func (h *DebateHandler) ApproveDebate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
-	if errors.Is(err, pgx.ErrNoRows) {
-		http.Error(w, "no active debate", http.StatusConflict)
-		return
-	}
-	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-
-	if approveErr := h.approveUnderLock(r.Context(), deb.ID, dctx.ticket.ID); approveErr != nil {
+	// No pre-check GetActiveDebate: approveUnderLock runs a JOIN that
+	// both finds the active debate AND takes FOR UPDATE in one
+	// statement. pgx.ErrNoRows from that path means no active debate;
+	// ErrDebateNotActive means a row exists but isn't active. Both
+	// surface as 409 at the user level with distinct messages.
+	if approveErr := h.approveUnderLock(r.Context(), dctx.ticket.ID); approveErr != nil {
 		switch {
+		case errors.Is(approveErr, pgx.ErrNoRows):
+			http.Error(w, "no active debate", http.StatusConflict)
 		case errors.Is(approveErr, models.ErrDebateNotActive):
 			http.Error(w, "debate not active", http.StatusConflict)
 		case errors.Is(approveErr, models.ErrExternalDescriptionEdit):
@@ -831,19 +828,30 @@ func (h *DebateHandler) ApproveDebate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusSeeOther)
 }
 
-func (h *DebateHandler) approveUnderLock(ctx context.Context, debateID, ticketID string) error {
+// approveUnderLock looks up the active debate for the ticket and runs
+// ApproveDebateTx under the combined debate+ticket row lock. No
+// separate GetActiveDebate round-trip: the JOIN inside ApproveDebateTx
+// (which already locks both rows) handles the lookup atomically.
+func (h *DebateHandler) approveUnderLock(ctx context.Context, ticketID string) error {
+	// Resolve active debate id inside a short query; ApproveDebateTx
+	// expects the debate id alongside the ticket id so its JOIN filter
+	// matches both. Using a regular SELECT here (not FOR UPDATE) is
+	// safe because ApproveDebateTx re-locks the debate row in its own
+	// tx with FOR UPDATE — this first read is just to resolve the id.
+	var debateID string
+	if err := h.db.Pool.QueryRow(ctx,
+		`SELECT id FROM feature_debates WHERE ticket_id = $1 AND status = 'active' LIMIT 1`,
+		ticketID,
+	).Scan(&debateID); err != nil {
+		return err
+	}
+
 	tx, err := h.db.Pool.Begin(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Lock the debate row first; all state-changing ops serialize here.
-	if _, qErr := tx.Exec(ctx,
-		`SELECT 1 FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
-	); qErr != nil {
-		return qErr
-	}
 	if aErr := h.db.ApproveDebateTx(ctx, tx, debateID, ticketID); aErr != nil {
 		return aErr
 	}
@@ -863,23 +871,16 @@ func (h *DebateHandler) AbandonDebate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deb, err := h.db.GetActiveDebate(r.Context(), dctx.ticket.ID)
-	if errors.Is(err, pgx.ErrNoRows) {
-		http.Error(w, "no active debate", http.StatusConflict)
-		return
-	}
-	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-
-	if abandonErr := h.abandonUnderLock(r.Context(), deb.ID); abandonErr != nil {
-		if errors.Is(abandonErr, models.ErrDebateNotActive) {
+	if abandonErr := h.abandonUnderLock(r.Context(), dctx.ticket.ID); abandonErr != nil {
+		switch {
+		case errors.Is(abandonErr, pgx.ErrNoRows):
+			http.Error(w, "no active debate", http.StatusConflict)
+		case errors.Is(abandonErr, models.ErrDebateNotActive):
 			http.Error(w, "debate not active", http.StatusConflict)
-			return
+		default:
+			log.Printf("debate AbandonDebate: %v", abandonErr)
+			http.Error(w, "internal error", http.StatusInternalServerError)
 		}
-		log.Printf("debate AbandonDebate: %v", abandonErr)
-		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
@@ -887,18 +888,25 @@ func (h *DebateHandler) AbandonDebate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusSeeOther)
 }
 
-func (h *DebateHandler) abandonUnderLock(ctx context.Context, debateID string) error {
+// abandonUnderLock resolves the active debate and runs the atomic
+// AbandonDebateTx. No pre-check round-trip: AbandonDebateTx uses an
+// UPDATE ... WHERE status='active' that completes in one statement
+// on the common path.
+func (h *DebateHandler) abandonUnderLock(ctx context.Context, ticketID string) error {
+	var debateID string
+	if err := h.db.Pool.QueryRow(ctx,
+		`SELECT id FROM feature_debates WHERE ticket_id = $1 AND status = 'active' LIMIT 1`,
+		ticketID,
+	).Scan(&debateID); err != nil {
+		return err
+	}
+
 	tx, err := h.db.Pool.Begin(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if _, qErr := tx.Exec(ctx,
-		`SELECT 1 FROM feature_debates WHERE id = $1 FOR UPDATE`, debateID,
-	); qErr != nil {
-		return qErr
-	}
 	if aErr := h.db.AbandonDebateTx(ctx, tx, debateID); aErr != nil {
 		return aErr
 	}

--- a/internal/handlers/debate_test.go
+++ b/internal/handlers/debate_test.go
@@ -3,12 +3,14 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/madalin/forgedesk/internal/ai"
 	"github.com/madalin/forgedesk/internal/auth"
 	"github.com/madalin/forgedesk/internal/middleware"
@@ -52,6 +54,8 @@ func setupDebateTestEnv(t *testing.T) (*chi.Mux, *models.DB, *auth.SessionStore)
 		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/accept", h.AcceptRound)
 		r.Post("/tickets/{ticketID}/debate/rounds/{roundID}/reject", h.RejectRound)
 		r.Post("/tickets/{ticketID}/debate/undo", h.UndoRound)
+		r.Post("/tickets/{ticketID}/debate/approve", h.ApproveDebate)
+		r.Post("/tickets/{ticketID}/debate/abandon", h.AbandonDebate)
 	})
 	return r, db, sessions
 }
@@ -513,4 +517,191 @@ func TestUndoRound_RejectsInvalidFrom(t *testing.T) {
 			t.Errorf("qs=%q: status = %d, want 400", qs, rec.Code)
 		}
 	}
+}
+
+func TestApproveDebate_WritesCurrentTextAndRedirects(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	// Accept one round so the debate has a current_text to approve.
+	startAndCreateRounds(t, r, db, cookie, ticket.ID, []string{"the approved description"})
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/approve", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body = %q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Hx-Redirect"); got != "/tickets/"+ticket.ID {
+		t.Errorf("Hx-Redirect = %q, want /tickets/%s", got, ticket.ID)
+	}
+
+	// Debate must be terminal + ticket description updated.
+	_, err := db.GetActiveDebate(ctx, ticket.ID)
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("expected pgx.ErrNoRows after approve (no active debate), got %v", err)
+	}
+	updated, err := db.GetTicket(ctx, ticket.ID)
+	if err != nil {
+		t.Fatalf("GetTicket after approve: %v", err)
+	}
+	if updated.DescriptionMarkdown != "the approved description" {
+		t.Errorf("ticket description = %q, want %q", updated.DescriptionMarkdown, "the approved description")
+	}
+}
+
+func TestApproveDebate_CASRejectsExternalEdit(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	startAndCreateRounds(t, r, db, cookie, ticket.ID, []string{"the approved description"})
+
+	// Simulate an out-of-band edit — e.g., a v0.1.0 pod during
+	// rolling upgrade — bypassing the IsDebateActive guard by
+	// writing the ticket description directly. The CAS in
+	// ApproveDebateTx must detect the drift and refuse.
+	if _, execErr := db.Pool.Exec(ctx,
+		`UPDATE tickets SET description_markdown = 'sneaky external edit' WHERE id = $1`,
+		ticket.ID,
+	); execErr != nil {
+		t.Fatalf("simulating external edit: %v", execErr)
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/approve", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "edited externally") {
+		t.Errorf("expected 'edited externally' error, got: %q", rec.Body.String())
+	}
+
+	// Debate must stay active; ticket must still show the external
+	// edit (we don't silently overwrite).
+	deb, err := db.GetActiveDebate(ctx, ticket.ID)
+	if err != nil {
+		t.Fatalf("GetActiveDebate: %v", err)
+	}
+	if deb.Status != "active" {
+		t.Errorf("debate status = %q, want active (CAS should not terminate)", deb.Status)
+	}
+	updated, _ := db.GetTicket(ctx, ticket.ID)
+	if updated.DescriptionMarkdown != "sneaky external edit" {
+		t.Errorf("ticket description = %q, expected external edit preserved", updated.DescriptionMarkdown)
+	}
+}
+
+func TestAbandonDebate_MarksAbandonedLeavesDescription(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	// Start debate + accept a round; description should NOT change on abandon.
+	startAndCreateRounds(t, r, db, cookie, ticket.ID, []string{"never-approved draft"})
+
+	originalTicket, _ := db.GetTicket(ctx, ticket.ID)
+	originalDesc := originalTicket.DescriptionMarkdown
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/abandon", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+
+	// No active debate should remain; terminal state persists but is
+	// no longer the "active" row that IsDebateActive matches.
+	if active, _ := db.IsDebateActive(ctx, ticket.ID); active {
+		t.Error("debate should no longer be active after Abandon")
+	}
+
+	updated, _ := db.GetTicket(ctx, ticket.ID)
+	if updated.DescriptionMarkdown != originalDesc {
+		t.Errorf("abandon changed description: %q → %q", originalDesc, updated.DescriptionMarkdown)
+	}
+}
+
+func TestUpdateTicketDescription_BlockedByActiveDebate(t *testing.T) {
+	// Model-layer guard test: the single-write-path invariant.
+	// Calls db.UpdateTicketDescription directly so this test catches
+	// bypasses from ANY caller (HTTP handler, AI assistant tool,
+	// future import path), not just a specific handler flow.
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	sessions := auth.NewSessionStore(pool)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	// No active debate → update succeeds.
+	if err := db.UpdateTicketDescription(ctx, ticket.ID, "freshly rewritten"); err != nil {
+		t.Fatalf("UpdateTicketDescription (no debate): %v", err)
+	}
+	got, _ := db.GetTicket(ctx, ticket.ID)
+	if got.DescriptionMarkdown != "freshly rewritten" {
+		t.Errorf("first update failed silently: got %q", got.DescriptionMarkdown)
+	}
+
+	// Start a debate → subsequent UpdateTicketDescription returns
+	// ErrDescriptionLocked regardless of caller identity.
+	if _, err := db.StartDebate(ctx, ticket.ID, ticket.ProjectID,
+		mustResolveOrgID(t, db, ticket.ProjectID), ticket.CreatedBy); err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+	err := db.UpdateTicketDescription(ctx, ticket.ID, "debate should block this")
+	if !errors.Is(err, models.ErrDescriptionLocked) {
+		t.Fatalf("expected ErrDescriptionLocked, got %v", err)
+	}
+	got, _ = db.GetTicket(ctx, ticket.ID)
+	if got.DescriptionMarkdown == "debate should block this" {
+		t.Error("UpdateTicketDescription wrote through the guard")
+	}
+}
+
+func TestUpdateTicketMetadata_AllowedDuringActiveDebate(t *testing.T) {
+	// Metadata (title, priority, dates, assignee) stays editable
+	// during an active debate — only description is locked.
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	sessions := auth.NewSessionStore(pool)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	ctx := context.Background()
+
+	if _, err := db.StartDebate(ctx, ticket.ID, ticket.ProjectID,
+		mustResolveOrgID(t, db, ticket.ProjectID), ticket.CreatedBy); err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	if err := db.UpdateTicketMetadata(ctx, ticket.ID, "new title", "high", nil, nil, nil); err != nil {
+		t.Fatalf("UpdateTicketMetadata during active debate: %v", err)
+	}
+	got, _ := db.GetTicket(ctx, ticket.ID)
+	if got.Title != "new title" {
+		t.Errorf("title = %q, want 'new title'", got.Title)
+	}
+	if got.Priority != "high" {
+		t.Errorf("priority = %q, want 'high'", got.Priority)
+	}
+}
+
+func mustResolveOrgID(t *testing.T, db *models.DB, projectID string) string {
+	t.Helper()
+	var orgID string
+	if err := db.Pool.QueryRow(context.Background(),
+		`SELECT org_id FROM projects WHERE id = $1`, projectID,
+	).Scan(&orgID); err != nil {
+		t.Fatalf("resolving org from project: %v", err)
+	}
+	return orgID
 }

--- a/internal/handlers/tickets.go
+++ b/internal/handlers/tickets.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"net/url"
@@ -290,6 +291,14 @@ func (h *TicketHandler) UpdateTicket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.db.UpdateTicket(r.Context(), ticket); err != nil {
+		if errors.Is(err, models.ErrDescriptionLocked) {
+			// Surface the debate-mode lockout explicitly so the client
+			// knows why the description change was rejected (and that
+			// metadata changes could still be submitted separately via
+			// a future endpoint if the plan warrants one).
+			http.Error(w, "ticket description is locked while a debate is active; finish or abandon the debate first", http.StatusConflict)
+			return
+		}
 		log.Printf("updating ticket: %v", err)
 		http.Error(w, "Failed to update ticket", http.StatusInternalServerError)
 		return

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -1128,14 +1128,163 @@ func (db *DB) UpdateTicketAgentMode(ctx context.Context, id string, mode, agent 
 	return nil
 }
 
+// UpdateTicket updates a ticket's title, description, priority,
+// dates, and assignee in a single statement. If a debate is active
+// for this ticket AND the new description differs from the stored
+// description, returns ErrDescriptionLocked — preventing debate-
+// guarded overwrites regardless of which caller (HTTP handler or
+// AI assistant tool) tries to bypass the lockout.
+//
+// The guard lives in the model layer so every caller gets it for
+// free; spec §3.3 "single write path" invariant. For callers that
+// explicitly need to update metadata-only (title/priority/dates)
+// during an active debate, use UpdateTicketMetadata which skips
+// description and skips the guard.
 func (db *DB) UpdateTicket(ctx context.Context, t *Ticket) error {
-	_, err := db.Pool.Exec(ctx,
+	active, err := db.IsDebateActive(ctx, t.ID)
+	if err != nil {
+		return fmt.Errorf("checking debate active: %w", err)
+	}
+	if active {
+		var currentDesc string
+		if descErr := db.Pool.QueryRow(ctx,
+			`SELECT description_markdown FROM tickets WHERE id = $1`, t.ID,
+		).Scan(&currentDesc); descErr != nil {
+			return fmt.Errorf("loading ticket description for guard: %w", descErr)
+		}
+		if currentDesc != t.DescriptionMarkdown {
+			return ErrDescriptionLocked
+		}
+	}
+	_, err = db.Pool.Exec(ctx,
 		`UPDATE tickets SET title = $1, description_markdown = $2, priority = $3, date_start = $4, date_end = $5, assigned_to = $6, updated_at = now() WHERE id = $7`,
 		t.Title, t.DescriptionMarkdown, t.Priority, t.DateStart, t.DateEnd, t.AssignedTo, t.ID)
 	if err != nil {
 		return fmt.Errorf("updating ticket: %w", err)
 	}
 	return nil
+}
+
+// UpdateTicketMetadata updates everything EXCEPT description_markdown.
+// No debate guard — title, priority, dates, and assignee remain
+// editable while a debate is active.
+func (db *DB) UpdateTicketMetadata(ctx context.Context, id, title, priority string, dateStart, dateEnd *time.Time, assignedTo *string) error {
+	_, err := db.Pool.Exec(ctx,
+		`UPDATE tickets
+		    SET title = $1, priority = $2, date_start = $3, date_end = $4,
+		        assigned_to = $5, updated_at = now()
+		  WHERE id = $6`,
+		title, priority, dateStart, dateEnd, assignedTo, id)
+	if err != nil {
+		return fmt.Errorf("updating ticket metadata: %w", err)
+	}
+	return nil
+}
+
+// UpdateTicketDescription updates description_markdown ONLY, with the
+// model-layer debate-active guard. Returns ErrDescriptionLocked if a
+// debate is currently active for the ticket. Callers (HTTP handler,
+// AI assistant tool, future paths) MUST use this method for
+// description changes so the guard is never bypassed.
+func (db *DB) UpdateTicketDescription(ctx context.Context, id, newMarkdown string) error {
+	active, err := db.IsDebateActive(ctx, id)
+	if err != nil {
+		return fmt.Errorf("checking debate active: %w", err)
+	}
+	if active {
+		return ErrDescriptionLocked
+	}
+	_, err = db.Pool.Exec(ctx,
+		`UPDATE tickets SET description_markdown = $1, updated_at = now() WHERE id = $2`,
+		newMarkdown, id)
+	if err != nil {
+		return fmt.Errorf("updating ticket description: %w", err)
+	}
+	return nil
+}
+
+// ApproveDebateTx writes the debate's current_text to the ticket's
+// description_markdown and transitions the debate to 'approved'.
+// Enforces two invariants under the caller's debate-row lock:
+//   - Debate must be status='active' (ErrDebateNotActive otherwise —
+//     terminal states can't be re-approved or flipped from abandoned).
+//   - tickets.description_markdown must equal the snapshot taken at
+//     StartDebate (original_ticket_description). If another code path
+//     edited the description out-of-band (e.g., a v0.1.0 pod during
+//     a rolling upgrade, before the IsDebateActive guard was in
+//     place), we refuse rather than silently overwrite. CAS failure
+//     maps to 409 at the handler so the user is told to Abandon
+//     the debate and manually reconcile.
+//
+// Caller MUST have opened the tx and already locked the debate row.
+var ErrExternalDescriptionEdit = errors.New("ticket description edited externally since debate started")
+
+func (db *DB) ApproveDebateTx(ctx context.Context, tx pgx.Tx, debateID, ticketID string) error {
+	var (
+		status       string
+		currentText  string
+		originalDesc string
+	)
+	err := tx.QueryRow(ctx, `
+		SELECT status, current_text, original_ticket_description
+		  FROM feature_debates WHERE id = $1`, debateID,
+	).Scan(&status, &currentText, &originalDesc)
+	if err != nil {
+		return err
+	}
+	if status != DebateStatusActive {
+		return ErrDebateNotActive
+	}
+
+	var ticketDesc string
+	if tErr := tx.QueryRow(ctx,
+		`SELECT description_markdown FROM tickets WHERE id = $1 FOR UPDATE`, ticketID,
+	).Scan(&ticketDesc); tErr != nil {
+		return tErr
+	}
+	if ticketDesc != originalDesc {
+		return ErrExternalDescriptionEdit
+	}
+
+	if _, uErr := tx.Exec(ctx,
+		`UPDATE tickets SET description_markdown = $1, updated_at = now() WHERE id = $2`,
+		currentText, ticketID,
+	); uErr != nil {
+		return uErr
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE feature_debates
+		   SET status = 'approved', approved_text = $1, updated_at = now()
+		 WHERE id = $2`, currentText, debateID,
+	)
+	return err
+}
+
+// AbandonDebateTx marks the debate as abandoned and force-clears any
+// lingering in_flight_request_id so the user can always unlock the
+// description even if a previous CreateRound crashed mid-AI-call.
+// The ticket's description is left untouched.
+//
+// Caller MUST have opened the tx and already locked the debate row.
+func (db *DB) AbandonDebateTx(ctx context.Context, tx pgx.Tx, debateID string) error {
+	var status string
+	if err := tx.QueryRow(ctx,
+		`SELECT status FROM feature_debates WHERE id = $1`, debateID,
+	).Scan(&status); err != nil {
+		return err
+	}
+	if status != DebateStatusActive {
+		return ErrDebateNotActive
+	}
+	_, err := tx.Exec(ctx, `
+		UPDATE feature_debates
+		   SET status = 'abandoned',
+		       in_flight_request_id = NULL,
+		       in_flight_started_at = NULL,
+		       updated_at = now()
+		 WHERE id = $1`, debateID,
+	)
+	return err
 }
 
 // ListAgentReady returns tickets that are ready for agent processing.

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -1141,26 +1141,42 @@ func (db *DB) UpdateTicketAgentMode(ctx context.Context, id string, mode, agent 
 // during an active debate, use UpdateTicketMetadata which skips
 // description and skips the guard.
 func (db *DB) UpdateTicket(ctx context.Context, t *Ticket) error {
-	active, err := db.IsDebateActive(ctx, t.ID)
-	if err != nil {
-		return fmt.Errorf("checking debate active: %w", err)
-	}
-	if active {
-		var currentDesc string
-		if descErr := db.Pool.QueryRow(ctx,
-			`SELECT description_markdown FROM tickets WHERE id = $1`, t.ID,
-		).Scan(&currentDesc); descErr != nil {
-			return fmt.Errorf("loading ticket description for guard: %w", descErr)
-		}
-		if currentDesc != t.DescriptionMarkdown {
-			return ErrDescriptionLocked
-		}
-	}
-	_, err = db.Pool.Exec(ctx,
-		`UPDATE tickets SET title = $1, description_markdown = $2, priority = $3, date_start = $4, date_end = $5, assigned_to = $6, updated_at = now() WHERE id = $7`,
+	// Atomic guard via conditional WHERE: the update applies only when
+	// the new description matches the stored one (metadata-only case),
+	// or when no active debate exists for this ticket. A debate
+	// starting between check and write cannot slip an overwrite
+	// through — the subquery is evaluated inside the same statement.
+	tag, err := db.Pool.Exec(ctx, `
+		UPDATE tickets
+		   SET title = $1, description_markdown = $2, priority = $3,
+		       date_start = $4, date_end = $5, assigned_to = $6,
+		       updated_at = now()
+		 WHERE id = $7
+		   AND (
+		         description_markdown = $2
+		         OR NOT EXISTS (
+		            SELECT 1 FROM feature_debates
+		             WHERE ticket_id = $7 AND status = 'active'
+		         )
+		       )`,
 		t.Title, t.DescriptionMarkdown, t.Priority, t.DateStart, t.DateEnd, t.AssignedTo, t.ID)
 	if err != nil {
 		return fmt.Errorf("updating ticket: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Either the ticket doesn't exist or the guard blocked the
+		// update. Distinguish by existence check so callers get the
+		// right sentinel.
+		var exists bool
+		if qErr := db.Pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM tickets WHERE id = $1)`, t.ID,
+		).Scan(&exists); qErr != nil {
+			return fmt.Errorf("post-guard existence check: %w", qErr)
+		}
+		if !exists {
+			return pgx.ErrNoRows
+		}
+		return ErrDescriptionLocked
 	}
 	return nil
 }
@@ -1187,18 +1203,32 @@ func (db *DB) UpdateTicketMetadata(ctx context.Context, id, title, priority stri
 // AI assistant tool, future paths) MUST use this method for
 // description changes so the guard is never bypassed.
 func (db *DB) UpdateTicketDescription(ctx context.Context, id, newMarkdown string) error {
-	active, err := db.IsDebateActive(ctx, id)
-	if err != nil {
-		return fmt.Errorf("checking debate active: %w", err)
-	}
-	if active {
-		return ErrDescriptionLocked
-	}
-	_, err = db.Pool.Exec(ctx,
-		`UPDATE tickets SET description_markdown = $1, updated_at = now() WHERE id = $2`,
-		newMarkdown, id)
+	// Atomic guard via NOT EXISTS subquery in the UPDATE. No TOCTOU
+	// window — a debate starting between a check and this call can't
+	// slip an overwrite through because the subquery is part of the
+	// same statement.
+	tag, err := db.Pool.Exec(ctx, `
+		UPDATE tickets
+		   SET description_markdown = $1, updated_at = now()
+		 WHERE id = $2
+		   AND NOT EXISTS (
+		     SELECT 1 FROM feature_debates
+		      WHERE ticket_id = $2 AND status = 'active'
+		   )`, newMarkdown, id)
 	if err != nil {
 		return fmt.Errorf("updating ticket description: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var exists bool
+		if qErr := db.Pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM tickets WHERE id = $1)`, id,
+		).Scan(&exists); qErr != nil {
+			return fmt.Errorf("post-guard existence check: %w", qErr)
+		}
+		if !exists {
+			return pgx.ErrNoRows
+		}
+		return ErrDescriptionLocked
 	}
 	return nil
 }
@@ -1220,27 +1250,30 @@ func (db *DB) UpdateTicketDescription(ctx context.Context, id, newMarkdown strin
 var ErrExternalDescriptionEdit = errors.New("ticket description edited externally since debate started")
 
 func (db *DB) ApproveDebateTx(ctx context.Context, tx pgx.Tx, debateID, ticketID string) error {
+	// Single combined query locks BOTH the debate row and the ticket
+	// row atomically, not sequentially, and removes one round-trip
+	// from the success path. If no debate row matches (wrong id or
+	// wrong ticket_id pairing), pgx.ErrNoRows surfaces to the caller
+	// which maps it to 404/409 as appropriate.
 	var (
 		status       string
 		currentText  string
 		originalDesc string
+		ticketDesc   string
 	)
 	err := tx.QueryRow(ctx, `
-		SELECT status, current_text, original_ticket_description
-		  FROM feature_debates WHERE id = $1`, debateID,
-	).Scan(&status, &currentText, &originalDesc)
+		SELECT fd.status, fd.current_text, fd.original_ticket_description,
+		       t.description_markdown
+		  FROM feature_debates fd
+		  JOIN tickets t ON t.id = fd.ticket_id
+		 WHERE fd.id = $1 AND fd.ticket_id = $2
+		 FOR UPDATE`, debateID, ticketID,
+	).Scan(&status, &currentText, &originalDesc, &ticketDesc)
 	if err != nil {
 		return err
 	}
 	if status != DebateStatusActive {
 		return ErrDebateNotActive
-	}
-
-	var ticketDesc string
-	if tErr := tx.QueryRow(ctx,
-		`SELECT description_markdown FROM tickets WHERE id = $1 FOR UPDATE`, ticketID,
-	).Scan(&ticketDesc); tErr != nil {
-		return tErr
 	}
 	if ticketDesc != originalDesc {
 		return ErrExternalDescriptionEdit
@@ -1267,24 +1300,34 @@ func (db *DB) ApproveDebateTx(ctx context.Context, tx pgx.Tx, debateID, ticketID
 //
 // Caller MUST have opened the tx and already locked the debate row.
 func (db *DB) AbandonDebateTx(ctx context.Context, tx pgx.Tx, debateID string) error {
-	var status string
-	if err := tx.QueryRow(ctx,
-		`SELECT status FROM feature_debates WHERE id = $1`, debateID,
-	).Scan(&status); err != nil {
-		return err
-	}
-	if status != DebateStatusActive {
-		return ErrDebateNotActive
-	}
-	_, err := tx.Exec(ctx, `
+	// Atomic UPDATE with the status filter directly in WHERE. Common
+	// success path is a single statement instead of SELECT-then-UPDATE.
+	// RowsAffected==0 means either the debate is missing or terminal —
+	// one disambiguating SELECT yields the right sentinel.
+	tag, err := tx.Exec(ctx, `
 		UPDATE feature_debates
 		   SET status = 'abandoned',
 		       in_flight_request_id = NULL,
 		       in_flight_started_at = NULL,
 		       updated_at = now()
-		 WHERE id = $1`, debateID,
+		 WHERE id = $1 AND status = 'active'`, debateID,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 1 {
+		return nil
+	}
+	var exists bool
+	if qErr := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM feature_debates WHERE id = $1)`, debateID,
+	).Scan(&exists); qErr != nil {
+		return qErr
+	}
+	if !exists {
+		return pgx.ErrNoRows
+	}
+	return ErrDebateNotActive
 }
 
 // ListAgentReady returns tickets that are ready for agent processing.


### PR DESCRIPTION
Closes #61 once merged.

## Summary

Implements [Task 9 from the plan](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/plans/2026-04-14-feature-debate-mode.md#task-9-featdebate--approve-abandon--description-edit-lockout). Closes the assistant-bypass hole flagged in round-3 spec review — every write path to `tickets.description_markdown` now routes through the model-layer guard.

+490 LOC across 6 files. Full suite green except pre-existing `internal/ai/TestToolDeclarations_*` failures.

## Highlights

- **Single-write-path invariant enforced at the model layer**: new `UpdateTicketDescription` returns `ErrDescriptionLocked` when a debate is active. Existing `UpdateTicket(*Ticket)` still works but now guards against accidental description changes. Metadata stays editable via new `UpdateTicketMetadata`.
- **Compare-and-swap external-edit guard** in `ApproveDebateTx` catches rolling-upgrade edits: if `tickets.description_markdown` no longer equals the debate's `original_ticket_description` snapshot, approve refuses with 409 and explains the Abandon → merge → restart recovery path.
- **Assistant tool updated** to surface `ErrDescriptionLocked` as a structured tool_error payload so the LLM can explain the refusal to the user instead of blindly retrying.
- **Abandon as escape hatch**: force-clears `in_flight_request_id` so orphaned reservations can always be recovered even if the 90s stale-timeout hasn't fired yet.

## Test plan

- [x] `go test ./internal/handlers -run "TestApprove|TestAbandon|TestUpdateTicket"` — 5 new tests pass
- [x] Full suite `go test ./internal/... -p 1 -count=1` green (exc. pre-existing internal/ai failures)
- [x] `golangci-lint run ./...` → 0 issues
- [x] `TestApproveDebate_CASRejectsExternalEdit` pins the rolling-deploy recovery story: raw-UPDATE simulates a bypass, approve refuses, debate stays active
- [x] `TestUpdateTicketDescription_BlockedByActiveDebate` calls the model method directly so it catches bypass attempts from ANY caller, not just a specific handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)