### PR TITLE
feat(ui): v0.3.0 PR-2 — migrate auth pages

### DIFF
--- a/templates/auth/invite_register.html
+++ b/templates/auth/invite_register.html
@@ -1,35 +1,46 @@
 {{define "content"}}
-<div class="stack-xl text-center">
+<div class="flex flex-col gap-8 text-center">
     <div>
-        <h1 style="font-size:var(--text-3xl)">Join {{with .Data}}{{.OrgName}}{{end}}</h1>
+        <h1 class="text-2xl font-semibold tracking-tight">
+            Join {{with .Data}}{{.OrgName}}{{end}}
+        </h1>
         {{with .Data}}
         {{if .InviterName}}
-        <p class="text-muted" style="margin-top:.5rem">
+        <p class="text-sm text-base-content/60 mt-2">
             {{.InviterName}} invited you to join this organization
         </p>
         {{end}}
         {{end}}
     </div>
     {{if .Flash}}{{else}}
-    <form method="POST" action="/invite/{{with .Data}}{{.Token}}{{end}}" class="stack-lg" style="text-align:left">
+    <form method="POST" action="/invite/{{with .Data}}{{.Token}}{{end}}" class="flex flex-col gap-4 text-left">
         {{csrfField}}
-        <div class="form-group">
-            <label for="name" class="form-label">Full name</label>
-            <input id="name" name="name" type="text" required class="form-input">
+        <div class="form-control">
+            <label for="name" class="label pb-1">
+                <span class="label-text">Full name</span>
+            </label>
+            <input id="name" name="name" type="text" required class="input input-bordered w-full">
         </div>
-        <div class="form-group">
-            <label for="email" class="form-label">Email address</label>
-            <input id="email" type="email" class="form-input" value="{{with .Data}}{{.Email}}{{end}}" disabled>
+        <div class="form-control">
+            <label for="email" class="label pb-1">
+                <span class="label-text">Email address</span>
+            </label>
+            <input id="email" type="email" disabled
+                   class="input input-bordered w-full bg-base-200"
+                   value="{{with .Data}}{{.Email}}{{end}}">
         </div>
-        <div class="form-group">
-            <label for="password" class="form-label">Password <span class="form-label-hint">(min 12 characters)</span></label>
+        <div class="form-control">
+            <label for="password" class="label pb-1">
+                <span class="label-text">Password</span>
+                <span class="label-text-alt text-base-content/60">min 12 characters</span>
+            </label>
             <input id="password" name="password" type="password" required minlength="12"
-                   class="form-input" autocomplete="new-password">
+                   class="input input-bordered w-full" autocomplete="new-password">
         </div>
-        <button type="submit" class="btn btn-primary btn-block">Create account &amp; join</button>
+        <button type="submit" class="btn btn-primary btn-block mt-2">Create account &amp; join</button>
     </form>
-    <p class="text-muted" style="margin-top:.5rem">
-        Already have an account? <a href="/login" class="btn-link">Sign in</a>
+    <p class="text-sm text-base-content/60">
+        Already have an account? <a href="/login" class="link link-primary">Sign in</a>
     </p>
     {{end}}
 </div>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,20 +1,22 @@
 {{define "content"}}
-<div class="stack-xl text-center">
+<div class="flex flex-col gap-8 text-center">
     <div>
-        <h1 style="font-size:var(--text-3xl)">Sign in to ForgeDesk</h1>
-        <p class="text-muted" style="margin-top:.5rem">
-            Or <a href="/register" class="btn-link">create an account</a>
+        <h1 class="text-2xl font-semibold tracking-tight">Sign in to ForgeDesk</h1>
+        <p class="text-sm text-base-content/60 mt-2">
+            Or <a href="/register" class="link link-primary">create an account</a>
         </p>
     </div>
-    <form method="POST" action="/login" class="stack-lg">
+    <form method="POST" action="/login" class="flex flex-col gap-4">
         {{csrfField}}
-        <div class="form-stacked">
+        <div class="flex flex-col gap-2">
             <label for="email" class="sr-only">Email address</label>
             <input id="email" name="email" type="email" required
-                   class="form-input" placeholder="Email address" autocomplete="email">
+                   class="input input-bordered w-full"
+                   placeholder="Email address" autocomplete="email">
             <label for="password" class="sr-only">Password</label>
             <input id="password" name="password" type="password" required
