### PR TITLE
feat(ui): v0.3.0 PR-1 — build pipeline + shared chrome

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -1,3 +1,16 @@
+## CSS build stage — compiles static/css/tw.css from tw-input.css via
+## the tailwindcss standalone CLI and DaisyUI bundle. Runs in an Alpine
+## sandbox with just bash + curl, downloading binaries on first build.
+## Output is copied into the Go build stage so the manifest hashing
+## step sees tw.css alongside the hand-written assets.
+FROM alpine:3.21 AS css-builder
+RUN apk add --no-cache bash curl
+WORKDIR /src
+COPY scripts/css.sh ./scripts/
+COPY static/css/tw-input.css ./static/css/
+COPY templates/ ./templates/
+RUN bash scripts/css.sh
+
 FROM golang:1.24.4-alpine3.21 AS builder
 ENV GOTOOLCHAIN=auto
 WORKDIR /app
@@ -5,6 +18,9 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN sh scripts/bundle.sh
+## Pull the compiled Tailwind/DaisyUI stylesheet from the CSS builder
+## stage into static/css/ before the manifest walks the tree.
+COPY --from=css-builder /src/static/css/tw.css ./static/css/tw.css
 RUN CGO_ENABLED=0 go build -o forgedesk ./cmd/server
 RUN CGO_ENABLED=0 go build -o orchestrator ./cmd/orchestrator
 

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -19,7 +19,12 @@ RUN go mod download
 COPY . .
 RUN sh scripts/bundle.sh
 ## Pull the compiled Tailwind/DaisyUI stylesheet from the CSS builder
-## stage into static/css/ before the manifest walks the tree.
+## stage into static/css/. The asset manifest is computed at runtime
+## by internal/static.NewManifest() on server startup (walks /app/static)
+## — not during the Go build — so as long as tw.css is present in the
+## final image at /app/static/css/tw.css, hashing works correctly.
+## This COPY happens AFTER bundle.sh (which only writes bundle.js);
+## their outputs are independent.
 COPY --from=css-builder /src/static/css/tw.css ./static/css/tw.css
 RUN CGO_ENABLED=0 go build -o forgedesk ./cmd/server
 RUN CGO_ENABLED=0 go build -o orchestrator ./cmd/orchestrator

--- a/scripts/css.sh
+++ b/scripts/css.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# css.sh — Build the Tailwind + DaisyUI stylesheet for the debate spike.
+#
+# Downloads the tailwindcss standalone binary and daisyUI bundle into
+# bin/ (gitignored, cached across runs) and runs the compiler against
+# static/css/tw-input.css, producing static/css/tw.css.
+#
+# No Node, no npm, no postcss — just a static binary + two .mjs plugin
+# files. Matches the no-JS-build-step philosophy of the existing
+# scripts/bundle.sh.
+#
+# Usage (must run under bash, not sh/dash — uses pipefail):
+#   bash scripts/css.sh          # one-shot build (minified)
+#   bash scripts/css.sh --watch  # watch mode for local dev
+#   ./scripts/css.sh             # also works if executable bit is set
+
+set -euo pipefail
+
+BIN_DIR="bin"
+mkdir -p "$BIN_DIR"
+
+TAILWIND_BIN="$BIN_DIR/tailwindcss"
+DAISY_BUNDLE="$BIN_DIR/daisyui.mjs"
+DAISY_THEMES="$BIN_DIR/daisyui-theme.mjs"
+
+# --- Download binaries if absent --------------------------------------------
+# We don't auto-update — pinning by absence-check keeps builds reproducible
+# across rebuilds. To refresh, delete bin/ and re-run.
+
+os_arch() {
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)   echo "linux-x64" ;;
+    Linux-aarch64)  echo "linux-arm64" ;;
+    Darwin-x86_64)  echo "macos-x64" ;;
+    Darwin-arm64)   echo "macos-arm64" ;;
+    *)              echo "unknown" ;;
+  esac
+}
+
+if [ ! -x "$TAILWIND_BIN" ]; then
+  arch=$(os_arch)
+  if [ "$arch" = "unknown" ]; then
+    echo "css.sh: unsupported platform $(uname -s)-$(uname -m)" >&2
+    exit 1
+  fi
+  echo "Downloading tailwindcss-$arch..."
+  curl -sSfLo "$TAILWIND_BIN" \
+    "https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-$arch"
+  chmod +x "$TAILWIND_BIN"
+fi
+
+if [ ! -f "$DAISY_BUNDLE" ]; then
+  echo "Downloading daisyui.mjs..."
+  curl -sSfLo "$DAISY_BUNDLE" \
+    "https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.mjs"
+fi
+
+if [ ! -f "$DAISY_THEMES" ]; then
+  echo "Downloading daisyui-theme.mjs..."
+  curl -sSfLo "$DAISY_THEMES" \
+    "https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.mjs"
+fi
+
+# --- Build -----------------------------------------------------------------
+
+INPUT="static/css/tw-input.css"
+OUTPUT="static/css/tw.css"
+
+if [ "${1:-}" = "--watch" ]; then
+  exec "$TAILWIND_BIN" -i "$INPUT" -o "$OUTPUT" --watch
+else
+  "$TAILWIND_BIN" -i "$INPUT" -o "$OUTPUT" --minify
+  echo "Built $OUTPUT ($(wc -c < "$OUTPUT" | tr -d ' ') bytes)"
+fi

--- a/scripts/css.sh
+++ b/scripts/css.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# css.sh — Build the Tailwind + DaisyUI stylesheet for the debate spike.
+# css.sh — Build the Tailwind + DaisyUI stylesheet for ForgeDesk.
 #
 # Downloads the tailwindcss standalone binary and daisyUI bundle into
 # bin/ (gitignored, cached across runs) and runs the compiler against
@@ -23,9 +23,42 @@ TAILWIND_BIN="$BIN_DIR/tailwindcss"
 DAISY_BUNDLE="$BIN_DIR/daisyui.mjs"
 DAISY_THEMES="$BIN_DIR/daisyui-theme.mjs"
 
