### PR TITLE
feat(ui): v0.3.0 PR-4 — migrate project pages

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -184,6 +184,56 @@ func NewEngine(templatesDir string, manifest *static.Manifest) (*Engine, error) 
 				return colorGray
 			}
 		},
+		// statusBadgeClass maps a ticket status to a DaisyUI badge
+		// variant. Used by migrated templates (PR-4 onward) to get
+		// theme-aware badge colors. The older statusColor helper
+		// (above) returns hand-CSS color names and is retained for
+		// still-unmigrated templates until PR-6.
+		"statusBadgeClass": func(status string) string {
+			const (
+				ghost   = "badge-ghost"
+				warning = "badge-warning"
+				primary = "badge-primary"
+			)
+			switch status {
+			case "backlog":
+				return ghost
+			case "ready":
+				return "badge-info"
+			case "planning", "plan_review":
+				return primary
+			case "implementing":
+				return warning
+			case "testing":
+				return warning
+			case "review":
+				return primary
+			case "done":
+				return "badge-success"
+			case "cancelled":
+				return "badge-error"
+			default:
+				return ghost
+			}
+		},
+		"priorityBadgeClass": func(p string) string {
+			const (
+				ghost   = "badge-ghost"
+				warning = "badge-warning"
+			)
+			switch p {
+			case "critical":
+				return "badge-error"
+			case "high":
+				return warning
+			case "medium":
+				return warning
+			case "low":
+				return ghost
+			default:
+				return ghost
+			}
+		},
 		"derefStr": func(s *string) string {
 			if s == nil {
 				return ""

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -217,17 +217,18 @@ func NewEngine(templatesDir string, manifest *static.Manifest) (*Engine, error) 
 			}
 		},
 		"priorityBadgeClass": func(p string) string {
-			const (
-				ghost   = "badge-ghost"
-				warning = "badge-warning"
-			)
+			// Preserves a 4-level visual hierarchy (error > warning
+			// > info > ghost) matching the legacy red/orange/yellow/
+			// gray palette; both high+medium mapping to warning would
+			// collapse two adjacent levels into one badge color.
+			const ghost = "badge-ghost"
 			switch p {
 			case "critical":
 				return "badge-error"
 			case "high":
-				return warning
+				return "badge-warning"
 			case "medium":
-				return warning
+				return "badge-info"
 			case "low":
 				return ghost
 			default:

--- a/templates/components/project_tabs.html
+++ b/templates/components/project_tabs.html
@@ -1,20 +1,20 @@
 {{define "project_tabs"}}
-<nav class="tabs">
+<div role="tablist" class="tabs tabs-bordered border-b border-base-300 mb-6 -mx-6 px-6">
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/brief"
-       class="tab-link {{if eq .Tab "brief"}}active{{end}}">Brief</a>
+       role="tab" class="tab {{if eq .Tab "brief"}}tab-active{{end}}">Brief</a>
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/features"
-       class="tab-link {{if eq .Tab "features"}}active{{end}}">Features</a>
+       role="tab" class="tab {{if eq .Tab "features"}}tab-active{{end}}">Features</a>
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/bugs"
-       class="tab-link {{if eq .Tab "bugs"}}active{{end}}">Bugs</a>
+       role="tab" class="tab {{if eq .Tab "bugs"}}tab-active{{end}}">Bugs</a>
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/gantt"
-       class="tab-link {{if eq .Tab "gantt"}}active{{end}}">Timeline</a>
+       role="tab" class="tab {{if eq .Tab "gantt"}}tab-active{{end}}">Timeline</a>
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/costs"
-       class="tab-link {{if eq .Tab "costs"}}active{{end}}">Costs</a>
+       role="tab" class="tab {{if eq .Tab "costs"}}tab-active{{end}}">Costs</a>
     {{if .IsStaff}}
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/archived"
-       class="tab-link {{if eq .Tab "archived"}}active{{end}}">Archived</a>
+       role="tab" class="tab {{if eq .Tab "archived"}}tab-active{{end}}">Archived</a>
     <a href="/orgs/{{.Org.Slug}}/projects/{{.Project.Slug}}/settings"
-       class="tab-link {{if eq .Tab "settings"}}active{{end}}">Settings</a>
+       role="tab" class="tab {{if eq .Tab "settings"}}tab-active{{end}}">Settings</a>
     {{end}}
-</nav>
+</div>
 {{end}}

--- a/templates/components/ticket_card.html
+++ b/templates/components/ticket_card.html
@@ -1,10 +1,10 @@
-<div class="card card-compact card-hover">
-    <a href="/tickets/{{.ID}}">
-        <div class="ticket-row">
-            <span class="ticket-row-title">{{.Title}}</span>
-            <div class="ticket-row-badges">
-                <span class="badge badge-{{statusColor .Status}}">{{.Status}}</span>
-            </div>
+<a href="/tickets/{{.ID}}"
+   class="card bg-base-100 border border-base-300 shadow-sm
+          hover:shadow-md hover:border-primary/40 transition-all">
+    <div class="card-body p-4 flex-row items-center justify-between gap-3">
+        <span class="font-medium text-sm truncate">{{.Title}}</span>
+        <div class="flex items-center gap-1.5 shrink-0">
+            <span class="badge badge-sm {{statusBadgeClass .Status}}">{{.Status}}</span>
         </div>
-    </a>
-</div>
+    </div>
+</a>

--- a/templates/pages/project_archived.html
+++ b/templates/pages/project_archived.html
@@ -1,38 +1,43 @@
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-6xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
-    <h2 class="mb-md">Archived Tickets</h2>
+    <div class="flex flex-col gap-4">
+        <h2 class="text-xl font-semibold">Archived Tickets</h2>
 
-    {{if .Tickets}}
-    <div class="stack-sm">
-        {{range .Tickets}}
-        <div class="card card-compact">
-            <div class="ticket-row">
-                <a href="/tickets/{{.ID}}" class="ticket-row-title" style="flex:1">{{.Title}}</a>
-                <div class="ticket-row-badges">
-                    <span class="badge badge-gray badge-uppercase">{{.Type}}</span>
-                    <span class="badge badge-{{statusColor .Status}}">{{.Status}}</span>
-                    <span class="badge badge-{{priorityColor .Priority}}">{{.Priority}}</span>
+        {{if .Tickets}}
+        <div class="flex flex-col gap-2">
+            {{range .Tickets}}
+            <div class="card bg-base-100 border border-base-300">
+                <div class="card-body p-4 flex-row items-center justify-between gap-3 flex-wrap">
+                    <a href="/tickets/{{.ID}}"
+                       class="flex-1 font-medium text-sm hover:text-primary min-w-32">{{.Title}}</a>
+                    <div class="flex items-center gap-1.5 shrink-0">
+                        <span class="badge badge-sm badge-ghost uppercase">{{.Type}}</span>
+                        <span class="badge badge-sm {{statusBadgeClass .Status}}">{{.Status}}</span>
+                        <span class="badge badge-sm {{priorityBadgeClass .Priority}}">{{.Priority}}</span>
+                    </div>
+                    <div class="flex gap-2 shrink-0">
+                        <button hx-post="/tickets/{{.ID}}/restore"
+                                hx-confirm="Restore this ticket and its children?"
+                                class="btn btn-ghost btn-sm">Restore</button>
+                        <button hx-delete="/tickets/{{.ID}}"
+                                hx-confirm="Permanently delete? This cannot be undone."
+                                class="btn btn-ghost btn-sm text-error">Delete</button>
+                    </div>
                 </div>
-                <div class="flex gap-sm" style="margin-left:auto">
-                    <button hx-post="/tickets/{{.ID}}/restore"
-                            hx-confirm="Restore this ticket and its children?"
-                            class="btn btn-secondary btn-sm">Restore</button>
-                    <button hx-delete="/tickets/{{.ID}}"
-                            hx-confirm="Permanently delete? This cannot be undone."
-                            class="btn btn-ghost btn-sm text-danger">Delete</button>
-                </div>
+            </div>
+            {{end}}
+        </div>
+        {{else}}
+        <div class="card bg-base-100 border border-base-300">
+            <div class="card-body p-8 text-center text-sm text-base-content/60">
+                No archived tickets.
             </div>
         </div>
         {{end}}
     </div>
-    {{else}}
-    <div class="empty-state">
-        <p>No archived tickets.</p>
-    </div>
-    {{end}}
 </div>
 {{end}}
 {{end}}

--- a/templates/pages/project_brief.html
+++ b/templates/pages/project_brief.html
@@ -4,84 +4,127 @@
 
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-4xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
     <div x-data="briefEditor()" x-ref="briefRoot">
         <div x-show="!editing">
-            <div class="flex items-center justify-between mb-md">
-                <h2>Project Brief</h2>
-                <div class="flex gap-sm">
+            <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+                <h2 class="text-xl font-semibold">Project Brief</h2>
+                <div class="flex gap-2">
                     {{if .Project.BriefMarkdown}}
                     <form hx-post="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/brief/reviewed" hx-swap="none"
                           hx-confirm="Confirm that you have reviewed this brief and have no changes?">
-                        <button type="submit" class="btn btn-secondary btn-sm">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                        <button type="submit" class="btn btn-ghost btn-sm gap-1.5">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                                 fill="none" stroke="currentColor" stroke-width="2"
+                                 stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="20 6 9 17 4 12"/>
+                            </svg>
                             Mark as reviewed
                         </button>
                     </form>
                     {{end}}
-                    <button @click="startEditing()" class="btn btn-secondary btn-sm">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                    <button @click="startEditing()" class="btn btn-primary btn-sm gap-1.5">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2"
+                             stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                        </svg>
                         Edit
                     </button>
                 </div>
             </div>
             {{if .Project.BriefMarkdown}}
-            <div class="card">
-                <div class="prose">{{markdown .Project.BriefMarkdown}}</div>
+            <div class="card bg-base-100 border border-base-300 shadow-sm">
+                <div class="card-body p-6">
+                    <div class="prose prose-sm max-w-none">{{markdown .Project.BriefMarkdown}}</div>
+                </div>
             </div>
             {{else}}
-            <div class="brief-empty-state">
-                <div class="brief-empty-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-                </div>
-                <h3>No project brief yet</h3>
-                <p>Your project brief is the foundation for all work — it describes what you're building, who it's for, and the key requirements.</p>
-                <div class="brief-empty-hint">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-                    <span>Open the <strong>Project Chat</strong> and describe your project — the AI will generate a detailed, structured brief that you can edit afterwards.</span>
+            <div class="card bg-base-200 border border-base-300">
+                <div class="card-body p-10 text-center gap-3">
+                    <div class="mx-auto text-base-content/40">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="1.5"
+                             stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                            <polyline points="14 2 14 8 20 8"/>
+                            <line x1="16" y1="13" x2="8" y2="13"/>
+                            <line x1="16" y1="17" x2="8" y2="17"/>
+                            <polyline points="10 9 9 9 8 9"/>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold">No project brief yet</h3>
+                    <p class="text-sm text-base-content/70">
+                        Your project brief is the foundation for all work — it describes what you're building, who it's for, and the key requirements.
+                    </p>
+                    <div class="alert alert-info mt-2 text-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2"
+                             stroke-linecap="round" stroke-linejoin="round">
+                            <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+                        </svg>
+                        <span>
+                            Open the <strong>Project Chat</strong> and describe your project — the AI will generate a detailed, structured brief that you can edit afterwards.
+                        </span>
+                    </div>
                 </div>
             </div>
             {{end}}
         </div>
         <div x-show="editing" x-cloak>
-            <div class="flex items-center justify-between mb-md">
-                <h2>Edit Brief</h2>
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="text-xl font-semibold">Edit Brief</h2>
             </div>
-            <form @submit="syncEditor()" hx-put="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/brief" hx-swap="none">
-                <div class="form-group">
-                    <textarea x-ref="briefTextarea" name="brief" rows="20" class="form-textarea font-mono">{{.Project.BriefMarkdown}}</textarea>
+            <form @submit="syncEditor()"
+                  hx-put="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/brief"
+                  hx-swap="none"
+                  class="flex flex-col gap-3">
+                <div class="form-control">
+                    <textarea x-ref="briefTextarea" name="brief" rows="20"
+                              class="textarea textarea-bordered font-mono text-sm">{{.Project.BriefMarkdown}}</textarea>
                 </div>
-                <div class="flex gap-sm">
+                <div class="flex gap-2">
                     <button type="submit" class="btn btn-primary">Save</button>
-                    <button type="button" @click="cancelEditing()" class="btn btn-secondary">Cancel</button>
+                    <button type="button" @click="cancelEditing()" class="btn btn-ghost">Cancel</button>
                 </div>
             </form>
         </div>
     </div>
 
     {{if .Revisions}}
-    <div class="mt-lg">
-        <h3 class="mb-md">Revision History</h3>
-        <div class="revision-list">
+    <div class="mt-8 flex flex-col gap-3">
+        <h3 class="text-base font-semibold">Revision History</h3>
+        <div class="flex flex-col gap-2">
             {{range .Revisions}}
-            <div class="revision-item">
-                <div class="revision-icon {{if eq .Action "edit"}}revision-icon-edit{{else}}revision-icon-reviewed{{end}}">
+            <div class="flex items-center gap-3 p-3 rounded-md bg-base-200 border border-base-300">
+                <div class="w-7 h-7 rounded-full flex items-center justify-center shrink-0
+                            {{if eq .Action "edit"}}bg-primary/10 text-primary{{else}}bg-success/10 text-success{{end}}">
                     {{if eq .Action "edit"}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                         fill="none" stroke="currentColor" stroke-width="2"
+                         stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                    </svg>
                     {{else}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                         fill="none" stroke="currentColor" stroke-width="2"
+                         stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="20 6 9 17 4 12"/>
+                    </svg>
                     {{end}}
                 </div>
-                <div class="revision-content">
-                    <span class="revision-author">{{.UserName}}</span>
+                <div class="flex-1 text-sm min-w-0">
+                    <span class="font-medium">{{.UserName}}</span>
                     {{if eq .Action "edit"}}
-                    <span class="revision-action">edited the brief</span>
+                    <span class="text-base-content/70">edited the brief</span>
                     {{else}}
-                    <span class="revision-action">reviewed — no changes</span>
+                    <span class="text-base-content/70">reviewed — no changes</span>
                     {{end}}
-                    <span class="revision-time">{{formatDateTime .CreatedAt}}</span>
+                    <span class="text-xs text-base-content/50 ml-2">{{formatDateTime .CreatedAt}}</span>
                 </div>
             </div>
             {{end}}
@@ -148,8 +191,6 @@ function briefEditor() {
         }
     };
 }
-
 </script>
-
 {{end}}
 {{end}}

--- a/templates/pages/project_bugs.html
+++ b/templates/pages/project_bugs.html
@@ -1,74 +1,93 @@
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-6xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
-    <div class="flex items-center justify-between mb-md">
-        <h2>Bugs</h2>
-        <div class="dropdown" x-data="{ open: false }">
-            <button @click="open = !open" class="btn btn-danger btn-sm">Report Bug</button>
-            <div x-show="open" @click.outside="open = false" x-transition class="dropdown-menu" style="min-width:20rem" @click.stop>
-                <form method="POST" action="/tickets" class="dropdown-form">
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <h2 class="text-xl font-semibold">Bugs</h2>
+        <div class="relative" x-data="{ open: false }">
+            <button @click="open = !open" class="btn btn-error btn-sm">Report Bug</button>
+            <div x-show="open" x-transition x-cloak @click.outside="open = false" @click.stop
+                 class="absolute right-0 mt-2 w-80 bg-base-100 border border-base-300
+                        rounded-lg shadow-xl z-40 p-4">
+                <form method="POST" action="/tickets" class="flex flex-col gap-3">
                     {{csrfField}}
                     <input type="hidden" name="project_id" value="{{.Project.ID}}">
                     <input type="hidden" name="type" value="bug">
-                    <div class="stack">
-                        <div class="form-group">
-                            <label class="form-label">Description</label>
-                            <textarea name="description" rows="3" required placeholder="Describe the bug..." class="form-textarea"></textarea>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Priority</label>
-                            <select name="priority" class="form-select">
-                                <option value="low">Low</option>
-                                <option value="medium" selected>Medium</option>
-                                <option value="high">High</option>
-                                <option value="critical">Critical</option>
-                            </select>
-                        </div>
-                        <div class="form-row">
-                            <div class="form-group">
-                                <label class="form-label">Start</label>
-                                <input type="date" name="date_start" class="form-input">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">End</label>
-                                <input type="date" name="date_end" class="form-input">
-                            </div>
-                        </div>
-                        <button type="submit" class="btn btn-danger btn-block">Report</button>
+                    <div class="form-control">
+                        <label class="label pb-1"><span class="label-text">Description</span></label>
+                        <textarea name="description" rows="3" required
+                                  placeholder="Describe the bug..."
+                                  class="textarea textarea-bordered w-full text-sm"></textarea>
                     </div>
+                    <div class="form-control">
+                        <label class="label pb-1"><span class="label-text">Priority</span></label>
+                        <select name="priority" class="select select-bordered select-sm w-full">
+                            <option value="low">Low</option>
+                            <option value="medium" selected>Medium</option>
+                            <option value="high">High</option>
+                            <option value="critical">Critical</option>
+                        </select>
+                    </div>
+                    <div class="grid grid-cols-2 gap-3">
+                        <div class="form-control">
+                            <label class="label pb-1"><span class="label-text">Start</span></label>
+                            <input type="date" name="date_start" class="input input-bordered input-sm w-full">
+                        </div>
+                        <div class="form-control">
+                            <label class="label pb-1"><span class="label-text">End</span></label>
+                            <input type="date" name="date_end" class="input input-bordered input-sm w-full">
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-error btn-sm btn-block">Report</button>
                 </form>
             </div>
         </div>
     </div>
 
     {{if .Tickets}}
-    <div class="stack-sm">
+    <div class="flex flex-col gap-2">
         {{range .Tickets}}
-        <a href="/tickets/{{.ID}}" class="card card-compact card-hover">
-            <div class="ticket-row">
-                <span class="ticket-row-title">{{.Title}}</span>
-                <div class="ticket-row-badges">
-                    <span class="badge badge-{{statusColor .Status}}">{{.Status}}</span>
-                    <span class="badge badge-{{priorityColor .Priority}}">{{.Priority}}</span>
+        <a href="/tickets/{{.ID}}"
+           class="card bg-base-100 border border-base-300 shadow-sm
+                  hover:shadow-md hover:border-primary/40 transition-all">
+            <div class="card-body p-4 gap-2">
+                <div class="flex items-center justify-between gap-3 flex-wrap">
+                    <span class="font-medium text-sm truncate flex-1 min-w-0">{{.Title}}</span>
+                    <div class="flex items-center gap-1.5 shrink-0">
+                        <span class="badge badge-sm {{statusBadgeClass .Status}}">{{.Status}}</span>
+                        <span class="badge badge-sm {{priorityBadgeClass .Priority}}">{{.Priority}}</span>
+                    </div>
                 </div>
+                {{if .DescriptionMarkdown}}
+                <div class="text-xs text-base-content/60 line-clamp-2">
+                    {{truncate .DescriptionMarkdown 150}}
+                </div>
+                {{end}}
+                {{if or .DateStart .DateEnd}}
+                <div class="flex items-center gap-1.5 text-xs text-base-content/60">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"
+                         fill="none" stroke="currentColor" stroke-width="2"
+                         stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                        <line x1="16" y1="2" x2="16" y2="6"/>
+                        <line x1="8" y1="2" x2="8" y2="6"/>
+                        <line x1="3" y1="10" x2="21" y2="10"/>
+                    </svg>
+                    <span>
+                        {{if .DateStart}}{{formatDate .DateStart}}{{end}}{{if and .DateStart .DateEnd}} → {{end}}{{if .DateEnd}}{{formatDate .DateEnd}}{{end}}
+                    </span>
+                </div>
+                {{end}}
             </div>
-            {{if .DescriptionMarkdown}}
-            <div class="ticket-row-desc">{{truncate .DescriptionMarkdown 150}}</div>
-            {{end}}
-            {{if or .DateStart .DateEnd}}
-            <div class="ticket-row-dates">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                {{if .DateStart}}{{formatDate .DateStart}}{{end}}{{if and .DateStart .DateEnd}} → {{end}}{{if .DateEnd}}{{formatDate .DateEnd}}{{end}}
-            </div>
-            {{end}}
         </a>
         {{end}}
     </div>
     {{else}}
-    <div class="empty-state">
-        <p>No bugs reported. That's great!</p>
+    <div class="card bg-base-100 border border-base-300">
+        <div class="card-body p-10 text-center text-sm text-base-content/60">
+            No bugs reported. That's great!
+        </div>
     </div>
     {{end}}
 </div>

--- a/templates/pages/project_costs.html
+++ b/templates/pages/project_costs.html
@@ -104,7 +104,8 @@
                                 <label class="label pb-1">
                                     <span class="label-text">Amount ({{$.Org.CurrencyCode}})</span>
                                 </label>
-                                <input type="text" name="amount"
+                                <input type="number" name="amount"
+                                       step="0.01" min="0"
                                        class="input input-bordered input-sm w-full"
                                        placeholder="12.50" required>
                             </div>

--- a/templates/pages/project_costs.html
+++ b/templates/pages/project_costs.html
@@ -1,162 +1,194 @@
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-6xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
-    <!-- Month Picker -->
-    <div class="flex items-center justify-between mb-lg">
-        <h2>Costs — {{.Month}}</h2>
-        <div class="flex items-center gap-sm">
-            <a href="?month={{.PrevMonth}}" class="btn btn-secondary btn-sm">&larr; Prev</a>
-            <span class="text-sm text-muted">{{.Month}}</span>
-            <a href="?month={{.NextMonth}}" class="btn btn-secondary btn-sm">Next &rarr;</a>
+    <header class="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <h2 class="text-xl font-semibold">Costs — {{.Month}}</h2>
+        <div class="flex items-center gap-2">
+            <a href="?month={{.PrevMonth}}" class="btn btn-ghost btn-sm">← Prev</a>
+            <span class="text-sm text-base-content/70 px-2 font-medium">{{.Month}}</span>
+            <a href="?month={{.NextMonth}}" class="btn btn-ghost btn-sm">Next →</a>
         </div>
-    </div>
+    </header>
 
-    <!-- Infrastructure Costs -->
-    <div class="mb-lg">
-        <h3 class="mb-sm">Infrastructure Costs</h3>
+    {{/* Infrastructure Costs */}}
+    <section class="flex flex-col gap-3 mb-6">
+        <h3 class="text-base font-semibold">Infrastructure Costs</h3>
         {{if .Costs}}
-        <div class="table-wrap">
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>Category</th>
-                        <th>Name</th>
-                        <th style="text-align:right">Amount</th>
-                        {{if .CanEdit}}<th style="width:6rem"></th>{{end}}
-                    </tr>
-                </thead>
-                <tbody>
-                    {{range .Costs}}
-                    <tr>
-                        <td class="cost-category">{{humanize .Category}}</td>
-                        <td>{{if .Name}}{{.Name}}{{else}}<span class="text-muted">—</span>{{end}}</td>
-                        <td style="text-align:right;font-weight:500">{{formatCents .AmountCents $.Org.CurrencyCode}}</td>
-                        {{if $.Data.CanEdit}}
-                        <td>
-                            <button class="btn btn-ghost btn-sm"
-                                    hx-delete="/costs/{{.ID}}"
-                                    hx-confirm="Delete this cost item?"
-                                    hx-target="closest tr"
-                                    hx-swap="outerHTML">Delete</button>
-                        </td>
-                        {{end}}
-                    </tr>
-                    {{end}}
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td colspan="2" style="font-weight:600">Infrastructure Subtotal</td>
-                        <td style="text-align:right;font-weight:600">{{formatCents .InfraTotal $.Org.CurrencyCode}}</td>
-                        {{if .CanEdit}}<td></td>{{end}}
-                    </tr>
-                </tfoot>
-            </table>
+        <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <div class="card-body p-5">
+                <div class="overflow-x-auto">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr class="text-base-content/70">
+                                <th>Category</th>
+                                <th>Name</th>
+                                <th class="text-right">Amount</th>
+                                {{if .CanEdit}}<th class="w-24"></th>{{end}}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{range .Costs}}
+                            <tr>
+                                <td class="font-mono text-xs">{{humanize .Category}}</td>
+                                <td>{{if .Name}}{{.Name}}{{else}}<span class="text-base-content/50">—</span>{{end}}</td>
+                                <td class="text-right font-medium">{{formatCents .AmountCents $.Org.CurrencyCode}}</td>
+                                {{if $.Data.CanEdit}}
+                                <td>
+                                    <button class="btn btn-ghost btn-xs text-error"
+                                            hx-delete="/costs/{{.ID}}"
+                                            hx-confirm="Delete this cost item?"
+                                            hx-target="closest tr"
+                                            hx-swap="outerHTML">Delete</button>
+                                </td>
+                                {{end}}
+                            </tr>
+                            {{end}}
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="2" class="font-semibold">Infrastructure Subtotal</td>
+                                <td class="text-right font-semibold">{{formatCents .InfraTotal $.Org.CurrencyCode}}</td>
+                                {{if .CanEdit}}<td></td>{{end}}
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
         </div>
         {{else}}
-        <div class="empty-state" style="padding:1.5rem">
-            <p class="text-muted">No infrastructure costs for this month.</p>
+        <div class="card bg-base-100 border border-base-300">
+            <div class="card-body p-6 text-center text-sm text-base-content/60">
+                No infrastructure costs for this month.
+            </div>
         </div>
         {{end}}
 
         {{if .CanEdit}}
-        <div class="mt-lg" x-data="{ open: false }">
-            <button @click="open = !open" class="btn btn-secondary btn-sm">Add Cost Item</button>
-            <div x-show="open" x-transition class="card card-compact mt-lg" style="max-width:32rem">
-                <form method="POST" action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/costs">
-                    {{csrfField}}
-                    <input type="hidden" name="month" value="{{.Month}}">
-                    <div class="stack">
-                        <div class="form-group">
-                            <label class="form-label">Category</label>
-                            <select name="category" class="form-select" required>
-                                <option value="">Select...</option>
-                                <option value="base_fee">Base Fee</option>
-                                <option value="dev_environment">Dev Environment</option>
-                                <option value="testing_db">Testing Database</option>
-                                <option value="testing_container">Testing Container</option>
-                                <option value="production_container">Production Container</option>
-                                <option value="production_database">Production Database</option>
-                                <option value="advanced_monitoring">Advanced Monitoring</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Name <span class="form-label-hint">(optional)</span></label>
-                            <input type="text" name="name" class="form-input" placeholder="e.g. PostgreSQL staging">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Amount ({{$.Org.CurrencyCode}})</label>
-                            <input type="text" name="amount" class="form-input" placeholder="12.50" required>
-                        </div>
-                        <button type="submit" class="btn btn-primary">Add</button>
+        <div x-data="{ open: false }">
+            <button @click="open = !open" class="btn btn-ghost btn-sm">
+                <span x-text="open ? '− Hide' : '+ Add Cost Item'">+ Add Cost Item</span>
+            </button>
+            <div x-show="open" x-transition x-cloak class="mt-3 max-w-md">
+                <div class="card bg-base-100 border border-base-300 shadow-sm">
+                    <div class="card-body p-5">
+                        <form method="POST"
+                              action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/costs"
+                              class="flex flex-col gap-3">
+                            {{csrfField}}
+                            <input type="hidden" name="month" value="{{.Month}}">
+                            <div class="form-control">
+                                <label class="label pb-1"><span class="label-text">Category</span></label>
+                                <select name="category" class="select select-bordered select-sm w-full" required>
+                                    <option value="">Select...</option>
+                                    <option value="base_fee">Base Fee</option>
+                                    <option value="dev_environment">Dev Environment</option>
+                                    <option value="testing_db">Testing Database</option>
+                                    <option value="testing_container">Testing Container</option>
+                                    <option value="production_container">Production Container</option>
+                                    <option value="production_database">Production Database</option>
+                                    <option value="advanced_monitoring">Advanced Monitoring</option>
+                                </select>
+                            </div>
+                            <div class="form-control">
+                                <label class="label pb-1">
+                                    <span class="label-text">Name</span>
+                                    <span class="label-text-alt text-base-content/60">optional</span>
+                                </label>
+                                <input type="text" name="name"
+                                       class="input input-bordered input-sm w-full"
+                                       placeholder="e.g. PostgreSQL staging">
+                            </div>
+                            <div class="form-control">
+                                <label class="label pb-1">
+                                    <span class="label-text">Amount ({{$.Org.CurrencyCode}})</span>
+                                </label>
+                                <input type="text" name="amount"
+                                       class="input input-bordered input-sm w-full"
+                                       placeholder="12.50" required>
+                            </div>
+                            <div>
+                                <button type="submit" class="btn btn-primary btn-sm">Add</button>
+                            </div>
+                        </form>
                     </div>
-                </form>
+                </div>
             </div>
         </div>
         {{end}}
-    </div>
+    </section>
 
-    <!-- AI Usage -->
-    <div class="mb-lg">
-        <h3 class="mb-sm">AI Usage</h3>
+    {{/* AI Usage */}}
+    <section class="flex flex-col gap-3 mb-6">
+        <h3 class="text-base font-semibold">AI Usage</h3>
         {{if .AIUsage}}
-        <div class="table-wrap">
-            <table class="table">
-                <thead>
-                    <tr>
-                        {{if .CanEdit}}<th>Model</th>{{end}}
-                        <th>Type</th>
-                        <th style="text-align:right">Count</th>
-                        {{if .CanEdit}}
-                        <th style="text-align:right">Input Tokens</th>
-                        <th style="text-align:right">Output Tokens</th>
-                        {{end}}
-                        <th style="text-align:right">Cost</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{range .AIUsage}}
-                    <tr>
-                        {{if $.Data.CanEdit}}<td class="text-muted">{{.Model}}</td>{{end}}
-                        <td style="font-weight:500">{{.Label}}</td>
-                        <td style="text-align:right">{{.EntryCount}}</td>
-                        {{if $.Data.CanEdit}}
-                        <td style="text-align:right">{{.InputTokens}}</td>
-                        <td style="text-align:right">{{.OutputTokens}}</td>
-                        {{end}}
-                        <td style="text-align:right;font-weight:500">{{formatCents .TotalCents $.Org.CurrencyCode}}</td>
-                    </tr>
-                    {{end}}
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td colspan="{{if .CanEdit}}5{{else}}2{{end}}" style="font-weight:600">AI Subtotal</td>
-                        {{if .CanEdit}}
-                        <td style="text-align:right;font-weight:600">
-                            {{formatCents .AITotal $.Org.CurrencyCode}}
-                            {{if gt .AIMargin 0}}
-                            <span class="text-sm text-muted" style="display:block">(billed: {{formatCents .AITotalWithMargin $.Org.CurrencyCode}} at +{{.AIMargin}}%)</span>
+        <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <div class="card-body p-5">
+                <div class="overflow-x-auto">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr class="text-base-content/70">
+                                {{if .CanEdit}}<th>Model</th>{{end}}
+                                <th>Type</th>
+                                <th class="text-right">Count</th>
+                                {{if .CanEdit}}
+                                <th class="text-right">Input Tokens</th>
+                                <th class="text-right">Output Tokens</th>
+                                {{end}}
+                                <th class="text-right">Cost</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{range .AIUsage}}
+                            <tr>
+                                {{if $.Data.CanEdit}}<td class="font-mono text-xs text-base-content/70">{{.Model}}</td>{{end}}
+                                <td class="font-medium">{{.Label}}</td>
+                                <td class="text-right">{{.EntryCount}}</td>
+                                {{if $.Data.CanEdit}}
+                                <td class="text-right">{{.InputTokens}}</td>
+                                <td class="text-right">{{.OutputTokens}}</td>
+                                {{end}}
+                                <td class="text-right font-medium">{{formatCents .TotalCents $.Org.CurrencyCode}}</td>
+                            </tr>
                             {{end}}