-                   class="form-input" placeholder="Password" autocomplete="current-password">
+                   class="input input-bordered w-full"
+                   placeholder="Password" autocomplete="current-password">
         </div>
         <button type="submit" class="btn btn-primary btn-block">Sign in</button>
     </form>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -8,17 +8,19 @@
     </div>
     <form method="POST" action="/login" class="flex flex-col gap-4">
         {{csrfField}}
-        <div class="flex flex-col gap-2">
+        <div class="form-control">
             <label for="email" class="sr-only">Email address</label>
             <input id="email" name="email" type="email" required
                    class="input input-bordered w-full"
                    placeholder="Email address" autocomplete="email">
+        </div>
+        <div class="form-control">
             <label for="password" class="sr-only">Password</label>
             <input id="password" name="password" type="password" required
                    class="input input-bordered w-full"
                    placeholder="Password" autocomplete="current-password">
         </div>
-        <button type="submit" class="btn btn-primary btn-block">Sign in</button>
+        <button type="submit" class="btn btn-primary btn-block mt-2">Sign in</button>
     </form>
 </div>
 {{end}}

--- a/templates/auth/recovery_codes.html
+++ b/templates/auth/recovery_codes.html
@@ -11,7 +11,7 @@
         <div class="card-body p-4">
             <div class="grid grid-cols-2 gap-2">
                 {{range .Data}}
-                <code class="font-mono text-xs px-3 py-2 bg-base-100 border border-base-300 rounded text-center select-all">{{.}}</code>
+                <code class="recovery-code font-mono text-xs px-3 py-2 bg-base-100 border border-base-300 rounded text-center select-all">{{.}}</code>
                 {{end}}
             </div>
         </div>

--- a/templates/auth/recovery_codes.html
+++ b/templates/auth/recovery_codes.html
@@ -1,15 +1,19 @@
 {{define "content"}}
-<div class="container-narrow">
-    <h1 class="mb-sm">Save Your Recovery Codes</h1>
-    <div class="flash flash-warning mb-lg">
-        These codes are shown only once. Save them somewhere safe. Each code can only be used once.
+<div class="flex flex-col gap-4">
+    <h1 class="text-2xl font-semibold tracking-tight">Save Your Recovery Codes</h1>
+    <div class="alert alert-warning">
+        <span class="text-sm">
+            These codes are shown only once. Save them somewhere safe. Each code can only be used once.
+        </span>
     </div>
 
-    <div class="card mb-lg">
-        <div class="recovery-grid">
-            {{range .Data}}
-            <code class="recovery-code">{{.}}</code>
-            {{end}}
+    <div class="card bg-base-200 border border-base-300">
+        <div class="card-body p-4">
+            <div class="grid grid-cols-2 gap-2">
+                {{range .Data}}
+                <code class="font-mono text-xs px-3 py-2 bg-base-100 border border-base-300 rounded text-center select-all">{{.}}</code>
+                {{end}}
+            </div>
         </div>
     </div>
 

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -1,27 +1,35 @@
 {{define "content"}}
-<div class="stack-xl text-center">
+<div class="flex flex-col gap-8 text-center">
     <div>
-        <h1 style="font-size:var(--text-3xl)">Create your account</h1>
-        <p class="text-muted" style="margin-top:.5rem">
-            Already have an account? <a href="/login" class="btn-link">Sign in</a>
+        <h1 class="text-2xl font-semibold tracking-tight">Create your account</h1>
+        <p class="text-sm text-base-content/60 mt-2">
+            Already have an account? <a href="/login" class="link link-primary">Sign in</a>
         </p>
     </div>
-    <form method="POST" action="/register" class="stack-lg" style="text-align:left">
+    <form method="POST" action="/register" class="flex flex-col gap-4 text-left">
         {{csrfField}}
-        <div class="form-group">
-            <label for="name" class="form-label">Full name</label>
-            <input id="name" name="name" type="text" required class="form-input">
+        <div class="form-control">
+            <label for="name" class="label pb-1">
+                <span class="label-text">Full name</span>
+            </label>
+            <input id="name" name="name" type="text" required class="input input-bordered w-full">
         </div>
-        <div class="form-group">
-            <label for="email" class="form-label">Email address</label>
-            <input id="email" name="email" type="email" required class="form-input" autocomplete="email">
+        <div class="form-control">
+            <label for="email" class="label pb-1">
+                <span class="label-text">Email address</span>
+            </label>
+            <input id="email" name="email" type="email" required
+                   class="input input-bordered w-full" autocomplete="email">
         </div>