-# --- Download binaries if absent --------------------------------------------
-# We don't auto-update — pinning by absence-check keeps builds reproducible
-# across rebuilds. To refresh, delete bin/ and re-run.
+# --- Pinned versions + checksums --------------------------------------------
+# Do NOT track `latest` — reproducible builds require explicit versions, and
+# verifying SHA-256 of downloaded artefacts mitigates supply-chain risk
+# (upstream compromise, MITM during build, tag reassignment).
+#
+# To bump: change the version below, delete the matching checksum, run this
+# script, grab the new digest from the failure message, paste it back in.
+# Ship the version bump as its own PR with a changelog pointer.
+
+TAILWIND_VERSION="v4.2.2"
+DAISY_VERSION="v5.5.19"
+
+# Per-arch binary checksums. Today only linux-x64 is verified (our VM + CI +
+# production Containerfile all run linux-x64). Expand when a contributor
+# needs macOS / arm64.
+TAILWIND_SHA256_linux_x64="4ab84f2b496c402d3ec4fd25e0e5559fe1184d886dadae8fb4438344ec044c22"
+
+# .mjs bundles are platform-independent.
+DAISY_BUNDLE_SHA256="5fe43ff5e83c5cf519ccc32d76aa1a82ed6bfc50ee3e6f5dc6007eea6239af1f"
+DAISY_THEMES_SHA256="b4071bef2e59bd83509659c1e726cc19704a1fd14ff2e56d479bc16a6a53f26d"
+
+verify_sha256() {
+  # $1 = path, $2 = expected hex digest
+  local actual
+  actual=$(sha256sum "$1" | awk '{print $1}')
+  if [ "$actual" != "$2" ]; then
+    echo "css.sh: SHA-256 mismatch for $1" >&2
+    echo "  expected: $2" >&2
+    echo "  actual:   $actual" >&2
+    echo "  — either the pinned checksum needs updating (intentional version bump)" >&2
+    echo "    or the download is corrupt / tampered. Delete bin/ and retry to" >&2
+    echo "    confirm, then investigate if it repeats." >&2
+    rm -f "$1"
+    exit 1
+  fi
+}
 
 os_arch() {
   case "$(uname -s)-$(uname -m)" in
@@ -37,28 +70,38 @@ os_arch() {
   esac
 }
 
+# --- Download binaries if absent --------------------------------------------
+# Absence-check keeps builds reproducible across rebuilds — to refresh,
+# delete bin/ and re-run. Checksums verify every download.
+
 if [ ! -x "$TAILWIND_BIN" ]; then
   arch=$(os_arch)
   if [ "$arch" = "unknown" ]; then
     echo "css.sh: unsupported platform $(uname -s)-$(uname -m)" >&2
     exit 1
   fi
-  echo "Downloading tailwindcss-$arch..."
+  echo "Downloading tailwindcss $TAILWIND_VERSION ($arch)..."
   curl -sSfLo "$TAILWIND_BIN" \
-    "https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-$arch"
+    "https://github.com/tailwindlabs/tailwindcss/releases/download/$TAILWIND_VERSION/tailwindcss-$arch"
   chmod +x "$TAILWIND_BIN"
+  case "$arch" in
+    linux-x64) verify_sha256 "$TAILWIND_BIN" "$TAILWIND_SHA256_linux_x64" ;;
+    *) echo "css.sh: no checksum pinned for arch=$arch — run locally only, not in CI" >&2 ;;
+  esac
 fi
 
 if [ ! -f "$DAISY_BUNDLE" ]; then
-  echo "Downloading daisyui.mjs..."
+  echo "Downloading daisyui $DAISY_VERSION bundle..."
   curl -sSfLo "$DAISY_BUNDLE" \
-    "https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.mjs"
+    "https://github.com/saadeghi/daisyui/releases/download/$DAISY_VERSION/daisyui.mjs"
+  verify_sha256 "$DAISY_BUNDLE" "$DAISY_BUNDLE_SHA256"
 fi
 
 if [ ! -f "$DAISY_THEMES" ]; then
-  echo "Downloading daisyui-theme.mjs..."
+  echo "Downloading daisyui $DAISY_VERSION theme bundle..."
   curl -sSfLo "$DAISY_THEMES" \
-    "https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.mjs"
+    "https://github.com/saadeghi/daisyui/releases/download/$DAISY_VERSION/daisyui-theme.mjs"
+  verify_sha256 "$DAISY_THEMES" "$DAISY_THEMES_SHA256"
 fi
 
 # --- Build -----------------------------------------------------------------

--- a/static/css/tw-input.css
+++ b/static/css/tw-input.css
@@ -1,0 +1,110 @@
+/* tw-input.css — Tailwind v4 + DaisyUI v5 source, compiled by
+   scripts/css.sh into static/css/tw.css.
+
+   Currently scoped to the Feature Debate page as a migration spike.
+   Do not import this from any template other than pages/debate.html
+   until the full app migration (v0.3.0) lands. */
+
+@import "tailwindcss";
+
+/* Suppress Tailwind's content scan on our own tooling. The standalone
+   CLI autoscans the working directory for class names; without these
+   excludes it would also walk the compiled daisyui bundle. */
+@source not "../../bin";
+@source not "../../bin/*.mjs";
+
+/* DaisyUI via the bundled .mjs plugins — downloaded by scripts/css.sh
+   into bin/. Path is relative to this CSS file. */
+@plugin "../../bin/daisyui.mjs" {
+  /* Restrict themes to what we actually want to ship:
+       - "corporate" — neutral corporate blue, closest to Linear/Asana
+       - "business"  — darker variant, for dark-mode default
+     Users can flip the active theme via <html data-theme="..."> */
+  themes: corporate --default, business --prefersdark;
+}
+
+/* --- Custom design tokens ------------------------------------------------
+   DaisyUI's `corporate` theme is close to Linear/Notion but reads a
+   little more "banking". Gentle overrides to push it toward the
+   Vercel/Supabase neutral-grayscale look: tighter radii, softer borders. */
+@plugin "../../bin/daisyui-theme.mjs" {
+  name: "forgedesk";
+  default: true;
+  prefersdark: false;
+  color-scheme: light;
+
+  /* Neutral near-white base stack */
+  --color-base-100: oklch(99% 0 0);
+  --color-base-200: oklch(97% 0 0);
+  --color-base-300: oklch(94% 0 0);
+  --color-base-content: oklch(22% 0.02 265);
+
+  /* Primary: cool indigo, Linear/Notion adjacent */
+  --color-primary: oklch(52% 0.22 270);
+  --color-primary-content: oklch(98% 0 0);
+
+  --color-secondary: oklch(62% 0.18 210);
+  --color-secondary-content: oklch(98% 0 0);
+
+  --color-accent: oklch(65% 0.22 160);
+  --color-accent-content: oklch(22% 0.02 265);
+
+  --color-neutral: oklch(28% 0.02 265);
+  --color-neutral-content: oklch(98% 0 0);
+
+  --color-info:    oklch(70% 0.18 220);
+  --color-success: oklch(65% 0.20 150);
+  --color-warning: oklch(78% 0.22 80);
+  --color-error:   oklch(62% 0.25 30);
+  --color-info-content:    oklch(98% 0 0);
+  --color-success-content: oklch(98% 0 0);
+  --color-warning-content: oklch(22% 0.05 80);
+  --color-error-content:   oklch(98% 0 0);
+
+  /* Tighter radii for the Linear feel */
+  --radius-selector: 0.375rem;
+  --radius-field:    0.375rem;
+  --radius-box:      0.5rem;
+
+  --size-selector: 0.25rem;
+  --size-field:    0.25rem;
+
+  --border: 1px;
+  --depth:  1;
+  --noise:  0;
+}
+
+/* --- Overrides for shared helpers that app.css styles dark --------------
+   The renderDiff FuncMap emits HTML with .diff-block/.diff-add/.diff-del/
+   .diff-ctx classes whose default styling in app.css is dark-theme
+   (black background, bright green/red spans). The debate page is now
+   light-theme via DaisyUI, so we restyle those classes here. When the
+   full v0.3.0 migration ships, app.css goes away and these become the
+   primary definitions. */
+.diff-block {
+  background: oklch(97% 0 0);
+  color: oklch(28% 0.02 265);
+  border: 1px solid oklch(92% 0 0);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  overflow-x: auto;
+  white-space: pre;
+  margin: 0;
+}
+.diff-add {
+  display: block;
+  background: oklch(94% 0.06 145);
+  color: oklch(40% 0.15 145);
+}
+.diff-del {
+  display: block;
+  background: oklch(94% 0.08 25);
+  color: oklch(44% 0.18 25);
+}
+.diff-ctx {
+  display: block;
+  color: oklch(55% 0.01 265);
+}