-                        </td>
-                        {{else}}
-                        <td style="text-align:right;font-weight:600">{{formatCents .AITotalWithMargin $.Org.CurrencyCode}}</td>
-                        {{end}}
-                    </tr>
-                </tfoot>
-            </table>
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="{{if .CanEdit}}5{{else}}2{{end}}" class="font-semibold">AI Subtotal</td>
+                                {{if .CanEdit}}
+                                <td class="text-right font-semibold">
+                                    {{formatCents .AITotal $.Org.CurrencyCode}}
+                                    {{if gt .AIMargin 0}}
+                                    <span class="block text-xs text-base-content/60 font-normal">
+                                        (billed: {{formatCents .AITotalWithMargin $.Org.CurrencyCode}} at +{{.AIMargin}}%)
+                                    </span>
+                                    {{end}}
+                                </td>
+                                {{else}}
+                                <td class="text-right font-semibold">{{formatCents .AITotalWithMargin $.Org.CurrencyCode}}</td>
+                                {{end}}
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
         </div>
         {{else}}
-        <div class="empty-state" style="padding:1.5rem">
-            <p class="text-muted">No AI usage for this month.</p>
+        <div class="card bg-base-100 border border-base-300">
+            <div class="card-body p-6 text-center text-sm text-base-content/60">
+                No AI usage for this month.
+            </div>
         </div>
         {{end}}