-        <div class="form-group">
-            <label for="password" class="form-label">Password <span class="form-label-hint">(min 12 characters)</span></label>
+        <div class="form-control">
+            <label for="password" class="label pb-1">
+                <span class="label-text">Password</span>
+                <span class="label-text-alt text-base-content/60">min 12 characters</span>
+            </label>
             <input id="password" name="password" type="password" required minlength="12"
-                   class="form-input" autocomplete="new-password">
+                   class="input input-bordered w-full" autocomplete="new-password">
         </div>
-        <button type="submit" class="btn btn-primary btn-block">Create account</button>
+        <button type="submit" class="btn btn-primary btn-block mt-2">Create account</button>
     </form>
 </div>
 {{end}}

--- a/templates/auth/setup_2fa.html
+++ b/templates/auth/setup_2fa.html
@@ -1,30 +1,36 @@
 {{define "content"}}
-<div class="container-narrow">
-    <h1 class="mb-sm">Set Up Two-Factor Authentication</h1>
-    <p class="text-muted mb-xl">Two-factor authentication is required for all accounts. Choose your preferred method:</p>
+<div class="flex flex-col gap-4">
+    <h1 class="text-2xl font-semibold tracking-tight">Set Up Two-Factor Authentication</h1>
+    <p class="text-sm text-base-content/70">
+        Two-factor authentication is required for all accounts. Choose your preferred method:
+    </p>
 
-    <div class="stack-lg">
-        <a href="/setup-2fa/totp" class="method-card">
-            <div class="method-icon method-icon-primary">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+    <div class="flex flex-col gap-3 mt-2">
+        <a href="/setup-2fa/totp"
+           class="flex items-center gap-4 p-4 rounded-lg border border-base-300
+                  hover:border-primary hover:bg-primary/5 transition-colors">
+            <div class="w-10 h-10 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
+                <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
                 </svg>
             </div>
-            <div class="method-info">
-                <h3>Authenticator App</h3>
-                <p>Use Google Authenticator, Authy, or any TOTP app</p>
+            <div class="text-left min-w-0">
+                <h3 class="font-semibold text-sm">Authenticator App</h3>
+                <p class="text-xs text-base-content/60 mt-0.5">Use Google Authenticator, Authy, or any TOTP app</p>
             </div>
         </a>
 
-        <div class="method-card disabled">
-            <div class="method-icon method-icon-muted">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
+        <div class="flex items-center gap-4 p-4 rounded-lg border border-base-300 opacity-50 cursor-not-allowed">
+            <div class="w-10 h-10 rounded-lg bg-base-200 text-base-content/50 flex items-center justify-center shrink-0">
+                <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
                 </svg>
             </div>
-            <div class="method-info">
-                <h3 style="color:var(--gray-500)">Security Key / Passkey</h3>
-                <p style="color:var(--gray-400)">YubiKey, Touch ID, Windows Hello — coming soon</p>
+            <div class="text-left min-w-0">
+                <h3 class="font-semibold text-sm text-base-content/50">Security Key / Passkey</h3>
+                <p class="text-xs text-base-content/40 mt-0.5">YubiKey, Touch ID, Windows Hello — coming soon</p>
             </div>
         </div>
     </div>

--- a/templates/auth/setup_2fa_totp.html
+++ b/templates/auth/setup_2fa_totp.html
@@ -1,29 +1,37 @@
 {{define "content"}}
-<div class="container-narrow">
-    <h1 class="mb-sm">Set Up Authenticator App</h1>
-    <p class="text-muted mb-lg">Scan this QR code with your authenticator app, then enter the 6-digit code to verify.</p>
+<div class="flex flex-col gap-4">
+    <h1 class="text-2xl font-semibold tracking-tight">Set Up Authenticator App</h1>
+    <p class="text-sm text-base-content/70">
+        Scan this QR code with your authenticator app, then enter the 6-digit code to verify.
+    </p>
 
     {{with .Data}}
     {{if index . "QRCode"}}
-    <div class="qr-container">
-        <img src="data:image/png;base64,{{index . "QRCode"}}" alt="TOTP QR Code">
+    <div class="flex justify-center py-3">
+        <img src="data:image/png;base64,{{index . "QRCode"}}"
+             alt="TOTP QR Code"
+             class="rounded-md border border-base-300 p-2 bg-base-100 max-w-48">
     </div>
     {{end}}
 
     {{if index . "ManualKey"}}