--- a/templates/components/image_modal.html
+++ b/templates/components/image_modal.html
@@ -1,72 +1,124 @@
 {{define "image_modal"}}
-<div x-data="imageInsertModal()" x-show="open" x-cloak class="modal-overlay" @keydown.escape.window="open && closeModal()" @open-image-modal.window="openModal($event.detail.editor, $event.detail.projectID)" aria-modal="true">
-    <div class="modal-backdrop" @click="closeModal()"></div>
-    <div class="modal-card modal-card-wide" @click.stop>
+<div x-data="imageInsertModal()" x-show="open" x-cloak
+     class="fixed inset-0 z-50 flex items-center justify-center p-4"
+     @keydown.escape.window="open && closeModal()"
+     @open-image-modal.window="openModal($event.detail.editor, $event.detail.projectID)"
+     aria-modal="true" role="dialog">
+    <div class="absolute inset-0 bg-black/50" @click="closeModal()"></div>
+    <div class="relative bg-base-100 border border-base-300 rounded-lg shadow-xl
+                w-full max-w-2xl max-h-[85vh] overflow-y-auto p-6"
+         @click.stop>
         <!-- Header -->
-        <div class="flex items-center justify-between mb-md">
-            <h3>Insert Image</h3>
-            <button @click="closeModal()" class="btn-close" aria-label="Close">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold">Insert Image</h3>
+            <button @click="closeModal()" class="btn btn-ghost btn-xs btn-square" aria-label="Close">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
             </button>
         </div>
 
         <!-- Tabs -->
-        <div class="modal-tabs">
-            <button class="modal-tab" :class="{ active: activeTab === 'upload' }" @click="switchTab('upload')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+        <div role="tablist" class="tabs tabs-bordered mb-4">
+            <button role="tab"
+                    class="tab gap-1.5"
+                    :class="{ 'tab-active': activeTab === 'upload' }"
+                    @click="switchTab('upload')">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                    <polyline points="17 8 12 3 7 8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
                 Upload
             </button>
-            <button class="modal-tab" :class="{ active: activeTab === 'generate' }" @click="switchTab('generate')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            <button role="tab"
+                    class="tab gap-1.5"
+                    :class="{ 'tab-active': activeTab === 'generate' }"
+                    @click="switchTab('generate')">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+                </svg>
                 AI Generate
             </button>
         </div>
 
         <!-- Upload panel -->
-        <div x-show="activeTab === 'upload'" style="min-height:12rem">
+        <div x-show="activeTab === 'upload'" class="min-h-48">
             <!-- Drop zone (before file selected) -->
             <div x-show="!file && !uploadedUrl"
-                 class="drop-zone"
+                 class="border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors"
+                 :class="dragover ? 'border-primary bg-primary/5' : 'border-base-300 hover:border-base-content/30'"
                  @dragover.prevent="dragover = true"
                  @dragleave.prevent="dragover = false"
                  @drop.prevent="onDrop($event)"
-                 :class="{ dragover: dragover }"
                  @click="$refs.fileInput.click()">
-                <input type="file" x-ref="fileInput" @change="onFileSelect($event)" accept="image/png,image/jpeg,image/gif,image/webp" style="display:none">
-                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--gray-400)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-                <p class="text-muted mt-sm mb-xs">Drag &amp; drop an image here</p>
-                <p class="text-muted text-xs">or <span class="text-brand" style="cursor:pointer;text-decoration:underline">choose a file</span></p>
+                <input type="file" x-ref="fileInput" class="hidden"
+                       @change="onFileSelect($event)"
+                       accept="image/png,image/jpeg,image/gif,image/webp">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"
+                     class="mx-auto text-base-content/40"
+                     fill="none" stroke="currentColor" stroke-width="1.5"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                    <polyline points="17 8 12 3 7 8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
+                <p class="text-sm text-base-content/70 mt-3 mb-1">Drag &amp; drop an image here</p>
+                <p class="text-xs text-base-content/50">
+                    or <span class="text-primary underline">choose a file</span>
+                </p>
             </div>
 
             <!-- Uploading / Preview -->
             <div x-show="file && !uploadedUrl" class="text-center">
-                <img x-show="preview" :src="preview" class="image-preview mb-sm" alt="Preview">
-                <p class="text-sm text-muted mb-xs" x-text="fileName"></p>
-                <p class="text-xs text-muted mb-sm" x-text="fileSize"></p>
-                <div x-show="uploading" class="text-sm text-muted">Uploading...</div>
+                <img x-show="preview" :src="preview"
+                     class="max-h-48 rounded-md mx-auto mb-3 border border-base-300" alt="Preview">
+                <p class="text-sm text-base-content/70" x-text="fileName"></p>
+                <p class="text-xs text-base-content/50 mb-3" x-text="fileSize"></p>
+                <div x-show="uploading" class="text-sm text-base-content/70 inline-flex items-center gap-2">
+                    <span class="loading loading-spinner loading-xs"></span>
+                    Uploading...
+                </div>
             </div>
 
             <!-- Upload complete -->
             <div x-show="uploadedUrl" class="text-center">
-                <img :src="uploadedUrl" class="image-preview mb-sm" alt="Uploaded">
-                <div class="flex gap-sm justify-center">
-                    <button @click="insert(uploadedUrl, 'image')" class="btn btn-primary">Insert</button>
-                    <button @click="resetUpload()" class="btn btn-secondary">Upload Another</button>
+                <img :src="uploadedUrl"
+                     class="max-h-48 rounded-md mx-auto mb-3 border border-base-300" alt="Uploaded">
+                <div class="flex gap-2 justify-center">
+                    <button @click="insert(uploadedUrl, 'image')" class="btn btn-primary btn-sm">Insert</button>
+                    <button @click="resetUpload()" class="btn btn-ghost btn-sm">Upload Another</button>
                 </div>
             </div>
         </div>
 
         <!-- Generate panel -->
-        <div x-show="activeTab === 'generate'" style="min-height:12rem">
+        <div x-show="activeTab === 'generate'" class="min-h-48">
             <!-- Prompt (before generation) -->
             <div x-show="!generatedUrl">
