### PR TITLE
feat(ui): v0.3.0 PR-3 — migrate dashboard + org pages

### DIFF
--- a/templates/pages/dashboard.html
+++ b/templates/pages/dashboard.html
@@ -1,102 +1,134 @@
 {{define "content"}}
-<div>
-    <div class="page-header">
-        <h1>{{if .Org}}{{.Org.Name}}{{else}}Dashboard{{end}}</h1>
+<div class="max-w-6xl mx-auto p-6">
+    <header class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-semibold tracking-tight">
+            {{if .Org}}{{.Org.Name}}{{else}}Dashboard{{end}}
+        </h1>
         {{if .User}}
-        <div class="flex items-center gap-md">
-        {{if .Org}}
-        <a href="/orgs/{{.Org.Slug}}/costs" class="btn btn-ghost btn-sm">Costs</a>
-        <a href="/orgs/{{.Org.Slug}}/settings" class="btn btn-ghost btn-sm">Settings</a>
-        {{end}}
-        <div class="dropdown" x-data="{ open: false }">
-            <button @click="open = !open" class="btn btn-primary">New...</button>
-            <div x-show="open" @click.outside="open = false" x-transition class="dropdown-menu" style="min-width:14rem">
-                {{if .Org}}
-                <form method="POST" action="/orgs/{{.Org.Slug}}/projects" class="dropdown-form" @click.stop>
-                    {{csrfField}}
-                    <label class="form-label">New Project</label>
-                    <input type="text" name="name" placeholder="Project name" required class="form-input mb-sm">
-                    <button type="submit" class="btn btn-primary btn-sm btn-block">Create Project</button>
-                </form>
-                {{end}}
-                <form method="POST" action="/orgs" class="dropdown-form" style="border-top:1px solid var(--gray-100)" @click.stop>
-                    {{csrfField}}
-                    <label class="form-label">New Organization</label>
-                    <input type="text" name="name" placeholder="Org name" required class="form-input mb-sm">
-                    <button type="submit" class="btn btn-primary btn-sm btn-block">Create Organization</button>
-                </form>
+        <div class="flex items-center gap-2">
+            {{if .Org}}
+            <a href="/orgs/{{.Org.Slug}}/costs" class="btn btn-ghost btn-sm">Costs</a>
+            <a href="/orgs/{{.Org.Slug}}/settings" class="btn btn-ghost btn-sm">Settings</a>
+            {{end}}
+            <div class="relative" x-data="{ open: false }">
+                <button @click="open = !open" class="btn btn-primary btn-sm">New…</button>
+                <div x-show="open" x-transition x-cloak @click.outside="open = false"
+                     class="absolute right-0 mt-2 w-72 bg-base-100 border border-base-300
+                            rounded-lg shadow-xl z-40 overflow-hidden">
+                    {{if .Org}}
+                    <form method="POST" action="/orgs/{{.Org.Slug}}/projects"
+                          class="p-3 flex flex-col gap-2" @click.stop>
+                        {{csrfField}}
+                        <label class="text-xs uppercase tracking-wider text-base-content/60 font-medium">
+                            New Project
+                        </label>
+                        <input type="text" name="name" placeholder="Project name" required
+                               class="input input-bordered input-sm w-full">
+                        <button type="submit" class="btn btn-primary btn-sm btn-block">
+                            Create Project
+                        </button>
+                    </form>
+                    {{end}}
+                    <form method="POST" action="/orgs"
+                          class="p-3 flex flex-col gap-2 border-t border-base-300" @click.stop>
+                        {{csrfField}}
+                        <label class="text-xs uppercase tracking-wider text-base-content/60 font-medium">
+                            New Organization
+                        </label>
+                        <input type="text" name="name" placeholder="Org name" required
+                               class="input input-bordered input-sm w-full">
+                        <button type="submit" class="btn btn-primary btn-sm btn-block">
+                            Create Organization
+                        </button>
+                    </form>
+                </div>
             </div>
         </div>
-        </div>
         {{end}}
-    </div>
+    </header>
 
     {{if .Org}}
     {{with .Data}}
-    <div class="grid grid-3">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {{range .}}
-        <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/brief" class="card card-hover">
-            <h3>{{.Name}}</h3>
-            <p class="text-muted text-sm" style="margin-top:.25rem">Created {{formatDate .CreatedAt}}</p>
+        <a href="/orgs/{{$.Org.Slug}}/projects/{{.Slug}}/brief"
+           class="card bg-base-100 border border-base-300 shadow-sm
+                  hover:shadow-md hover:border-primary/40 transition-all">
+            <div class="card-body p-5">
+                <h3 class="font-semibold text-base">{{.Name}}</h3>
+                <p class="text-xs text-base-content/60 mt-1">
+                    Created {{formatDate .CreatedAt}}
+                </p>
+            </div>
         </a>
         {{end}}
     </div>
     {{else}}
-    <div class="empty-state">
-        <p>No projects yet</p>
-        <p class="empty-subtitle">Create your first project to get started</p>
+    <div class="flex flex-col items-center py-16 text-center gap-1">
+        <p class="text-base font-medium text-base-content/80">No projects yet</p>
+        <p class="text-sm text-base-content/60">Create your first project to get started</p>
     </div>
     {{end}}
 
     {{else}}
 
-    {{/* Pending invitations section */}}
+    {{/* Pending invitations */}}
     {{with .Data}}
     {{with .PendingInvites}}