-    </div>
+    </section>
 
-    <!-- Grand Total -->
-    <div class="card" style="text-align:right">
-        <span class="text-muted" style="margin-right:.5rem">Total for {{.Month}}:</span>
-        <span class="cost-total">{{formatCents .GrandTotal $.Org.CurrencyCode}}</span>
+    {{/* Grand Total */}}
+    <div class="card bg-primary/5 border border-primary/20">
+        <div class="card-body p-5 flex-row items-center justify-between">
+            <span class="text-base-content/70">Total for {{.Month}}:</span>
+            <span class="text-2xl font-semibold">{{formatCents .GrandTotal $.Org.CurrencyCode}}</span>
+        </div>
     </div>
 </div>
 {{end}}

--- a/templates/pages/project_features.html
+++ b/templates/pages/project_features.html
@@ -1,66 +1,85 @@
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-6xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
-    <div class="flex items-center justify-between mb-md">
-        <h2>Features</h2>
-        <div class="dropdown" x-data="{ open: false }">
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <h2 class="text-xl font-semibold">Features</h2>
+        <div class="relative" x-data="{ open: false }">
             <button @click="open = !open" class="btn btn-primary btn-sm">New Feature</button>
-            <div x-show="open" @click.outside="open = false" x-transition class="dropdown-menu" style="min-width:20rem" @click.stop>
-                <form method="POST" action="/tickets" class="dropdown-form">
+            <div x-show="open" x-transition x-cloak @click.outside="open = false" @click.stop
+                 class="absolute right-0 mt-2 w-80 bg-base-100 border border-base-300
+                        rounded-lg shadow-xl z-40 p-4">
+                <form method="POST" action="/tickets" class="flex flex-col gap-3">
                     {{csrfField}}
                     <input type="hidden" name="project_id" value="{{.Project.ID}}">
                     <input type="hidden" name="type" value="feature">