-                <div class="form-group mb-md">
-                    <label class="form-label">Describe the image you want</label>
-                    <textarea x-model="prompt" class="form-textarea" rows="3" placeholder="A clean diagram showing..."></textarea>
+                <div class="form-control mb-4">
+                    <label class="label pb-1">
+                        <span class="label-text text-sm">Describe the image you want</span>
+                    </label>
+                    <textarea x-model="prompt"
+                              class="textarea textarea-bordered w-full text-sm"
+                              rows="3"
+                              placeholder="A clean diagram showing..."></textarea>
                 </div>
-                <div x-show="generating" class="text-sm text-muted mb-sm">Generating image...</div>
+                <div x-show="generating" class="text-sm text-base-content/70 mb-3 inline-flex items-center gap-2">
+                    <span class="loading loading-spinner loading-xs"></span>
+                    Generating image...
+                </div>
                 <div class="flex justify-end">
-                    <button @click="generate()" class="btn btn-primary" :disabled="generating || !prompt.trim()">
+                    <button @click="generate()"
+                            class="btn btn-primary btn-sm"
+                            :disabled="generating || !prompt.trim()">
                         <span x-show="!generating">Generate</span>
                         <span x-show="generating">Generating...</span>
                     </button>
@@ -75,20 +127,24 @@
 
             <!-- Generation complete -->
             <div x-show="generatedUrl" class="text-center">
-                <img :src="generatedUrl" class="image-preview mb-sm" alt="Generated">
-                <div class="flex gap-sm justify-center">
-                    <button @click="insert(generatedUrl, prompt.substring(0, 40))" class="btn btn-primary">Insert</button>
-                    <button @click="generatedUrl = ''" class="btn btn-secondary">Generate Another</button>
+                <img :src="generatedUrl"
+                     class="max-h-48 rounded-md mx-auto mb-3 border border-base-300" alt="Generated">
+                <div class="flex gap-2 justify-center">
+                    <button @click="insert(generatedUrl, prompt.substring(0, 40))"
+                            class="btn btn-primary btn-sm">Insert</button>
+                    <button @click="generatedUrl = ''" class="btn btn-ghost btn-sm">Generate Another</button>
                 </div>
             </div>
         </div>
 
         <!-- Error -->
-        <div x-show="error" class="text-danger mt-sm text-sm" x-text="error"></div>
+        <div x-show="error" class="alert alert-error alert-sm mt-3">
+            <span x-text="error"></span>
+        </div>
 
         <!-- Footer -->
-        <div class="flex justify-end mt-md">
-            <button @click="closeModal()" class="btn btn-secondary">Cancel</button>
+        <div class="flex justify-end mt-4">
+            <button @click="closeModal()" class="btn btn-ghost btn-sm">Cancel</button>
         </div>
     </div>
 </div>
@@ -158,12 +214,10 @@ function imageInsertModal() {
             this.file = f;
             this.fileName = f.name;
             this.fileSize = this.formatSize(f.size);
-            // Show preview
             var reader = new FileReader();
             var self = this;
             reader.onload = function(e) { self.preview = e.target.result; };
             reader.readAsDataURL(f);
-            // Auto-upload
             this.upload();
         },
 