-    <div class="manual-key">
-        <p class="manual-key-label">Manual entry key:</p>
-        <code class="select-all">{{index . "ManualKey"}}</code>
+    <div class="bg-base-200 rounded-md p-3 text-center">
+        <p class="text-xs text-base-content/60 mb-1">Manual entry key:</p>
+        <code class="select-all text-xs font-mono break-all">{{index . "ManualKey"}}</code>
     </div>
     {{end}}
     {{end}}
 
-    <form method="POST" action="/setup-2fa/totp/verify" class="stack-lg">
+    <form method="POST" action="/setup-2fa/totp/verify" class="flex flex-col gap-4 mt-2">
         {{csrfField}}
-        <div class="form-group">
-            <label for="code" class="form-label">Verification code</label>
-            <input id="code" name="code" type="text" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" required autofocus
-                   class="form-input form-input-code" placeholder="000000" autocomplete="one-time-code">
+        <div class="form-control">
+            <label for="code" class="label pb-1">
+                <span class="label-text">Verification code</span>
+            </label>
+            <input id="code" name="code" type="text" inputmode="numeric"
+                   pattern="[0-9]{6}" maxlength="6" required autofocus
+                   class="input input-bordered w-full text-center text-xl tracking-[0.3em] font-mono"
+                   placeholder="000000" autocomplete="one-time-code">
         </div>
         <button type="submit" class="btn btn-primary btn-block">Verify and continue</button>
     </form>

--- a/templates/auth/setup_2fa_webauthn.html
+++ b/templates/auth/setup_2fa_webauthn.html
@@ -1,7 +1,9 @@
 {{define "content"}}
-<div class="container-narrow text-center">
-    <h1 class="mb-md">Register Security Key</h1>
-    <p class="text-muted mb-lg">WebAuthn support coming soon. Please use an authenticator app for now.</p>
-    <a href="/setup-2fa" class="btn-link">Go back</a>
+<div class="flex flex-col gap-3 text-center">
+    <h1 class="text-2xl font-semibold tracking-tight">Register Security Key</h1>
+    <p class="text-sm text-base-content/70">
+        WebAuthn support coming soon. Please use an authenticator app for now.
+    </p>
+    <a href="/setup-2fa" class="link link-primary text-sm">Go back</a>
 </div>
 {{end}}

--- a/templates/auth/verify_2fa.html
+++ b/templates/auth/verify_2fa.html
@@ -1,18 +1,22 @@
 {{define "content"}}
-<div class="stack-xl text-center">
+<div class="flex flex-col gap-6 text-center">
     <div>
-        <h1 style="font-size:var(--text-3xl)">Two-Factor Verification</h1>
-        <p class="text-muted" style="margin-top:.5rem">Enter the 6-digit code from your authenticator app</p>
+        <h1 class="text-2xl font-semibold tracking-tight">Two-Factor Verification</h1>
+        <p class="text-sm text-base-content/60 mt-2">
+            Enter the 6-digit code from your authenticator app
+        </p>
     </div>
-    <form method="POST" action="/verify-2fa" class="stack-lg">
+    <form method="POST" action="/verify-2fa" class="flex flex-col gap-4">
         {{csrfField}}
         <div>
             <label for="code" class="sr-only">Verification code</label>
-            <input id="code" name="code" type="text" inputmode="numeric" pattern="[0-9A-Z]{6,8}" maxlength="8" required autofocus
-                   class="form-input form-input-code" placeholder="000000" autocomplete="one-time-code">
+            <input id="code" name="code" type="text" inputmode="numeric"
+                   pattern="[0-9A-Z]{6,8}" maxlength="8" required autofocus
+                   class="input input-bordered w-full text-center text-xl tracking-[0.3em] font-mono"
+                   placeholder="000000" autocomplete="one-time-code">
         </div>
         <button type="submit" class="btn btn-primary btn-block">Verify</button>
-        <p class="text-muted text-sm">You can also enter a recovery code</p>
+        <p class="text-xs text-base-content/60">You can also enter a recovery code</p>
     </form>
 </div>
 {{end}}