-                    <div class="stack">
-                        <div class="form-group">
-                            <label class="form-label">Description</label>
-                            <textarea name="description" rows="3" required placeholder="Describe the feature..." class="form-textarea"></textarea>
-                        </div>
-                        <div class="form-row">
-                            <div class="form-group">
-                                <label class="form-label">Start</label>
-                                <input type="date" name="date_start" class="form-input">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">End</label>
-                                <input type="date" name="date_end" class="form-input">
-                            </div>
-                        </div>
-                        <button type="submit" class="btn btn-primary btn-block">Create</button>
+                    <div class="form-control">
+                        <label class="label pb-1"><span class="label-text">Description</span></label>
+                        <textarea name="description" rows="3" required
+                                  placeholder="Describe the feature..."
+                                  class="textarea textarea-bordered w-full text-sm"></textarea>
                     </div>
+                    <div class="grid grid-cols-2 gap-3">
+                        <div class="form-control">
+                            <label class="label pb-1"><span class="label-text">Start</span></label>
+                            <input type="date" name="date_start" class="input input-bordered input-sm w-full">
+                        </div>
+                        <div class="form-control">
+                            <label class="label pb-1"><span class="label-text">End</span></label>
+                            <input type="date" name="date_end" class="input input-bordered input-sm w-full">
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-sm btn-block">Create</button>
                 </form>
             </div>
         </div>
     </div>
 
     {{if .Tickets}}
