### PR TITLE
fix(debate): show next-round picker after Accept (Hx-Refresh)

### DIFF
--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -556,12 +556,15 @@ func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
 			deb.ID, round.ID, dctx.ticket.ProjectID, round.OutputText)
 	}
 
-	// Wrap the round in {Round, TicketID} so the partial can build
-	// scoped action URLs (Undo button on the now-accepted card).
-	_ = h.engine.RenderPartial(w, "debate_round.html", map[string]any{
-		"Round":    round,
-		"TicketID": dctx.ticket.ID,
-	})
+	// Hx-Refresh triggers a full client-side reload after accept.
+	// We can't return just the round card via outerHTML swap because
+	// the next-round picker form is suppressed during in_review and
+	// only re-rendered by debate.html when no round is in_review.
+	// Without a reload the user sees the accepted card but no way to
+	// continue the debate (only Undo + Approve final remain). The
+	// reload re-renders debate.html which puts the picker back.
+	w.Header().Set("Hx-Refresh", "true")
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // acceptRoundUnderLock runs the accept transaction: lock debate row,

--- a/internal/handlers/debate_test.go
+++ b/internal/handlers/debate_test.go
@@ -400,13 +400,15 @@ func startAndCreateRounds(t *testing.T, r *chi.Mux, db *models.DB, cookie *http.
 		}
 
 		// Accept via the HTTP handler so we exercise the production
-		// tx path including the FOR UPDATE status check.
+		// tx path including the FOR UPDATE status check. Accept any
+		// 2xx — current handler returns 204 + Hx-Refresh, but the
+		// status itself isn't load-bearing for the test.
 		acceptRec := httptest.NewRecorder()
 		acceptReq := httptest.NewRequest(http.MethodPost,
 			"/tickets/"+ticketID+"/debate/rounds/"+round.ID+"/accept", http.NoBody)
 		acceptReq.AddCookie(cookie)
 		r.ServeHTTP(acceptRec, acceptReq)
-		if acceptRec.Code != http.StatusOK {
+		if acceptRec.Code < 200 || acceptRec.Code >= 300 {
 			t.Fatalf("/accept round %d: %d %s", i+1, acceptRec.Code, acceptRec.Body.String())
 		}
 		// Re-fetch the round to get its updated (accepted) state.


### PR DESCRIPTION
## Reported live on v0.3.0

After triggering a Claude round + getting the diff + accepting it, the user sees only **Undo from here** and **Approve final** — no way to continue the debate with another round (no AI picker, no feedback textarea).

## Root cause

\`debate.html\` renders \`debate_next_round.html\` only when no round is currently \`in_review\`:

\`\`\`html
{{if not $inReview}}
  {{template \"debate_next_round.html\" ...}}
{{end}}
\`\`\`

Before accept: the in-review round suppresses the picker. After accept via HTMX, the round card is swapped via \`hx-target=\"closest .card\"\` to its \"accepted\" state — but the picker section that should now appear isn't part of the swap target. It never existed in the DOM during in_review, so the swap can't add it.

\`RejectRound\` doesn't have this bug because it returns the \`debate_next_round.html\` partial directly (replacing the rejected card with the picker form). \`UndoRound\` doesn't have it either because it uses \`Hx-Redirect\` for a full re-render. Accept was the odd one out.

This bug pre-dates v0.3.0 — it was in the v0.2.0 design. The visual migration didn't introduce it, but once a real human actually used the debate flow end-to-end it surfaced immediately.

## Fix

\`AcceptRound\` now sets \`Hx-Refresh: true\` + returns 204 No Content. HTMX sees the header, ignores any body, triggers \`location.reload()\`. The page re-renders \`debate.html\` which puts the picker back where it belongs.

This is the established escape hatch in this codebase for swap operations that need broader DOM updates than a single \`hx-target\` can express.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\` clean (0 issues)
- [x] Full handler test suite passes (7.845s, all 13 debate tests + the rest)
- [x] \`startAndCreateRounds\` test helper updated: was asserting \`Code == 200\`; now accepts any 2xx since the status code isn't load-bearing — the side effect (current_text updated, round flipped to accepted) is what matters
- [ ] **Manual on v0.3.0+1 once deployed:** start debate → submit Claude round → accept → confirm picker reappears with all 3 chips + Refactor button

🤖 Generated with [Claude Code](https://claude.com/claude-code)