@@ -177,8 +231,6 @@ function imageInsertModal() {
             window.apiFetch('/api/upload-image', { method: 'POST', body: fd })
                 .then(function(j) {
                     self.uploading = false;
-                    // apiFetch rejects non-2xx responses, so we only get here
-                    // on success — j.error is for application-level errors.
                     if (j.error) { self.error = j.error; return; }
                     self.uploadedUrl = j.data.filePath;
                 })

--- a/templates/components/invitation_list.html
+++ b/templates/components/invitation_list.html
@@ -2,23 +2,25 @@
 {{$canManage := .CanManage}}
 
 {{range .Invitations}}
-<div class="member-row" id="invitation-{{.Invitation.ID}}">
-    <div class="member-info">
-        <p>{{.Invitation.Email}}</p>
-        <p class="text-muted text-sm">Invited by {{.InviterName}} &middot; Role: {{.Invitation.OrgRole}}</p>
+<div class="flex items-center justify-between py-3 px-4 border-b border-base-300 last:border-b-0"
+     id="invitation-{{.Invitation.ID}}">
+    <div class="min-w-0">
+        <p class="font-medium text-sm truncate">{{.Invitation.Email}}</p>
+        <p class="text-xs text-base-content/60 truncate">
+            Invited by {{.InviterName}} · Role: {{.Invitation.OrgRole}}
+        </p>
     </div>
-    <div class="flex items-center gap-md">
-        <span class="badge badge-pill badge-yellow">pending</span>
+    <div class="flex items-center gap-2 shrink-0">
+        <span class="badge badge-warning badge-sm">pending</span>
         {{if $canManage}}
-        <button class="btn btn-ghost btn-sm"
+        <button class="btn btn-ghost btn-xs"
                 hx-post="/orgs/{{$orgSlug}}/invitations/{{.Invitation.ID}}/resend"
                 hx-target="#invitation-list"
                 hx-swap="innerHTML"
                 hx-confirm="Resend invitation to {{.Invitation.Email}}?">
             Resend
         </button>
-        <button class="btn btn-ghost btn-sm"
-                style="color:var(--red-600);"
+        <button class="btn btn-ghost btn-xs text-error"
                 hx-delete="/orgs/{{$orgSlug}}/invitations/{{.Invitation.ID}}"
                 hx-target="#invitation-list"
                 hx-swap="innerHTML"
@@ -29,5 +31,5 @@
     </div>
 </div>
 {{else}}
-<p class="text-muted text-sm" style="padding:.75rem 0;">No pending invitations</p>
+<p class="py-3 text-sm text-base-content/60">No pending invitations</p>
 {{end}}

--- a/templates/components/invite_result.html
+++ b/templates/components/invite_result.html
@@ -1,14 +1,16 @@
-<div class="flash flash-success" style="margin-top:.75rem">
-    <p style="margin-bottom:.5rem">Invitation sent to <strong>{{.Email}}</strong>.</p>
+<div class="alert alert-success mt-3 flex-col items-start gap-2">
+    <p>Invitation sent to <strong>{{.Email}}</strong>.</p>
     {{if .EmailEnabled}}
-    <p class="text-sm text-muted" style="margin-bottom:.5rem">An email has been sent with the invite link.</p>
+    <p class="text-sm opacity-70">An email has been sent with the invite link.</p>
     {{else}}
-    <p class="text-sm text-muted" style="margin-bottom:.5rem">SMTP is not configured — share the link manually.</p>
+    <p class="text-sm opacity-70">SMTP is not configured — share the link manually.</p>
     {{end}}
-    <div class="flex items-center gap-sm" style="margin-top:.5rem">
-        <input type="text" class="form-input" value="{{.InviteURL}}" readonly id="invite-url-input"
-               style="font-size:var(--text-xs);">
-        <button type="button" class="btn btn-sm btn-primary" onclick="navigator.clipboard.writeText(document.getElementById('invite-url-input').value).then(() => this.textContent = 'Copied!')">
+    <div class="flex items-center gap-2 w-full mt-1">
+        <input type="text"
+               class="input input-bordered input-sm flex-1 text-xs font-mono"
+               value="{{.InviteURL}}" readonly id="invite-url-input">
+        <button type="button" class="btn btn-primary btn-sm"
+                onclick="navigator.clipboard.writeText(document.getElementById('invite-url-input').value).then(() => this.textContent = 'Copied!')">
             Copy Link
         </button>
     </div>

--- a/templates/components/member_list.html
+++ b/templates/components/member_list.html
@@ -3,16 +3,17 @@
 {{$orgSlug := .OrgSlug}}
 
 {{range .Members}}
-<div class="member-row" id="member-{{.User.ID}}">
-    <div class="member-info">
-        <p>{{.User.Name}}</p>
-        <p>{{.User.Email}}</p>
+<div class="flex items-center justify-between py-3 px-4 border-b border-base-300 last:border-b-0"
+     id="member-{{.User.ID}}">
+    <div class="min-w-0">
+        <p class="font-medium text-sm truncate">{{.User.Name}}</p>
+        <p class="text-xs text-base-content/60 truncate">{{.User.Email}}</p>
     </div>
-    <div class="flex items-center gap-md">
+    <div class="flex items-center gap-3 shrink-0">
         {{if $canManage}}
             {{if ne .User.ID $currentUserID}}
-                <form class="flex items-center gap-xs">
-                    <select class="form-select" style="width:auto; padding:.325rem .5rem; font-size:var(--text-xs);"
+                <form class="flex items-center">
+                    <select class="select select-bordered select-xs"
                             name="role"
                             hx-patch="/orgs/{{$orgSlug}}/members/{{.User.ID}}/role"
                             hx-target="#member-list"
@@ -23,18 +24,17 @@
                     </select>
                 </form>
             {{else}}
-                <span class="badge badge-pill badge-gray">{{.Membership.Role}}</span>
+                <span class="badge badge-ghost badge-sm">{{.Membership.Role}}</span>
             {{end}}
         {{else}}
-            <span class="badge badge-pill badge-gray">{{.Membership.Role}}</span>
+            <span class="badge badge-ghost badge-sm">{{.Membership.Role}}</span>
         {{end}}
 
-        <span class="badge badge-pill badge-indigo">{{.User.Role}}</span>
+        <span class="badge badge-primary badge-sm">{{.User.Role}}</span>
 
         {{if $canManage}}
             {{if ne .User.ID $currentUserID}}
-                <button class="btn btn-ghost btn-sm"
-                        style="color:var(--red-600);"
+                <button class="btn btn-ghost btn-xs text-error"
                         hx-delete="/orgs/{{$orgSlug}}/members/{{.User.ID}}"
                         hx-target="#member-list"
                         hx-swap="innerHTML"
@@ -46,7 +46,7 @@
     </div>
 </div>
 {{else}}
-<div class="empty-state" style="padding:1.5rem;">
-    <p>No members yet</p>
+<div class="py-6 px-4 text-center text-sm text-base-content/60">
+    No members yet
 </div>
 {{end}}

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,6 +1,11 @@
-<div x-show="open" x-transition class="modal-overlay" aria-modal="true">
-    <div class="modal-backdrop" @click="open = false"></div>
-    <div class="modal-card">
+{{/* Generic modal overlay. Consumers wrap their trigger with Alpine
+     x-data="{ open: false }" and override the modal_content block. */}}
+<div x-show="open" x-transition x-cloak
+     class="fixed inset-0 z-50 flex items-center justify-center p-4"
+     aria-modal="true" role="dialog">
+    <div class="absolute inset-0 bg-black/50" @click="open = false"></div>
+    <div class="relative bg-base-100 border border-base-300 rounded-lg shadow-xl
+                w-full max-w-lg max-h-[85vh] overflow-y-auto p-6">
         {{block "modal_content" .}}{{end}}
     </div>
 </div>

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -1,33 +1,43 @@
 {{define "base"}}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="forgedesk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Title}} — ForgeDesk</title>
+    {{/* Legacy hand-written app.css loaded first — pages not yet
+         migrated to Tailwind still depend on it. Removed in PR-6
+         when every template has been migrated. */}}
     <link rel="stylesheet" href="{{asset "css/app.css"}}">
+    <link rel="stylesheet" href="{{asset "css/tw.css"}}">
     {{highlightCSS}}
     <script src="{{asset "js/bundle.js"}}" defer></script>
     <meta name="htmx-config" content='{"historyCacheSize":0}'>
     {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}">{{end}}
     {{block "page_head" .}}{{end}}
 </head>
-<body hx-boost="true">
+<body hx-boost="true" class="min-h-screen bg-base-100 text-base-content antialiased">
     {{if .User}}
-    <div class="app-shell">
-        <aside class="sidebar">
-            <div class="sidebar-brand">
-                <a href="/">ForgeDesk</a>
+    <div class="min-h-screen flex">
+        {{/* Sidebar: scoped to DaisyUI's `business` theme regardless of
+             the content-area theme, producing the Linear/Supabase dark-
+             chrome + light-content split. */}}
+        <aside class="w-60 shrink-0 flex flex-col border-r border-base-300"
+               data-theme="business">
+            <div class="p-4 border-b border-base-300">
+                <a href="/" class="text-lg font-semibold tracking-tight">ForgeDesk</a>
             </div>
 
-            <nav class="sidebar-nav">
+            <nav class="flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1 text-sm">
                 {{if .Orgs}}
                 {{if and .User (or (eq .User.Role "superadmin") (eq .User.Role "staff"))}}
                 {{if gt (len .Orgs) 1}}
-                <div class="sidebar-org-selector">
+                <div class="mb-3">
                     <form method="POST" action="/switch-org" hx-boost="false">
                         {{csrfField}}
-                        <select name="org_id" class="sidebar-org-select" onchange="this.form.submit()">
+                        <select name="org_id"
+                                class="select select-sm select-bordered w-full bg-base-200"
+                                onchange="this.form.submit()">
                             <option value="">Select organization...</option>
                             {{range .Orgs}}
                             <option value="{{.ID}}" {{if and $.Org (eq $.Org.ID .ID)}}selected{{end}}>{{.Name}}</option>
@@ -37,86 +47,102 @@
                 </div>
                 {{else}}
                 {{if .Org}}
-                <div class="sidebar-org-selector">
-                    <div class="sidebar-org-name">{{.Org.Name}}</div>
+                <div class="mb-3 px-2 py-1 text-xs uppercase tracking-wider text-base-content/60 font-medium">
+                    {{.Org.Name}}
                 </div>
                 {{end}}
                 {{end}}
                 {{else}}
-                {{/* Client user: show org name if selected */}}
                 {{if .Org}}
-                <div class="sidebar-org-selector">
-                    <div class="sidebar-org-name">{{.Org.Name}}</div>
+                <div class="mb-3 px-2 py-1 text-xs uppercase tracking-wider text-base-content/60 font-medium">
+                    {{.Org.Name}}
                 </div>
                 {{end}}
                 {{end}}
                 {{end}}
 
                 {{if and .Org .Projects}}
-                <div class="sidebar-section-label">Projects</div>
+                <div class="px-2 pt-2 text-xs uppercase tracking-wider text-base-content/50 font-medium">Projects</div>
                 {{range .Projects}}
                 <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/brief"
-                   class="sidebar-link {{if and $.ActiveProject (eq $.ActiveProject.ID .ID)}}active{{end}}">
+                   class="px-2 py-1.5 rounded-md hover:bg-base-200 transition-colors
+                          {{if and $.ActiveProject (eq $.ActiveProject.ID .ID)}}bg-base-200 font-medium{{end}}">
                     {{.Name}}
                 </a>
                 {{if and $.ActiveProject (eq $.ActiveProject.ID .ID)}}
-                <div class="sidebar-sub-links">
+                <div class="flex flex-col gap-0.5 ml-3 mb-2 border-l border-base-300 pl-2">
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/brief"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "brief"}}active{{end}}">Brief</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "brief"}}text-primary font-medium{{end}}">Brief</a>
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/features"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "features"}}active{{end}}">Features</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "features"}}text-primary font-medium{{end}}">Features</a>
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/bugs"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "bugs"}}active{{end}}">Bugs</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "bugs"}}text-primary font-medium{{end}}">Bugs</a>
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/gantt"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "gantt"}}active{{end}}">Timeline</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "gantt"}}text-primary font-medium{{end}}">Timeline</a>
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/costs"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "costs"}}active{{end}}">Costs</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "costs"}}text-primary font-medium{{end}}">Costs</a>
                     {{if or (eq $.User.Role "superadmin") (eq $.User.Role "staff")}}
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/archived"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "archived"}}active{{end}}">Archived</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "archived"}}text-primary font-medium{{end}}">Archived</a>
                     <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/settings"