-    <div class="stack-sm">
+    <div class="flex flex-col gap-2">
         {{range .Tickets}}
-        <a href="/tickets/{{.ID}}" class="card card-compact card-hover">
-            <div class="ticket-row">
-                <span class="ticket-row-title">{{.Title}}</span>
-                <div class="ticket-row-badges">
-                    <span class="badge badge-{{statusColor .Status}}">{{.Status}}</span>
-                    <span class="badge badge-{{priorityColor .Priority}}">{{.Priority}}</span>
-                    {{if .ChildCount}}<span class="badge badge-gray">{{.ChildCount}} tasks</span>{{end}}
+        <a href="/tickets/{{.ID}}"
+           class="card bg-base-100 border border-base-300 shadow-sm
+                  hover:shadow-md hover:border-primary/40 transition-all">
+            <div class="card-body p-4 gap-2">
+                <div class="flex items-center justify-between gap-3 flex-wrap">
+                    <span class="font-medium text-sm truncate flex-1 min-w-0">{{.Title}}</span>
+                    <div class="flex items-center gap-1.5 shrink-0">
+                        <span class="badge badge-sm {{statusBadgeClass .Status}}">{{.Status}}</span>
+                        <span class="badge badge-sm {{priorityBadgeClass .Priority}}">{{.Priority}}</span>
+                        {{if .ChildCount}}<span class="badge badge-sm badge-ghost">{{.ChildCount}} tasks</span>{{end}}
+                    </div>
                 </div>