-    <div class="card mb-lg">
-        <h2 class="mb-md">Pending Invitations</h2>
-        <div class="divide-y">
-            {{range .}}
-            <div class="member-row" id="invite-card-{{.Invitation.ID}}">
-                <div class="member-info">
-                    <p><strong>{{.Organization.Name}}</strong></p>
-                    <p class="text-muted text-sm">Invited by {{.InviterName}} &middot; Role: {{.Invitation.OrgRole}}</p>
+    <div class="card bg-base-100 border border-base-300 shadow-sm mb-6">
+        <div class="card-body p-5 gap-3">
+            <h2 class="text-lg font-semibold">Pending Invitations</h2>
+            <div class="divide-y divide-base-300">
+                {{range .}}
+                <div class="flex items-center justify-between py-3" id="invite-card-{{.Invitation.ID}}">
+                    <div class="min-w-0">
+                        <p class="font-medium text-sm">{{.Organization.Name}}</p>
+                        <p class="text-xs text-base-content/60 mt-0.5">
+                            Invited by {{.InviterName}} · Role: {{.Invitation.OrgRole}}
+                        </p>
+                    </div>
+                    <div class="flex items-center gap-2 shrink-0">
+                        <button class="btn btn-primary btn-sm"
+                                hx-post="/invitations/{{.Invitation.ID}}/accept"
+                                hx-target="#invite-card-{{.Invitation.ID}}"
+                                hx-swap="outerHTML">
+                            Accept
+                        </button>
+                        <button class="btn btn-ghost btn-sm"
+                                hx-post="/invitations/{{.Invitation.ID}}/decline"
+                                hx-target="#invite-card-{{.Invitation.ID}}"
+                                hx-swap="outerHTML"
+                                hx-confirm="Decline invitation to {{.Organization.Name}}?">
+                            Decline
+                        </button>
+                    </div>
                 </div>
-                <div class="flex items-center gap-sm">
-                    <button class="btn btn-primary btn-sm"
-                            hx-post="/invitations/{{.Invitation.ID}}/accept"
-                            hx-target="#invite-card-{{.Invitation.ID}}"
-                            hx-swap="outerHTML">
-                        Accept
-                    </button>
-                    <button class="btn btn-ghost btn-sm"
-                            hx-post="/invitations/{{.Invitation.ID}}/decline"
-                            hx-target="#invite-card-{{.Invitation.ID}}"
-                            hx-swap="outerHTML"
-                            hx-confirm="Decline invitation to {{.Organization.Name}}?">
-                        Decline
-                    </button>
-                </div>
+                {{end}}
             </div>
-            {{end}}
         </div>
     </div>
     {{end}}
     {{end}}
 
     {{if .Orgs}}
-    <div class="grid grid-3">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {{range .Orgs}}
-        <a href="/orgs/{{.Slug}}" class="card card-hover">
-            <h3>{{.Name}}</h3>
-            <p class="text-muted text-sm" style="margin-top:.25rem">Created {{formatDate .CreatedAt}}</p>
+        <a href="/orgs/{{.Slug}}"
+           class="card bg-base-100 border border-base-300 shadow-sm
+                  hover:shadow-md hover:border-primary/40 transition-all">
+            <div class="card-body p-5">
+                <h3 class="font-semibold text-base">{{.Name}}</h3>
+                <p class="text-xs text-base-content/60 mt-1">
+                    Created {{formatDate .CreatedAt}}
+                </p>
+            </div>
         </a>
         {{end}}
     </div>
     {{else}}
-    <div class="empty-state">
-        <p>Welcome to ForgeDesk</p>
-        <p class="empty-subtitle">Create an organization to get started</p>
+    <div class="flex flex-col items-center py-16 text-center gap-1">
+        <p class="text-base font-medium text-base-content/80">Welcome to ForgeDesk</p>
+        <p class="text-sm text-base-content/60">Create an organization to get started</p>
     </div>
     {{end}}
     {{end}}

--- a/templates/pages/org_costs.html
+++ b/templates/pages/org_costs.html
@@ -1,118 +1,133 @@
 {{define "content"}}
 {{with .Data}}
-<div>
-    <!-- Month Picker -->
-    <div class="flex items-center justify-between mb-lg">
-        <h1>Organization Costs — {{.Month}}</h1>
-        <div class="flex items-center gap-sm">
-            <a href="?month={{.PrevMonth}}" class="btn btn-secondary btn-sm">&larr; Prev</a>
-            <span class="text-sm text-muted">{{.Month}}</span>
-            <a href="?month={{.NextMonth}}" class="btn btn-secondary btn-sm">Next &rarr;</a>
+<div class="max-w-6xl mx-auto p-6 flex flex-col gap-6">
+    <header class="flex items-center justify-between flex-wrap gap-3">
+        <h1 class="text-2xl font-semibold tracking-tight">
+            Organization Costs — {{.Month}}
+        </h1>
+        <div class="flex items-center gap-2">
+            <a href="?month={{.PrevMonth}}" class="btn btn-ghost btn-sm">← Prev</a>
+            <span class="text-sm text-base-content/70 px-2 font-medium">{{.Month}}</span>
+            <a href="?month={{.NextMonth}}" class="btn btn-ghost btn-sm">Next →</a>
         </div>
-    </div>
+    </header>
 
-    <!-- Per-Project Infrastructure Costs -->
+    {{/* Per-Project Infrastructure Costs */}}
     {{if .ProjectCosts}}
-    <div class="mb-lg">
-        <h2 class="mb-sm">Infrastructure Costs by Project</h2>
+    <section class="flex flex-col gap-4">
+        <h2 class="text-lg font-semibold">Infrastructure Costs by Project</h2>
         {{range .ProjectCosts}}