-                       class="sidebar-sub-link {{if eq $.ActiveTab "settings"}}active{{end}}">Settings</a>
+                       class="px-2 py-1 text-xs rounded hover:bg-base-200 {{if eq $.ActiveTab "settings"}}text-primary font-medium{{end}}">Settings</a>
                     {{end}}
                 </div>
                 {{end}}
                 {{end}}
                 {{else if .Org}}
-                <div class="sidebar-section-label">Projects</div>
-                <div class="sidebar-empty-hint">No projects yet</div>
+                <div class="px-2 pt-2 text-xs uppercase tracking-wider text-base-content/50 font-medium">Projects</div>
+                <div class="px-2 py-1 text-xs text-base-content/60">No projects yet</div>
                 {{end}}
 
                 {{if .Org}}
-                <div class="sidebar-section-label" style="margin-top:1rem">Organization</div>
-                <a href="/orgs/{{.Org.Slug}}/costs" class="sidebar-link {{if hasPrefix .CurrentPath (printf "/orgs/%s/costs" .Org.Slug)}}active{{end}}">Costs</a>
-                <a href="/orgs/{{.Org.Slug}}/settings" class="sidebar-link {{if hasPrefix .CurrentPath (printf "/orgs/%s/settings" .Org.Slug)}}active{{end}}">Settings</a>
+                <div class="px-2 pt-4 text-xs uppercase tracking-wider text-base-content/50 font-medium">Organization</div>
+                <a href="/orgs/{{.Org.Slug}}/costs"
+                   class="px-2 py-1.5 rounded-md hover:bg-base-200 {{if hasPrefix .CurrentPath (printf "/orgs/%s/costs" .Org.Slug)}}bg-base-200 font-medium{{end}}">Costs</a>
+                <a href="/orgs/{{.Org.Slug}}/settings"
+                   class="px-2 py-1.5 rounded-md hover:bg-base-200 {{if hasPrefix .CurrentPath (printf "/orgs/%s/settings" .Org.Slug)}}bg-base-200 font-medium{{end}}">Settings</a>
                 {{end}}
 
                 {{if eq .User.Role "superadmin"}}
-                <div class="sidebar-section-label" style="margin-top:1rem">Admin</div>
-                <a href="/admin" class="sidebar-link {{if hasPrefix .CurrentPath "/admin"}}active{{end}}">Admin Panel</a>
+                <div class="px-2 pt-4 text-xs uppercase tracking-wider text-base-content/50 font-medium">Admin</div>
+                <a href="/admin"
+                   class="px-2 py-1.5 rounded-md hover:bg-base-200 {{if hasPrefix .CurrentPath "/admin"}}bg-base-200 font-medium{{end}}">Admin Panel</a>
                 {{end}}
             </nav>
 
-            <div class="sidebar-footer" x-data="{ open: false }">
-                <button @click="open = !open" class="user-trigger">
-                    <span class="user-avatar">{{slice .User.Name 0 1}}</span>
-                    <span class="truncate">{{.User.Name}}</span>
+            <div class="p-3 border-t border-base-300 relative" x-data="{ open: false }">
+                <button @click="open = !open"
+                        class="w-full flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-base-200 transition-colors">
+                    <span class="w-7 h-7 rounded-full bg-primary text-primary-content
+                                 flex items-center justify-center text-xs font-semibold shrink-0">
+                        {{slice .User.Name 0 1}}
+                    </span>
+                    <span class="truncate text-sm">{{.User.Name}}</span>
                 </button>
-                <div x-show="open" @click.outside="open = false" x-transition class="user-menu">
-                    <a href="/account/settings">Account Settings</a>
+                <div x-show="open" @click.outside="open = false" x-transition x-cloak
+                     class="absolute bottom-full left-3 right-3 mb-2 bg-base-100 border border-base-300
+                            rounded-md shadow-lg py-1 z-50">
+                    <a href="/account/settings"
+                       class="block px-3 py-2 text-sm hover:bg-base-200 text-base-content">Account Settings</a>
                     <form method="POST" action="/logout">
                         {{csrfField}}
-                        <button type="submit">Sign Out</button>
+                        <button type="submit"
+                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-200 text-base-content">
+                            Sign Out
+                        </button>
                     </form>
                 </div>
             </div>
         </aside>
 
-        <main class="main-area">
+        <main class="flex-1 min-w-0 overflow-x-hidden">
             {{if .Flash}}
-            <div class="main-content" style="padding-bottom:0">
-                <div class="flash {{if eq .FlashType "error"}}flash-error{{else if eq .FlashType "warning"}}flash-warning{{else}}flash-success{{end}}">
-                    {{.Flash}}
+            <div class="px-6 pt-6">
+                <div class="alert
+                            {{if eq .FlashType "error"}}alert-error
+                            {{else if eq .FlashType "warning"}}alert-warning
+                            {{else}}alert-success{{end}}">
+                    <span>{{.Flash}}</span>
                 </div>
             </div>
             {{end}}
