### PR TITLE
fix(ai): require title for create_ticket + subset tool-decl assertion

### DIFF
--- a/internal/ai/gemini.go
+++ b/internal/ai/gemini.go
@@ -117,7 +117,7 @@ func toolDeclarations() []*genai.FunctionDeclaration {
 					"date_start":  {Type: genai.TypeString, Description: "Start date in YYYY-MM-DD format (e.g. 2026-03-15). Used for timeline/Gantt view."},
 					"date_end":    {Type: genai.TypeString, Description: "End date in YYYY-MM-DD format (e.g. 2026-03-20). Used for timeline/Gantt view."},
 				},
-				Required: []string{"project_id", "type", "priority"},
+				Required: []string{"project_id", "title", "type", "priority"},
 			},
 		},
 		{

--- a/internal/ai/gemini_test.go
+++ b/internal/ai/gemini_test.go
@@ -9,6 +9,8 @@ import (
 func TestToolDeclarations_ReturnsExpectedTools(t *testing.T) {
 	decls := toolDeclarations()
 
+	// Stable core tools that must always be advertised. The full set grows
+	// over time, so assert these are a subset rather than an exact count.
 	expected := []string{
 		"search_tickets",
 		"get_project_brief",
@@ -16,10 +18,6 @@ func TestToolDeclarations_ReturnsExpectedTools(t *testing.T) {
 		"update_ticket_status",
 		"post_comment",
 		"update_project_brief",
-	}
-
-	if len(decls) != len(expected) {
-		t.Fatalf("expected %d tool declarations, got %d", len(expected), len(decls))
 	}
 
 	names := make(map[string]bool, len(decls))


### PR DESCRIPTION
## Summary

Fixes two **pre-existing** unit-test failures in `internal/ai` that fail on `main` (stale since the Gemini tool surface grew from 6 to 15 declarations — unrelated to any recent feature work).

1. **`TestToolDeclarations_ReturnsExpectedTools`** asserted an exact count of 6 tools via `len(decls) != len(expected) → Fatalf`, but `toolDeclarations()` now returns 15. Converted to a **subset assertion** — the existing name-presence loop already verifies the 6 stable core tools — so adding tools no longer breaks the test.
2. **`TestToolDeclarations_CreateTicketRequiredFields`** expected `title` in `create_ticket`'s `Required` list, but it had been dropped. **Re-added `"title"`** so the Gemini model is required to supply a title — matching the `title TEXT NOT NULL` column (migration `000006`) and the handler's title validation in `assistant.go`.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test ./internal/ai/` — ok
- Local review: Codex (approve, 0 findings) + Vibe (approve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)