-        <div class="card mb-md">
-            <h3 class="mb-sm">{{.Project.Name}}</h3>
-            <div class="table-wrap">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Category</th>
-                            <th>Name</th>
-                            <th style="text-align:right">Amount</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{range .Costs}}
-                        <tr>
-                            <td class="cost-category">{{humanize .Category}}</td>
-                            <td>{{if .Name}}{{.Name}}{{else}}<span class="text-muted">—</span>{{end}}</td>
-                            <td style="text-align:right;font-weight:500">{{formatCents .AmountCents $.Org.CurrencyCode}}</td>
-                        </tr>
-                        {{end}}
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <td colspan="2" style="font-weight:600">Project Subtotal</td>
-                            <td style="text-align:right;font-weight:600">{{formatCents .InfraTotal $.Org.CurrencyCode}}</td>
-                        </tr>
-                    </tfoot>
-                </table>
+        <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <div class="card-body p-5 gap-3">
+                <h3 class="font-semibold">{{.Project.Name}}</h3>
+                <div class="overflow-x-auto">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr class="text-base-content/70">
+                                <th>Category</th>
+                                <th>Name</th>
+                                <th class="text-right">Amount</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{range .Costs}}
+                            <tr>
+                                <td class="font-mono text-xs">{{humanize .Category}}</td>
+                                <td>{{if .Name}}{{.Name}}{{else}}<span class="text-base-content/50">—</span>{{end}}</td>
+                                <td class="text-right font-medium">{{formatCents .AmountCents $.Org.CurrencyCode}}</td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="2" class="font-semibold">Project Subtotal</td>
+                                <td class="text-right font-semibold">{{formatCents .InfraTotal $.Org.CurrencyCode}}</td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
             </div>
         </div>
         {{end}}
-    </div>
+    </section>
     {{else}}
-    <div class="empty-state mb-lg" style="padding:1.5rem">
-        <p class="text-muted">No infrastructure costs for this month.</p>
+    <div class="card bg-base-100 border border-base-300">
+        <div class="card-body p-6 text-center text-base-content/60 text-sm">
+            No infrastructure costs for this month.
+        </div>
     </div>
     {{end}}
 
-    <!-- Org-wide AI Usage -->
-    <div class="mb-lg">
-        <h2 class="mb-sm">AI Usage</h2>
+    {{/* Org-wide AI Usage */}}
+    <section class="flex flex-col gap-3">
+        <h2 class="text-lg font-semibold">AI Usage</h2>
         {{if .AIUsage}}
-        <div class="table-wrap">
-            <table class="table">
-                <thead>
-                    <tr>
-                        {{if .CanEdit}}<th>Model</th>{{end}}
-                        <th>Type</th>
-                        <th style="text-align:right">Count</th>
-                        {{if .CanEdit}}
-                        <th style="text-align:right">Input Tokens</th>
-                        <th style="text-align:right">Output Tokens</th>
-                        {{end}}
-                        <th style="text-align:right">Cost</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{range .AIUsage}}
-                    <tr>
-                        {{if $.Data.CanEdit}}<td class="text-muted">{{.Model}}</td>{{end}}
-                        <td style="font-weight:500">{{.Label}}</td>
-                        <td style="text-align:right">{{.EntryCount}}</td>
-                        {{if $.Data.CanEdit}}
-                        <td style="text-align:right">{{.InputTokens}}</td>
-                        <td style="text-align:right">{{.OutputTokens}}</td>
-                        {{end}}
-                        <td style="text-align:right;font-weight:500">{{formatCents .TotalCents $.Org.CurrencyCode}}</td>
-                    </tr>
-                    {{end}}
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td colspan="{{if .CanEdit}}5{{else}}2{{end}}" style="font-weight:600">AI Subtotal</td>
-                        {{if .CanEdit}}
-                        <td style="text-align:right;font-weight:600">
-                            {{formatCents .AITotal $.Org.CurrencyCode}}
-                            {{if gt .AIMargin 0}}
-                            <span class="text-sm text-muted" style="display:block">(billed: {{formatCents .AITotalWithMargin $.Org.CurrencyCode}} at +{{.AIMargin}}%)</span>
+        <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <div class="card-body p-5">
+                <div class="overflow-x-auto">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr class="text-base-content/70">
+                                {{if .CanEdit}}<th>Model</th>{{end}}
+                                <th>Type</th>
+                                <th class="text-right">Count</th>
+                                {{if .CanEdit}}
+                                <th class="text-right">Input Tokens</th>
+                                <th class="text-right">Output Tokens</th>
+                                {{end}}
+                                <th class="text-right">Cost</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{range .AIUsage}}
+                            <tr>
+                                {{if $.Data.CanEdit}}<td class="font-mono text-xs text-base-content/70">{{.Model}}</td>{{end}}
+                                <td class="font-medium">{{.Label}}</td>
+                                <td class="text-right">{{.EntryCount}}</td>
+                                {{if $.Data.CanEdit}}
+                                <td class="text-right">{{.InputTokens}}</td>
+                                <td class="text-right">{{.OutputTokens}}</td>
+                                {{end}}
+                                <td class="text-right font-medium">{{formatCents .TotalCents $.Org.CurrencyCode}}</td>
+                            </tr>
                             {{end}}
-                        </td>
-                        {{else}}
-                        <td style="text-align:right;font-weight:600">{{formatCents .AITotalWithMargin $.Org.CurrencyCode}}</td>
-                        {{end}}
-                    </tr>
-                </tfoot>
-            </table>
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="{{if .CanEdit}}5{{else}}2{{end}}" class="font-semibold">AI Subtotal</td>
+                                {{if .CanEdit}}
+                                <td class="text-right font-semibold">
+                                    {{formatCents .AITotal $.Org.CurrencyCode}}
+                                    {{if gt .AIMargin 0}}
+                                    <span class="block text-xs text-base-content/60 font-normal">
+                                        (billed: {{formatCents .AITotalWithMargin $.Org.CurrencyCode}} at +{{.AIMargin}}%)
+                                    </span>
+                                    {{end}}
+                                </td>
+                                {{else}}
+                                <td class="text-right font-semibold">{{formatCents .AITotalWithMargin $.Org.CurrencyCode}}</td>
+                                {{end}}
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
         </div>
         {{else}}