+                {{if .DescriptionMarkdown}}
+                <div class="text-xs text-base-content/60 line-clamp-2">
+                    {{truncate .DescriptionMarkdown 150}}
+                </div>
+                {{end}}
+                {{if or .DateStart .DateEnd}}
+                <div class="flex items-center gap-1.5 text-xs text-base-content/60">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"
+                         fill="none" stroke="currentColor" stroke-width="2"
+                         stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                        <line x1="16" y1="2" x2="16" y2="6"/>
+                        <line x1="8" y1="2" x2="8" y2="6"/>
+                        <line x1="3" y1="10" x2="21" y2="10"/>
+                    </svg>
+                    <span>
+                        {{if .DateStart}}{{formatDate .DateStart}}{{end}}{{if and .DateStart .DateEnd}} → {{end}}{{if .DateEnd}}{{formatDate .DateEnd}}{{end}}
+                    </span>
+                </div>
+                {{end}}
             </div>
-            {{if .DescriptionMarkdown}}
-            <div class="ticket-row-desc">{{truncate .DescriptionMarkdown 150}}</div>
-            {{end}}
-            {{if or .DateStart .DateEnd}}
-            <div class="ticket-row-dates">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                {{if .DateStart}}{{formatDate .DateStart}}{{end}}{{if and .DateStart .DateEnd}} → {{end}}{{if .DateEnd}}{{formatDate .DateEnd}}{{end}}
-            </div>
-            {{end}}
         </a>
         {{end}}
     </div>
     {{else}}