@@ -130,57 +156,91 @@
         {{$av := asset "img/simona-avatar.png"}}
         <div id="assistant-project-ctx" data-project-id="{{.ProjectID}}"></div>
         <div id="assistant-widget" hx-preserve="true" x-data="chatWidget()" x-init="init()" x-cloak
-             data-user-id="{{.User.ID}}" data-user-name="{{.User.Name}}">
+             data-user-id="{{.User.ID}}" data-user-name="{{.User.Name}}"
+             class="fixed bottom-6 right-6 z-40">
             <!-- FAB -->
-            <button @click="toggle()" class="chat-fab" :aria-label="open ? 'Close assistant' : 'Open assistant'">
-                <img x-show="!open" src="{{$av}}" alt="Simona" class="chat-fab-avatar">
-                <svg x-show="open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-                <span x-show="!open && unreadCount > 0" x-text="unreadCount > 99 ? '99+' : unreadCount" x-transition class="chat-badge"></span>
+            <button @click="toggle()"
+                    :aria-label="open ? 'Close assistant' : 'Open assistant'"
+                    class="relative w-14 h-14 rounded-full bg-primary text-primary-content shadow-lg
+                           hover:scale-105 active:scale-95 transition-transform
+                           flex items-center justify-center">
+                <img x-show="!open" src="{{$av}}" alt="Simona" class="w-10 h-10 rounded-full object-cover">
+                <svg x-show="open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+                <span x-show="!open && unreadCount > 0" x-text="unreadCount > 99 ? '99+' : unreadCount"
+                      x-transition
+                      class="absolute -top-1 -right-1 min-w-5 h-5 px-1 rounded-full bg-error
+                             text-error-content text-xs font-semibold
+                             flex items-center justify-center"></span>
             </button>
 
             <!-- Chat Panel -->
-            <div x-show="open" x-transition.opacity class="chat-panel" :class="{ 'chat-panel-enlarged': enlarged }">
-                <div class="chat-header">
-                    <div class="chat-header-identity">
-                        <img src="{{$av}}" alt="Simona" class="chat-header-avatar">
-                        <span class="chat-header-title">Simona</span>
+            <div x-show="open" x-transition.opacity x-cloak
+                 :class="enlarged ? 'w-[min(90vw,880px)] h-[min(85vh,720px)]' : 'w-96 h-[32rem]'"
+                 class="absolute bottom-16 right-0 bg-base-100 border border-base-300 rounded-lg shadow-xl
+                        flex flex-col overflow-hidden">
+                <div class="flex items-center justify-between px-4 py-3 border-b border-base-300 bg-base-200">
+                    <div class="flex items-center gap-2">
+                        <img src="{{$av}}" alt="Simona" class="w-7 h-7 rounded-full object-cover">
+                        <span class="font-semibold text-sm">Simona</span>
                     </div>
-                    <div class="chat-header-actions">
-                        <button @click="toggleEnlarge()" class="chat-header-btn" :title="enlarged ? 'Shrink' : 'Enlarge'">
-                            <svg x-show="!enlarged" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
-                            <svg x-show="enlarged" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+                    <div class="flex items-center gap-1">
+                        <button @click="toggleEnlarge()"
+                                class="btn btn-ghost btn-xs btn-square"
+                                :title="enlarged ? 'Shrink' : 'Enlarge'">
+                            <svg x-show="!enlarged" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                                 class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                                 stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/>
+                                <line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/>
+                            </svg>
+                            <svg x-show="enlarged" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                                 class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                                 stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/>
+                                <line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/>
+                            </svg>
                         </button>
-                        <button @click="toggle()" class="chat-header-btn" title="Close">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                        <button @click="toggle()" class="btn btn-ghost btn-xs btn-square" title="Close">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                                 class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                                 stroke-linecap="round" stroke-linejoin="round">
+                                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                            </svg>
                         </button>
                     </div>
                 </div>
 
-                <div class="chat-messages" x-ref="chatMessages">
+                <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-3" x-ref="chatMessages">
                     <template x-if="messages.length === 0 && !streamingText && !loading">
-                        <div class="chat-empty">
-                            <img src="{{$av}}" alt="Simona" class="chat-empty-avatar">
+                        <div class="flex flex-col items-center text-center text-sm text-base-content/60 py-8 gap-2">
+                            <img src="{{$av}}" alt="Simona" class="w-16 h-16 rounded-full object-cover">
                             <p>Hi, I'm <strong>Simona</strong>. Ask me anything about this project.</p>
                         </div>
                     </template>
                     <template x-for="(msg, i) in messages" :key="msg.id || i">
                         <div>
                             <template x-if="msg.role === 'assistant'">
-                                <div class="chat-msg-row chat-msg-row-assistant">
-                                    <img src="{{$av}}" alt="Simona" class="chat-msg-avatar">
-                                    <div class="chat-msg chat-msg-assistant">
+                                <div class="flex gap-2">
+                                    <img src="{{$av}}" alt="Simona" class="w-7 h-7 rounded-full object-cover shrink-0">
+                                    <div class="bg-base-200 rounded-lg px-3 py-2 text-sm max-w-[85%]">
                                         <div x-html="renderMd(msg.content, msg.role)"></div>
                                     </div>
                                 </div>
                             </template>
                             <template x-if="msg.role === 'user'">
-                                <div class="chat-msg chat-msg-user"
+                                <div class="rounded-lg px-3 py-2 text-sm max-w-[85%] ml-auto
+                                            bg-primary text-primary-content"
                                      :class="{
-                                        'chat-msg-self': msg.user_id === _currentUserID,
-                                        'chat-msg-other': msg.user_id && msg.user_id !== _currentUserID
+                                        'ml-auto': msg.user_id === _currentUserID || !msg.user_id,
+                                        'mr-auto bg-base-200 text-base-content':
+                                            msg.user_id && msg.user_id !== _currentUserID
                                      }">
                                     <template x-if="msg.user_name">
-                                        <div class="chat-msg-author" x-text="msg.user_name"></div>
+                                        <div class="text-xs font-medium opacity-70 mb-0.5" x-text="msg.user_name"></div>
                                     </template>
                                     <div x-html="renderMd(msg.content, msg.role)"></div>
                                 </div>
@@ -188,25 +248,24 @@
                         </div>
                     </template>
                     <template x-if="streamingText">
-                        <div class="chat-msg-row chat-msg-row-assistant">
-                            <img src="{{$av}}" alt="Simona" class="chat-msg-avatar">
-                            <div class="chat-msg chat-msg-streaming" x-html="renderMd(streamingText, 'assistant')"></div>
+                        <div class="flex gap-2">
+                            <img src="{{$av}}" alt="Simona" class="w-7 h-7 rounded-full object-cover shrink-0">
+                            <div class="bg-base-200 rounded-lg px-3 py-2 text-sm max-w-[85%]"
+                                 x-html="renderMd(streamingText, 'assistant')"></div>
                         </div>
                     </template>
                     <template x-if="loading && !streamingText">