-        <div class="empty-state" style="padding:1.5rem">
-            <p class="text-muted">No AI usage for this month.</p>
+        <div class="card bg-base-100 border border-base-300">
+            <div class="card-body p-6 text-center text-base-content/60 text-sm">
+                No AI usage for this month.
+            </div>
         </div>
         {{end}}
-    </div>
+    </section>
 
-    <!-- Grand Total -->
-    <div class="card" style="text-align:right">
-        <span class="text-muted" style="margin-right:.5rem">Total for {{.Month}}:</span>
-        <span class="cost-total">{{formatCents .GrandTotal $.Org.CurrencyCode}}</span>
+    {{/* Grand Total */}}
+    <div class="card bg-primary/5 border border-primary/20">
+        <div class="card-body p-5 flex-row items-center justify-between">
+            <span class="text-base-content/70">Total for {{.Month}}:</span>
+            <span class="text-2xl font-semibold">{{formatCents .GrandTotal $.Org.CurrencyCode}}</span>
+        </div>
     </div>
 </div>
 {{end}}

--- a/templates/pages/org_settings.html
+++ b/templates/pages/org_settings.html
@@ -1,189 +1,255 @@
 {{define "content"}}
-<div class="container-medium">
-    <h1 class="mb-lg">{{.Org.Name}} — Settings</h1>
+<div class="max-w-4xl mx-auto p-6 flex flex-col gap-6">
+    <h1 class="text-2xl font-semibold tracking-tight">
+        {{.Org.Name}} — Settings
+    </h1>
 
     {{with .Data}}
 
     {{if or .IsStaff .CanManage}}