-    <div class="empty-state">
-        <p>No features yet. Create one to start planning.</p>
+    <div class="card bg-base-100 border border-base-300">
+        <div class="card-body p-10 text-center text-sm text-base-content/60">
+            No features yet. Create one to start planning.
+        </div>
     </div>
     {{end}}
 </div>

--- a/templates/pages/project_gantt.html
+++ b/templates/pages/project_gantt.html
@@ -1,24 +1,32 @@
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-7xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
-    <h2 class="mb-md">Timeline</h2>
+    <div class="flex flex-col gap-4">
+        <h2 class="text-xl font-semibold">Timeline</h2>
 
-    {{if .Tickets}}
-    <div id="gantt-chart" class="gantt-container"></div>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            if (typeof renderGantt === 'function') {
-                renderGantt('#gantt-chart', {{toJSON .Tickets}});
-            }
-        });
-    </script>
-    {{else}}
-    <div class="empty-state">
-        <p>No tickets with dates set. Add start/end dates to tickets to see them on the timeline.</p>
+        {{if .Tickets}}
+        {{/* The Gantt chart's own CSS (.gantt-*) is preserved in app.css
+             until the full-migration cleanup in PR-6. static/js/app/gantt.js
+             reads the ticket JSON and injects time-scaled bars into
+             #gantt-chart — nothing here changes its behaviour. */}}
+        <div id="gantt-chart" class="gantt-container"></div>
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                if (typeof renderGantt === 'function') {
+                    renderGantt('#gantt-chart', {{toJSON .Tickets}});
+                }
+            });
+        </script>
+        {{else}}
+        <div class="card bg-base-100 border border-base-300">
+            <div class="card-body p-12 text-center text-sm text-base-content/60">
+                No tickets with dates set. Add start/end dates to tickets to see them on the timeline.
+            </div>
+        </div>
+        {{end}}
     </div>
-    {{end}}
 </div>
 {{end}}
 {{end}}

--- a/templates/pages/project_settings.html
+++ b/templates/pages/project_settings.html
@@ -22,7 +22,10 @@
                         <label class="label pb-1" for="repo_url">
                             <span class="label-text">Repository URL</span>
                         </label>
-                        <input type="url" id="repo_url" name="repo_url"
+                        {{/* type="text", not "url" — SSH Git URLs
+                             (git@github.com:org/repo.git) don't match
+                             the browser's url validation scheme. */}}
+                        <input type="text" id="repo_url" name="repo_url"
                                class="input input-bordered w-full font-mono text-sm"
                                value="{{.Project.RepoURL}}"
                                placeholder="https://github.com/org/repo.git or git@github.com:org/repo.git">

--- a/templates/pages/project_settings.html
+++ b/templates/pages/project_settings.html
@@ -1,55 +1,91 @@
 {{define "content"}}
 {{with .Data}}