-                        <div class="chat-msg-row chat-msg-row-assistant">
-                            <img src="{{$av}}" alt="Simona" class="chat-msg-avatar">
-                            <div class="chat-typing">
-                                <div class="chat-typing-dot"></div>
-                                <div class="chat-typing-dot"></div>
-                                <div class="chat-typing-dot"></div>
+                        <div class="flex gap-2">
+                            <img src="{{$av}}" alt="Simona" class="w-7 h-7 rounded-full object-cover shrink-0">
+                            <div class="flex items-center gap-1 bg-base-200 rounded-lg px-3 py-2">
+                                <span class="loading loading-dots loading-xs text-base-content/50"></span>
                             </div>
                         </div>
                     </template>
                 </div>
 
-                <div class="chat-input-area">
-                    <div class="chat-input-wrap">
+                <div class="border-t border-base-300 p-3">
+                    <div class="flex gap-2 items-end">
                         <textarea
                             x-ref="chatInput"
                             x-model="input"
@@ -214,9 +273,17 @@
                             placeholder="Ask something..."
                             rows="1"
                             :disabled="loading"
+                            class="textarea textarea-bordered textarea-sm flex-1 resize-none max-h-32"
                         ></textarea>
-                        <button @click="send()" class="chat-send-btn" :disabled="loading || !input.trim()">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+                        <button @click="send()"
+                                class="btn btn-primary btn-sm btn-square"
+                                :disabled="loading || !input.trim()">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                                 class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                                 stroke-linecap="round" stroke-linejoin="round">
+                                <line x1="22" y1="2" x2="11" y2="13"/>
+                                <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+                            </svg>
                         </button>
                     </div>
                 </div>
@@ -225,14 +292,17 @@
         {{end}}
     </div>
     {{else}}
-    <div class="auth-page">
-        <div class="auth-card">
-            {{if .Flash}}
-            <div class="flash {{if eq .FlashType "error"}}flash-error{{else}}flash-success{{end}}">
-                {{.Flash}}
+    <div class="min-h-screen flex items-center justify-center p-4 bg-base-200">
+        <div class="card bg-base-100 shadow-lg w-full max-w-md">
+            <div class="card-body">
+                {{if .Flash}}
+                <div class="alert alert-sm
+                            {{if eq .FlashType "error"}}alert-error{{else}}alert-success{{end}}">
+                    <span>{{.Flash}}</span>
+                </div>
+                {{end}}
+                {{template "content" .}}
             </div>
-            {{end}}
-            {{template "content" .}}
         </div>
     </div>
     {{end}}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -115,7 +115,7 @@
                         class="w-full flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-base-200 transition-colors">
                     <span class="w-7 h-7 rounded-full bg-primary text-primary-content
                                  flex items-center justify-center text-xs font-semibold shrink-0">
-                        {{slice .User.Name 0 1}}
+                        {{if .User.Name}}{{slice .User.Name 0 1}}{{else}}?{{end}}
                     </span>
                     <span class="truncate text-sm">{{.User.Name}}</span>
                 </button>


### PR DESCRIPTION
## Scope — closes #83

First PR of the v0.3.0 UI migration. Establishes the build pipeline, loads Tailwind v4 + DaisyUI v5 globally, and migrates the shared chrome (base.html + 5 reusable components). All other pages still render with \`app.css\` until their own PR.

Per spec: [\`docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md §6 PR-1\`](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md)

## What changed

| File | Change |
|---|---|
| \`scripts/css.sh\` | **NEW** — downloads tailwindcss + daisyUI bundles, compiles tw.css. Self-bootstrapping, no Node |
| \`static/css/tw-input.css\` | **NEW** — forgedesk theme (light default + business dark), light-themed diff overrides |
| \`deploy/Containerfile\` | **MOD** — new \`css-builder\` stage runs scripts/css.sh before Go build |
| \`templates/layouts/base.html\` | **REWRITE** — Tailwind+DaisyUI utilities, sidebar scoped to \`data-theme=\"business\"\`, chat FAB restyled |
| \`templates/components/modal.html\` | **REWRITE** — DaisyUI overlay + card |
| \`templates/components/image_modal.html\` | **REWRITE** — DaisyUI tabs + form controls, Alpine state + JS logic preserved |
| \`templates/components/member_list.html\` | **REWRITE** — DaisyUI badges + row layout |
| \`templates/components/invitation_list.html\` | **REWRITE** — DaisyUI badges + row layout |
| \`templates/components/invite_result.html\` | **REWRITE** — DaisyUI alert + input group |

**498 insertions, 167 deletions across 9 files.**

## Dual-stylesheet strategy (mid-migration only)

\`base.html\` loads **both** \`app.css\` AND \`tw.css\`. Unmigrated pages (auth, dashboard, project, ticket, debate) still depend on \`app.css\`; the chrome and migrated components use \`tw.css\`. \`app.css\` gets deleted entirely in PR-6 when every template has been migrated.

Tailwind's Preflight globally resets some elements (heading margins, list bullets, button defaults). If a downstream page looks off after this merges, the fix belongs in *that page's* migration PR, not here.

## Known mid-migration oddity

The debate page currently renders rough because its \`.round\` CSS class (from \`app.css\`) uses a dark surface color that clashes with the new light forgedesk theme. **This is fixed in PR-5** (ticket + debate migration) where debate templates move to DaisyUI classes. Screenshot below shows this explicitly so nobody thinks it's a regression.

## Architecture decisions in play

- **Dark sidebar via theme scope**: \`<aside class=\"sidebar\" data-theme=\"business\">\` — DaisyUI looks up the nearest \`data-theme\` ancestor, so sidebar always sees \`business\` tokens while content sees \`forgedesk\` (or \`business\` in dark mode too). Linear/Vercel pattern.
- **OS-preference dark mode**: \`themes: forgedesk --default, business --prefersdark\` in tw-input.css. No user toggle in v0.3.0 (deferred — spec §2).
- **Forgedesk theme**: Custom OKLCH palette, cool indigo primary, tighter radii. Will refine when brand colors land (one CSS block, ~30 lines).

## Screenshots

See \`pr1-base-sidebar.png\` attachment below (included via PR comment in next step — GitHub markdown doesn't embed local files).

Sidebar shows:
- Dark \`business\`-theme scope on \`<aside>\`
- ForgeDesk brand, nav sections (Admin, Projects, Organization)
- User pill at bottom with avatar + hover state
- Click-outside dismissible user menu via Alpine

Main content area shows the debate page (unmigrated — see oddity note above).

## Test plan

- [x] \`bash scripts/css.sh\` builds \`tw.css\` (370ms, 115KB minified)
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\` clean (0 issues)
- [x] Full handler test suite passes (exercises base.html rendering via real auth flow)
- [x] Preview server smoke test: sidebar renders, nav links, user menu, flash styling, assistant FAB all work
- [ ] Docker build from clean checkout: \`docker build -f deploy/Containerfile .\` produces a working image with tw.css in \`static/css/\`

## What this unblocks

All 5 remaining PRs (PR-2 through PR-6) depend on this merging first. Tailwind utilities + DaisyUI components are the toolbox they'll all use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)