-    <div class="card mb-lg">
-        <h2 class="mb-md">Business Details</h2>
-        <p class="text-sm text-muted mb-md">Legal and contact information for this organization.</p>
-        <form method="POST" action="/orgs/{{.OrgSlug}}/settings/business">
-            {{csrfField}}
-            <div class="form-group mb-md">
-                <label class="form-label" for="business_name">Business Name</label>
-                <input type="text" id="business_name" name="business_name" class="form-input"
-                       value="{{$.Org.BusinessName}}" placeholder="Legal business name">
-            </div>
-            <div class="grid grid-2 mb-md">
-                <div class="form-group">
-                    <label class="form-label" for="vat_number">VAT Number</label>
-                    <input type="text" id="vat_number" name="vat_number" class="form-input"
-                           value="{{$.Org.VATNumber}}" placeholder="e.g. RO12345678">
-                </div>
-                <div class="form-group">
-                    <label class="form-label" for="registration_number">Registration Number</label>
-                    <input type="text" id="registration_number" name="registration_number" class="form-input"
-                           value="{{$.Org.RegistrationNumber}}" placeholder="e.g. J40/1234/2020">
-                </div>
-            </div>
-            <div class="form-group mb-md">
-                <label class="form-label" for="address_street">Street Address</label>
-                <input type="text" id="address_street" name="address_street" class="form-input"
-                       value="{{$.Org.AddressStreet}}" placeholder="Street name and number">
-            </div>
-            <div class="form-group mb-md">
-                <label class="form-label" for="address_extra">Address Line 2</label>
-                <span class="form-label-hint">Office number, floor, building, etc.</span>
-                <input type="text" id="address_extra" name="address_extra" class="form-input"
-                       value="{{$.Org.AddressExtra}}">
-            </div>
-            <div class="grid grid-2 mb-md">
-                <div class="form-group">
-                    <label class="form-label" for="postal_code">Postal Code</label>
-                    <input type="text" id="postal_code" name="postal_code" class="form-input"
-                           value="{{$.Org.PostalCode}}">
-                </div>
-                <div class="form-group">
-                    <label class="form-label" for="city">City</label>
-                    <input type="text" id="city" name="city" class="form-input"
-                           value="{{$.Org.City}}">
-                </div>
-            </div>
-            <div class="form-group mb-md">
-                <label class="form-label" for="country">Country</label>
-                <select id="country" name="country" class="form-select">
-                    {{$ctry := $.Org.Country}}
-                    <option value="" {{if eq $ctry ""}}selected{{end}}>— Select country —</option>
-                    <option value="AT" {{if eq $ctry "AT"}}selected{{end}}>Austria</option>
-                    <option value="BE" {{if eq $ctry "BE"}}selected{{end}}>Belgium</option>
-                    <option value="BG" {{if eq $ctry "BG"}}selected{{end}}>Bulgaria</option>
-                    <option value="HR" {{if eq $ctry "HR"}}selected{{end}}>Croatia</option>
-                    <option value="CY" {{if eq $ctry "CY"}}selected{{end}}>Cyprus</option>
-                    <option value="CZ" {{if eq $ctry "CZ"}}selected{{end}}>Czech Republic</option>
-                    <option value="DK" {{if eq $ctry "DK"}}selected{{end}}>Denmark</option>
-                    <option value="EE" {{if eq $ctry "EE"}}selected{{end}}>Estonia</option>
-                    <option value="FI" {{if eq $ctry "FI"}}selected{{end}}>Finland</option>
-                    <option value="FR" {{if eq $ctry "FR"}}selected{{end}}>France</option>
-                    <option value="DE" {{if eq $ctry "DE"}}selected{{end}}>Germany</option>
-                    <option value="GR" {{if eq $ctry "GR"}}selected{{end}}>Greece</option>
-                    <option value="HU" {{if eq $ctry "HU"}}selected{{end}}>Hungary</option>
-                    <option value="IE" {{if eq $ctry "IE"}}selected{{end}}>Ireland</option>
-                    <option value="IT" {{if eq $ctry "IT"}}selected{{end}}>Italy</option>
-                    <option value="LV" {{if eq $ctry "LV"}}selected{{end}}>Latvia</option>
-                    <option value="LT" {{if eq $ctry "LT"}}selected{{end}}>Lithuania</option>
-                    <option value="LU" {{if eq $ctry "LU"}}selected{{end}}>Luxembourg</option>
-                    <option value="MT" {{if eq $ctry "MT"}}selected{{end}}>Malta</option>
-                    <option value="MD" {{if eq $ctry "MD"}}selected{{end}}>Moldova</option>
-                    <option value="NL" {{if eq $ctry "NL"}}selected{{end}}>Netherlands</option>
-                    <option value="NO" {{if eq $ctry "NO"}}selected{{end}}>Norway</option>
-                    <option value="PL" {{if eq $ctry "PL"}}selected{{end}}>Poland</option>
-                    <option value="PT" {{if eq $ctry "PT"}}selected{{end}}>Portugal</option>
-                    <option value="RO" {{if eq $ctry "RO"}}selected{{end}}>Romania</option>
-                    <option value="SK" {{if eq $ctry "SK"}}selected{{end}}>Slovakia</option>
-                    <option value="SI" {{if eq $ctry "SI"}}selected{{end}}>Slovenia</option>
-                    <option value="ES" {{if eq $ctry "ES"}}selected{{end}}>Spain</option>
-                    <option value="SE" {{if eq $ctry "SE"}}selected{{end}}>Sweden</option>
-                    <option value="CH" {{if eq $ctry "CH"}}selected{{end}}>Switzerland</option>
-                    <option value="GB" {{if eq $ctry "GB"}}selected{{end}}>United Kingdom</option>
-                    <option value="US" {{if eq $ctry "US"}}selected{{end}}>United States</option>
-                    <option value="CA" {{if eq $ctry "CA"}}selected{{end}}>Canada</option>
-                    <option value="AU" {{if eq $ctry "AU"}}selected{{end}}>Australia</option>
-                    <option value="JP" {{if eq $ctry "JP"}}selected{{end}}>Japan</option>
-                </select>
-            </div>
-            <div class="form-group mb-md">
-                <label class="form-label" for="contact_phones">Contact Phone Numbers</label>
-                <span class="form-label-hint">Comma-separated if multiple</span>
-                <input type="text" id="contact_phones" name="contact_phones" class="form-input"
-                       value="{{$.Org.ContactPhones}}" placeholder="e.g. +40 21 123 4567, +40 722 123 456">
-            </div>
-            <div class="form-group mb-md">
-                <label class="form-label" for="contact_emails">Contact Email Addresses</label>
-                <span class="form-label-hint">Comma-separated if multiple</span>
-                <input type="text" id="contact_emails" name="contact_emails" class="form-input"
-                       value="{{$.Org.ContactEmails}}" placeholder="e.g. office@company.com, billing@company.com">
-            </div>
-            <button type="submit" class="btn btn-primary">Save Business Details</button>
-        </form>
-    </div>
-    {{end}}
-
-    {{if .IsStaff}}
-    <div class="card mb-lg">
-        <h2 class="mb-md">AI Cost Margin</h2>
-        <p class="text-sm text-muted mb-md">Percentage markup applied to AI usage costs for client billing.</p>
-        <form method="POST" action="/orgs/{{.OrgSlug}}/settings/margin" class="flex items-center gap-md">
-            {{csrfField}}
-            <input type="number" name="ai_margin_percent" value="{{$.Org.AIMarginPercent}}"
-                   min="0" max="500" class="form-input" style="width:6rem">
-            <span class="text-sm text-muted">%</span>
-            <button type="submit" class="btn btn-primary btn-sm">Save</button>
-        </form>
-    </div>
-    <div class="card mb-lg">
-        <h2 class="mb-md">Display Currency</h2>
-        <p class="text-sm text-muted mb-md">Currency used to display costs for this organization. Does not convert amounts.</p>
-        <form method="POST" action="/orgs/{{.OrgSlug}}/settings/currency" class="flex items-center gap-md">
-            {{csrfField}}
-            <select name="currency_code" class="form-select" style="width:auto">
-                {{$cur := $.Org.CurrencyCode}}
-                <option value="EUR" {{if eq $cur "EUR"}}selected{{end}}>EUR — €</option>
-                <option value="USD" {{if eq $cur "USD"}}selected{{end}}>USD — $</option>
-                <option value="GBP" {{if eq $cur "GBP"}}selected{{end}}>GBP — £</option>
-                <option value="CHF" {{if eq $cur "CHF"}}selected{{end}}>CHF</option>
-                <option value="SEK" {{if eq $cur "SEK"}}selected{{end}}>SEK</option>
-                <option value="NOK" {{if eq $cur "NOK"}}selected{{end}}>NOK</option>
-                <option value="DKK" {{if eq $cur "DKK"}}selected{{end}}>DKK</option>
-                <option value="PLN" {{if eq $cur "PLN"}}selected{{end}}>PLN</option>
-                <option value="CZK" {{if eq $cur "CZK"}}selected{{end}}>CZK</option>
-                <option value="RON" {{if eq $cur "RON"}}selected{{end}}>RON</option>
-                <option value="HUF" {{if eq $cur "HUF"}}selected{{end}}>HUF</option>
-                <option value="BGN" {{if eq $cur "BGN"}}selected{{end}}>BGN</option>
-                <option value="HRK" {{if eq $cur "HRK"}}selected{{end}}>HRK</option>
-                <option value="JPY" {{if eq $cur "JPY"}}selected{{end}}>JPY — ¥</option>
-                <option value="CAD" {{if eq $cur "CAD"}}selected{{end}}>CAD — $</option>
-                <option value="AUD" {{if eq $cur "AUD"}}selected{{end}}>AUD — $</option>
-            </select>
-            <button type="submit" class="btn btn-primary btn-sm">Save</button>
-        </form>
-    </div>
-    {{end}}
-
-    {{if .CanManage}}
-    <div class="card mb-lg">
-        <h2 class="mb-md">Invite Member</h2>
-        <form class="flex items-center gap-md"
-              hx-post="/orgs/{{.OrgSlug}}/invitations"
-              hx-target="#invite-result-area"
-              hx-swap="innerHTML"
-              hx-on::after-request="if(event.detail.successful) { this.reset(); htmx.trigger('#invitation-list', 'refresh'); }">
-            <div class="flex-1">
-                <input type="email" name="email" class="form-input" placeholder="user@example.com" required>
-            </div>
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-4">
             <div>