-{{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
+<div class="max-w-3xl mx-auto p-6">
+    {{template "project_tabs" dict "Org" $.Org "Project" .Project "Tab" .Tab "IsStaff" .IsStaff}}
 
-<div class="mt-lg">
-    <h2 class="mb-lg">Project Settings</h2>
+    <div class="flex flex-col gap-6">
+        <h2 class="text-xl font-semibold">Project Settings</h2>
 
-    <div class="card mb-lg">
-        <h3 class="mb-sm">Repository</h3>
-        <p class="text-sm text-muted mb-md">Git repository URL for this project. Required for the orchestrator to clone code and create agent worktrees.</p>
-        <form method="POST" action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/settings/repo">
-            {{csrfField}}
-            <div class="form-group mb-md">
-                <label class="form-label" for="repo_url">Repository URL</label>
-                <input type="url" id="repo_url" name="repo_url" class="form-input"
-                       value="{{.Project.RepoURL}}"
-                       placeholder="https://github.com/org/repo.git or git@github.com:org/repo.git">
-                <span class="form-label-hint">SSH or HTTPS URL. The orchestrator VM must have access to clone this repo.</span>
-            </div>
-            <button type="submit" class="btn btn-primary">Save Repository URL</button>
-        </form>
-    </div>
-
-    {{if gt (len .AllOrgs) 1}}
-    <div class="card" x-data="{ confirm: false, targetName: '' }">
-        <h3 class="mb-sm" style="color: var(--red-600)">Transfer Project</h3>
-        <p class="text-sm text-muted mb-md">Move this project and all its tickets, comments, and costs to a different organization.</p>
-        <form method="POST" action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/transfer"
-              @submit.prevent="if (confirm) { $el.submit() } else { targetName = $refs.orgSelect.selectedOptions[0]?.text || ''; confirm = true; }">
-            {{csrfField}}
-            <div class="form-group mb-md">
-                <label class="form-label" for="target_org_id">Target Organization</label>
-                <select id="target_org_id" name="target_org_id" class="form-select" required x-ref="orgSelect" @change="confirm = false">
-                    <option value="">Select organization...</option>
-                    {{range .AllOrgs}}
-                    {{if ne .ID $.Org.ID}}
-                    <option value="{{.ID}}">{{.Name}}</option>
-                    {{end}}
-                    {{end}}
-                </select>
-            </div>
-            <template x-if="confirm">
-                <div class="mb-md" style="padding: .75rem; background: var(--red-50, #fef2f2); border: 1px solid var(--red-200, #fecaca); border-radius: var(--radius-md);">
-                    <p class="text-sm" style="color: var(--red-700, #b91c1c); margin: 0;">
-                        Transfer <strong>{{.Project.Name}}</strong> to <strong x-text="targetName"></strong>? All tickets, comments, and costs will move with it.
+        <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <div class="card-body p-6 gap-3">
+                <div>
+                    <h3 class="text-lg font-semibold">Repository</h3>
+                    <p class="text-sm text-base-content/60 mt-1">
+                        Git repository URL for this project. Required for the orchestrator to clone code and create agent worktrees.
                     </p>
                 </div>
-            </template>
-            <button type="submit" class="btn btn-danger" x-text="confirm ? 'Confirm Transfer' : 'Transfer Project'"></button>
-        </form>
+                <form method="POST"
+                      action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/settings/repo"
+                      class="flex flex-col gap-3">
+                    {{csrfField}}
+                    <div class="form-control">
+                        <label class="label pb-1" for="repo_url">
+                            <span class="label-text">Repository URL</span>
+                        </label>
+                        <input type="url" id="repo_url" name="repo_url"
+                               class="input input-bordered w-full font-mono text-sm"
+                               value="{{.Project.RepoURL}}"
+                               placeholder="https://github.com/org/repo.git or git@github.com:org/repo.git">
+                        <label class="label pt-1">
+                            <span class="label-text-alt text-base-content/60">
+                                SSH or HTTPS URL. The orchestrator VM must have access to clone this repo.
+                            </span>
+                        </label>
+                    </div>
+                    <div>
+                        <button type="submit" class="btn btn-primary">Save Repository URL</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        {{if gt (len .AllOrgs) 1}}
+        <div class="card bg-base-100 border border-error/30 shadow-sm"
+             x-data="{ confirm: false, targetName: '' }">
+            <div class="card-body p-6 gap-3">
+                <div>
+                    <h3 class="text-lg font-semibold text-error">Transfer Project</h3>
+                    <p class="text-sm text-base-content/60 mt-1">
+                        Move this project and all its tickets, comments, and costs to a different organization.
+                    </p>
+                </div>
+                <form method="POST"
+                      action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/transfer"
+                      class="flex flex-col gap-3"
+                      @submit.prevent="if (confirm) { $el.submit() } else { targetName = $refs.orgSelect.selectedOptions[0]?.text || ''; confirm = true; }">
+                    {{csrfField}}
+                    <div class="form-control">
+                        <label class="label pb-1" for="target_org_id">
+                            <span class="label-text">Target Organization</span>
+                        </label>
+                        <select id="target_org_id" name="target_org_id"
+                                class="select select-bordered w-full"
+                                required x-ref="orgSelect" @change="confirm = false">
+                            <option value="">Select organization...</option>
+                            {{range .AllOrgs}}
+                            {{if ne .ID $.Org.ID}}
+                            <option value="{{.ID}}">{{.Name}}</option>
+                            {{end}}
+                            {{end}}
+                        </select>
+                    </div>
+                    <template x-if="confirm">
+                        <div class="alert alert-warning">
+                            <span class="text-sm">
+                                Transfer <strong>{{.Project.Name}}</strong> to
+                                <strong x-text="targetName"></strong>? All tickets, comments, and costs will move with it.
+                            </span>
+                        </div>
+                    </template>
+                    <div>
+                        <button type="submit" class="btn btn-error"
+                                x-text="confirm ? 'Confirm Transfer' : 'Transfer Project'"></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        {{end}}
     </div>
-    {{end}}
 </div>
 {{end}}
 {{end}}


### PR DESCRIPTION
## Scope — closes #86

Fourth PR of the v0.3.0 UI migration. **The heaviest migration PR** — 9 templates covering the entire project-scoped UI.

Per spec: [\`§6 PR-4\`](https://github.com/madalinignisca/yaaipm/blob/main/docs/superpowers/specs/2026-04-16-ui-migration-v0.3.0.md). Depends on #89, #90, #91 (all merged).

## Templates migrated

| Template | LOC | Key elements |
|---|---|---|
| \`project_tabs.html\` | 22 | 7-tab nav, DaisyUI \`tabs-bordered\` + \`tab-active\` state |
| \`ticket_card.html\` | 10 | compact card, hover shadow, status badge |
| \`project_brief.html\` | 215 | EasyMDE markdown editor, image modal, revision history, empty-state with Project Chat CTA |
| \`project_features.html\` | 85 | feature list + \"New Feature\" dropdown (description + dates) |
| \`project_bugs.html\` | 95 | bug list + \"Report Bug\" dropdown (description + priority + dates) |
| \`project_gantt.html\` | 32 | thin shell over \`static/js/app/gantt.js\` — chart itself unchanged |
| \`project_costs.html\` | 213 | month picker, infra cost table, AI usage table, add-cost form, grand total |
| \`project_archived.html\` | 43 | archived ticket list, HTMX restore + delete |
| \`project_settings.html\` | 98 | repo URL form + danger-zone transfer flow (Alpine confirm) |

**584 insertions, 374 deletions across 10 files** (the 10th is \`render.go\` — 2 new FuncMap helpers).

## New render helpers

Added \`statusBadgeClass\` + \`priorityBadgeClass\` FuncMap helpers that return DaisyUI badge variants (\`badge-info\`, \`badge-warning\`, \`badge-success\`, \`badge-error\`, \`badge-ghost\`) instead of the hand-CSS color names returned by the legacy \`statusColor\` / \`priorityColor\` helpers. Old helpers kept untouched for compatibility with PR-5 / PR-6 templates still in hand-CSS.

DRY'd string literals into \`const\` blocks to satisfy \`goconst\`.

## Gantt chart: deferred to PR-6

The Gantt chart's own CSS (\`.gantt-*\` classes) lives in \`static/js/app/gantt.js\` + \`app.css\`. Template wrapper is migrated (\`<div id=\"gantt-chart\" class=\"gantt-container\">\`) but the chart continues to use its existing hand-CSS until PR-6 when \`app.css\` is removed. At that point the Gantt's ~150 lines of CSS move into \`tw-input.css\` as a component block — one-time port, already audited.

This preserves the time-scaled horizontal scroll + hierarchy + today marker + status-colored bars without any risk during PR-4.

## Test plan

- [x] \`bash scripts/css.sh\` builds (121KB, +1.5KB from PR-3)
- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` clean (0 issues)
- [x] Full handler test suite passes (7.856s — no regression)
- [ ] Manual: create project, edit brief (markdown editor), insert image via modal, list features, create feature, view Gantt (unchanged), costs page, add cost item, archive ticket, restore, transfer project

## Visual verification

Screenshots skipped — patterns (cards, tabs, badges, dropdowns, tables, forms) match those already verified in PR-1 chrome and PR-2/PR-3 content screenshots. The Gantt chart is visually unchanged because its rendering path (JS + app.css) is unchanged.

If you want a screenshot of the new project brief empty-state or features list, tell me and I'll spin up the preview tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)