--- a/templates/auth/verify_2fa.html
+++ b/templates/auth/verify_2fa.html
@@ -10,8 +10,12 @@
         {{csrfField}}
         <div>
             <label for="code" class="sr-only">Verification code</label>
-            <input id="code" name="code" type="text" inputmode="numeric"
+            {{/* inputmode="text" — the pattern allows alphanumerics so recovery
+                 codes (ABCD-1234 format) work on mobile keyboards. A numeric
+                 inputmode would block mobile users from entering them. */}}
+            <input id="code" name="code" type="text" inputmode="text"
                    pattern="[0-9A-Z]{6,8}" maxlength="8" required autofocus
+                   autocapitalize="characters"
                    class="input input-bordered w-full text-center text-xl tracking-[0.3em] font-mono"
                    placeholder="000000" autocomplete="one-time-code">
         </div>


### PR DESCRIPTION
## Scope — closes #84

Second PR of the v0.3.0 UI migration. Migrates all 8 auth-flow templates to DaisyUI + Tailwind utilities.

Per spec: [\`docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md §6 PR-2\`](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md)

Depends on #89 (PR-1, merged) which established the build pipeline and the auth-card wrapper in \`base.html\`.

## Templates migrated (8)

| Template | Purpose | Key DaisyUI components |
|---|---|---|
| \`login.html\` | Sign in | \`input input-bordered\`, \`btn btn-primary btn-block\` |
| \`register.html\` | Create account | \`form-control\`, \`label-text\`, \`label-text-alt\` |
| \`invite_register.html\` | Accept invitation | disabled input with \`bg-base-200\` |
| \`setup_2fa.html\` | Method picker | Method cards with hover state + icon badges |
| \`setup_2fa_totp.html\` | QR + 6-digit verify | QR in bordered frame, monospace key, code-input |
| \`setup_2fa_webauthn.html\` | Coming-soon placeholder | Minimal |
| \`verify_2fa.html\` | 6–8 char code entry | Centered tracking-[0.3em] monospace input |
| \`recovery_codes.html\` | One-time display | 2-col grid, \`alert alert-warning\` |

## Class migration patterns

All previously hand-written classes map cleanly to DaisyUI equivalents:

- \`.stack-xl / stack-lg\` → \`flex flex-col gap-{6,8}\`
- \`.form-group\` → \`form-control\`
- \`.form-label\` → \`label + label-text\`
- \`.form-input\` → \`input input-bordered w-full\`
- \`.form-input-code\` (OTP) → \`input input-bordered text-center text-xl tracking-[0.3em] font-mono\`
- \`.btn btn-primary btn-block\` → same classes (DaisyUI shares them exactly — zero rename)
- \`.btn-link\` → \`link link-primary\`
- \`.method-card\` → custom row card with \`hover:border-primary hover:bg-primary/5 transition-colors\`
- \`.flash-warning\` → \`alert alert-warning\`

## Screenshots

Screenshots for login, register, setup-2fa (method picker), setup-2fa-totp (QR), verify-2fa, and recovery-codes all render correctly with the forgedesk theme. Captured locally via a throwaway \`cmd/preview\` tool (not committed).

Visual highlights:
- **Login/register**: centered card on \`bg-base-200\`, clean indigo primary button, generous whitespace
- **2FA method picker**: interactive cards with icon badges, disabled state for coming-soon passkey option
- **TOTP setup**: QR code in a bordered frame, manual key in \`code\` block with \`select-all\`, centered 6-digit input with 0.3em tracking
- **Verify 2FA**: minimal monospace input, primary button
- **Recovery codes**: 2-column grid of codes with \`select-all\` styling, amber \`alert\` at top, clear continue button

## Test plan

- [x] \`bash scripts/css.sh\` builds (~117KB)
- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` clean (0 issues)
- [x] Auth handler tests pass (\`Test(Login|Register|Invite|Verify2FA|Setup2FA)\` — all green)
- [ ] Manual: full auth journey — register → setup-2fa → totp → recovery codes → dashboard
- [ ] Dark mode: \`prefers-color-scheme: dark\` auto-flips the auth card (rest of migration not yet tested in dark)

## Out of scope for this PR

- The \`link link-primary\` classes render subtly in the current forgedesk theme — links show but don't stand out. Will be tuned in a later theme-polish pass or when brand colors land.
- Real SMTP invitation flow untouched (just the template)
- WebAuthn remains a placeholder (production code stub, spec-confirmed carry-over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)