-                <select name="role" class="form-select" style="width:auto;">
-                    <option value="member">Member</option>
-                    <option value="admin">Admin</option>
-                </select>
+                <h2 class="text-lg font-semibold">Business Details</h2>
+                <p class="text-sm text-base-content/60 mt-1">
+                    Legal and contact information for this organization.
+                </p>
             </div>
-            <button type="submit" class="btn btn-primary btn-sm">Invite</button>
-        </form>
-        <div id="invite-result-area"></div>
-    </div>
-
-    <div class="card mb-lg">
-        <h2 class="mb-md">Pending Invitations</h2>
-        <div class="divide-y" id="invitation-list">
-            {{template "invitation_list.html" .}}
+            <form method="POST" action="/orgs/{{.OrgSlug}}/settings/business" class="flex flex-col gap-4">
+                {{csrfField}}
+                <div class="form-control">
+                    <label class="label pb-1" for="business_name">
+                        <span class="label-text">Business Name</span>
+                    </label>
+                    <input type="text" id="business_name" name="business_name"
+                           class="input input-bordered w-full"
+                           value="{{$.Org.BusinessName}}" placeholder="Legal business name">
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-control">
+                        <label class="label pb-1" for="vat_number">
+                            <span class="label-text">VAT Number</span>
+                        </label>
+                        <input type="text" id="vat_number" name="vat_number"
+                               class="input input-bordered w-full"
+                               value="{{$.Org.VATNumber}}" placeholder="e.g. RO12345678">
+                    </div>
+                    <div class="form-control">
+                        <label class="label pb-1" for="registration_number">
+                            <span class="label-text">Registration Number</span>
+                        </label>
+                        <input type="text" id="registration_number" name="registration_number"
+                               class="input input-bordered w-full"
+                               value="{{$.Org.RegistrationNumber}}" placeholder="e.g. J40/1234/2020">
+                    </div>
+                </div>
+                <div class="form-control">
+                    <label class="label pb-1" for="address_street">
+                        <span class="label-text">Street Address</span>
+                    </label>
+                    <input type="text" id="address_street" name="address_street"
+                           class="input input-bordered w-full"
+                           value="{{$.Org.AddressStreet}}" placeholder="Street name and number">
+                </div>
+                <div class="form-control">
+                    <label class="label pb-1" for="address_extra">
+                        <span class="label-text">Address Line 2</span>
+                        <span class="label-text-alt text-base-content/60">
+                            Office number, floor, building, etc.
+                        </span>
+                    </label>
+                    <input type="text" id="address_extra" name="address_extra"
+                           class="input input-bordered w-full"
+                           value="{{$.Org.AddressExtra}}">
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-control">
+                        <label class="label pb-1" for="postal_code">
+                            <span class="label-text">Postal Code</span>
+                        </label>
+                        <input type="text" id="postal_code" name="postal_code"
+                               class="input input-bordered w-full"
+                               value="{{$.Org.PostalCode}}">
+                    </div>
+                    <div class="form-control">
+                        <label class="label pb-1" for="city">
+                            <span class="label-text">City</span>
+                        </label>
+                        <input type="text" id="city" name="city"
+                               class="input input-bordered w-full"
+                               value="{{$.Org.City}}">
+                    </div>
+                </div>
+                <div class="form-control">
+                    <label class="label pb-1" for="country">
+                        <span class="label-text">Country</span>
+                    </label>
+                    <select id="country" name="country" class="select select-bordered w-full">
+                        {{$ctry := $.Org.Country}}
+                        <option value="" {{if eq $ctry ""}}selected{{end}}>— Select country —</option>
+                        <option value="AT" {{if eq $ctry "AT"}}selected{{end}}>Austria</option>
+                        <option value="BE" {{if eq $ctry "BE"}}selected{{end}}>Belgium</option>
+                        <option value="BG" {{if eq $ctry "BG"}}selected{{end}}>Bulgaria</option>
+                        <option value="HR" {{if eq $ctry "HR"}}selected{{end}}>Croatia</option>
+                        <option value="CY" {{if eq $ctry "CY"}}selected{{end}}>Cyprus</option>
+                        <option value="CZ" {{if eq $ctry "CZ"}}selected{{end}}>Czech Republic</option>
+                        <option value="DK" {{if eq $ctry "DK"}}selected{{end}}>Denmark</option>
+                        <option value="EE" {{if eq $ctry "EE"}}selected{{end}}>Estonia</option>
+                        <option value="FI" {{if eq $ctry "FI"}}selected{{end}}>Finland</option>
+                        <option value="FR" {{if eq $ctry "FR"}}selected{{end}}>France</option>
+                        <option value="DE" {{if eq $ctry "DE"}}selected{{end}}>Germany</option>
+                        <option value="GR" {{if eq $ctry "GR"}}selected{{end}}>Greece</option>
+                        <option value="HU" {{if eq $ctry "HU"}}selected{{end}}>Hungary</option>
+                        <option value="IE" {{if eq $ctry "IE"}}selected{{end}}>Ireland</option>
+                        <option value="IT" {{if eq $ctry "IT"}}selected{{end}}>Italy</option>
+                        <option value="LV" {{if eq $ctry "LV"}}selected{{end}}>Latvia</option>
+                        <option value="LT" {{if eq $ctry "LT"}}selected{{end}}>Lithuania</option>
+                        <option value="LU" {{if eq $ctry "LU"}}selected{{end}}>Luxembourg</option>
+                        <option value="MT" {{if eq $ctry "MT"}}selected{{end}}>Malta</option>
+                        <option value="MD" {{if eq $ctry "MD"}}selected{{end}}>Moldova</option>
+                        <option value="NL" {{if eq $ctry "NL"}}selected{{end}}>Netherlands</option>
+                        <option value="NO" {{if eq $ctry "NO"}}selected{{end}}>Norway</option>
+                        <option value="PL" {{if eq $ctry "PL"}}selected{{end}}>Poland</option>
+                        <option value="PT" {{if eq $ctry "PT"}}selected{{end}}>Portugal</option>
+                        <option value="RO" {{if eq $ctry "RO"}}selected{{end}}>Romania</option>
+                        <option value="SK" {{if eq $ctry "SK"}}selected{{end}}>Slovakia</option>
+                        <option value="SI" {{if eq $ctry "SI"}}selected{{end}}>Slovenia</option>
+                        <option value="ES" {{if eq $ctry "ES"}}selected{{end}}>Spain</option>
+                        <option value="SE" {{if eq $ctry "SE"}}selected{{end}}>Sweden</option>
+                        <option value="CH" {{if eq $ctry "CH"}}selected{{end}}>Switzerland</option>
+                        <option value="GB" {{if eq $ctry "GB"}}selected{{end}}>United Kingdom</option>
+                        <option value="US" {{if eq $ctry "US"}}selected{{end}}>United States</option>
+                        <option value="CA" {{if eq $ctry "CA"}}selected{{end}}>Canada</option>
+                        <option value="AU" {{if eq $ctry "AU"}}selected{{end}}>Australia</option>
+                        <option value="JP" {{if eq $ctry "JP"}}selected{{end}}>Japan</option>
+                    </select>
+                </div>
+                <div class="form-control">
+                    <label class="label pb-1" for="contact_phones">
+                        <span class="label-text">Contact Phone Numbers</span>
+                        <span class="label-text-alt text-base-content/60">Comma-separated if multiple</span>
+                    </label>
+                    <input type="text" id="contact_phones" name="contact_phones"
+                           class="input input-bordered w-full"
+                           value="{{$.Org.ContactPhones}}"
+                           placeholder="e.g. +40 21 123 4567, +40 722 123 456">
+                </div>
+                <div class="form-control">
+                    <label class="label pb-1" for="contact_emails">
+                        <span class="label-text">Contact Email Addresses</span>
+                        <span class="label-text-alt text-base-content/60">Comma-separated if multiple</span>
+                    </label>
+                    <input type="text" id="contact_emails" name="contact_emails"
+                           class="input input-bordered w-full"
+                           value="{{$.Org.ContactEmails}}"
+                           placeholder="e.g. office@company.com, billing@company.com">
+                </div>
+                <div>
+                    <button type="submit" class="btn btn-primary">Save Business Details</button>
+                </div>
+            </form>
         </div>
     </div>
     {{end}}
 
-    <div class="card">
-        <h2 class="mb-md">Members</h2>
-        <div class="divide-y" id="member-list">
-            {{template "member_list.html" .}}
+    {{if .IsStaff}}
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-3">
+            <div>
+                <h2 class="text-lg font-semibold">AI Cost Margin</h2>
+                <p class="text-sm text-base-content/60 mt-1">
+                    Percentage markup applied to AI usage costs for client billing.
+                </p>
+            </div>
+            <form method="POST" action="/orgs/{{.OrgSlug}}/settings/margin"
+                  class="flex items-center gap-3">
+                {{csrfField}}
+                <input type="number" name="ai_margin_percent"
+                       value="{{$.Org.AIMarginPercent}}"
+                       min="0" max="500"
+                       class="input input-bordered input-sm w-24">
+                <span class="text-sm text-base-content/70">%</span>
+                <button type="submit" class="btn btn-primary btn-sm">Save</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-3">
+            <div>
+                <h2 class="text-lg font-semibold">Display Currency</h2>
+                <p class="text-sm text-base-content/60 mt-1">
+                    Currency used to display costs for this organization. Does not convert amounts.
+                </p>
+            </div>
+            <form method="POST" action="/orgs/{{.OrgSlug}}/settings/currency"
+                  class="flex items-center gap-3">
+                {{csrfField}}
+                <select name="currency_code" class="select select-bordered select-sm">
+                    {{$cur := $.Org.CurrencyCode}}
+                    <option value="EUR" {{if eq $cur "EUR"}}selected{{end}}>EUR — €</option>
+                    <option value="USD" {{if eq $cur "USD"}}selected{{end}}>USD — $</option>
+                    <option value="GBP" {{if eq $cur "GBP"}}selected{{end}}>GBP — £</option>
+                    <option value="CHF" {{if eq $cur "CHF"}}selected{{end}}>CHF</option>
+                    <option value="SEK" {{if eq $cur "SEK"}}selected{{end}}>SEK</option>
+                    <option value="NOK" {{if eq $cur "NOK"}}selected{{end}}>NOK</option>
+                    <option value="DKK" {{if eq $cur "DKK"}}selected{{end}}>DKK</option>
+                    <option value="PLN" {{if eq $cur "PLN"}}selected{{end}}>PLN</option>
+                    <option value="CZK" {{if eq $cur "CZK"}}selected{{end}}>CZK</option>
+                    <option value="RON" {{if eq $cur "RON"}}selected{{end}}>RON</option>
+                    <option value="HUF" {{if eq $cur "HUF"}}selected{{end}}>HUF</option>
+                    <option value="BGN" {{if eq $cur "BGN"}}selected{{end}}>BGN</option>
+                    <option value="HRK" {{if eq $cur "HRK"}}selected{{end}}>HRK</option>
+                    <option value="JPY" {{if eq $cur "JPY"}}selected{{end}}>JPY — ¥</option>
+                    <option value="CAD" {{if eq $cur "CAD"}}selected{{end}}>CAD — $</option>
+                    <option value="AUD" {{if eq $cur "AUD"}}selected{{end}}>AUD — $</option>
+                </select>
+                <button type="submit" class="btn btn-primary btn-sm">Save</button>
+            </form>
+        </div>
+    </div>
+    {{end}}
+
+    {{if .CanManage}}
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-3">
+            <h2 class="text-lg font-semibold">Invite Member</h2>
+            <form class="flex flex-wrap items-center gap-3"
+                  hx-post="/orgs/{{.OrgSlug}}/invitations"
+                  hx-target="#invite-result-area"
+                  hx-swap="innerHTML"
+                  hx-on::after-request="if(event.detail.successful) { this.reset(); htmx.trigger('#invitation-list', 'refresh'); }">
+                <div class="flex-1 min-w-52">
+                    <input type="email" name="email"
+                           class="input input-bordered w-full"
+                           placeholder="user@example.com" required>
+                </div>
+                <select name="role" class="select select-bordered">
+                    <option value="member">Member</option>
+                    <option value="admin">Admin</option>
+                </select>
+                <button type="submit" class="btn btn-primary btn-sm">Invite</button>
+            </form>
+            <div id="invite-result-area"></div>
+        </div>
+    </div>
+
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-3">
+            <h2 class="text-lg font-semibold">Pending Invitations</h2>
+            <div class="divide-y divide-base-300" id="invitation-list">
+                {{template "invitation_list.html" .}}
+            </div>
+        </div>
+    </div>
+    {{end}}
+
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-3">
+            <h2 class="text-lg font-semibold">Members</h2>
+            <div class="divide-y divide-base-300" id="member-list">
+                {{template "member_list.html" .}}
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Scope — closes #85

Third PR of the v0.3.0 UI migration. Migrates dashboard.html + org_settings.html + org_costs.html to DaisyUI + Tailwind.

Per spec: [\`docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md §6 PR-3\`](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md)

Depends on #89 (PR-1) and #90 (PR-2) — both merged. Uses the shared \`invitation_list.html\` + \`member_list.html\` partials migrated in PR-1.

## Templates migrated

| Template | LOC | Highlights |
|---|---|---|
| \`dashboard.html\` | 126 | Alpine-driven \"New…\" dropdown with sibling forms (project/org), card grid with hover state, HTMX accept/decline on pending invites, empty-state branches |
| \`org_settings.html\` | 296 | Business details form (VAT, address, 34-country select), staff-only AI margin % + display currency controls, member invite flow with HTMX auto-reset, pending invites list, members list |
| \`org_costs.html\` | 132 | Month-picker header, per-project infra cost tables, org-wide AI usage table with margin-billed subtotal (staff vs client views), highlighted grand total |

**449 insertions, 336 deletions across 3 files.**

## New Tailwind/DaisyUI patterns beyond PR-2

- **Alpine dropdown** (\`.dropdown / .dropdown-menu\`): kept existing Alpine state, swapped positioning to \`relative\` + \`absolute right-0 mt-2 w-72 bg-base-100 border border-base-300 rounded-lg shadow-xl\` — flip-to-left on narrow viewports handled natively by \`right-0\`.
- **Card grid**: \`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4\` responsive with \`hover:shadow-md hover:border-primary/40 transition-all\`.
- **DaisyUI tables**: \`table table-sm\` inside \`overflow-x-auto\` — clean default styling with DaisyUI's semantic thead/tbody/tfoot tokens.
- **Form spanning**: grid-cols-2 for VAT+Reg, Postal+City pairs on desktop; single column on mobile.

## Test plan

- [x] \`bash scripts/css.sh\` builds (119KB, +4KB from PR-2)
- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` clean (0 issues)
- [x] Full handler test suite passes (8.272s — no regression)
- [ ] Manual: dashboard renders org cards, \"New…\" dropdown creates project/org, accept/decline invites via HTMX, org settings saves business details, AI margin slider works, currency select persists, member list HTMX updates

## Visual verification

Screenshots skipped this PR — the visual language (cards, grids, tables, forms, dropdowns) matches the patterns already verified in PR-1 base chrome and PR-2 auth-card screenshots. PR-4 will need careful screenshots since the Gantt chart has its own styling independent of DaisyUI.

If you want screenshots before merging, tell me which page and I'll spin up the preview tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)