### PR TITLE
test(debate): fake-backed e2e in CI + opt-in real-AI smoke (#81)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,72 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  debate-e2e:
+    name: debate fake-backed e2e
+    runs-on: ubuntu-latest
+    # Cap the whole job so a hung image build or stuck container can't run the
+    # runner indefinitely (the per-step health wait only covers startup).
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build + start the full stack (postgres, minio, migrate, app) with
+      # DEBATE_REFINER_MODE=fake (set in docker-compose.test.yml), so the
+      # debate refiners return canned output and no provider API keys are
+      # needed. The app is published on :8081.
+      - name: Start test stack
+        run: docker compose -f docker-compose.test.yml up -d --build
+
+      - name: Wait for app health
+        run: |
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/health || true)
+            if [ "$code" = "200" ]; then echo "app healthy"; exit 0; fi
+            sleep 3
+          done
+          echo "::error::app did not become healthy on :8081"
+          docker compose -f docker-compose.test.yml logs app
+          exit 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install e2e dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      # Runs the fake-backed debate spec only. It self-registers the first
+      # user (registration is first-user-only), so it must run against the
+      # fresh CI database on its own — do not add other self-registering
+      # specs to this invocation.
+      - name: Run fake-backed debate e2e
+        working-directory: e2e
+        env:
+          BASE_URL: http://localhost:8081
+        run: npx playwright test 12-debate-fake.spec.js
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: e2e/test-results/
+          retention-days: 7
+
+      - name: Dump app logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.test.yml logs app

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -141,12 +141,21 @@ func main() {
 	// (anything that isn't localhost/127.0.0.1 or explicitly marked
 	// as an http test origin). Fakes in production are how you ship
 	// a feature that "works" but talks to no real AI.
+	const debateRefinerModeFake = "fake"
 	debateRefinerMode := os.Getenv("DEBATE_REFINER_MODE")
-	if debateRefinerMode == "fake" {
+	if debateRefinerMode == debateRefinerModeFake {
 		if !isLocalDebateEnv(cfg.BaseURL) {
 			log.Fatalf("DEBATE_REFINER_MODE=fake set against non-local BaseURL %q — refusing to start (see cmd/server/main.go)", cfg.BaseURL)
 		}
 		log.Printf("WARNING: DEBATE_REFINER_MODE=fake — all debate refiners return canned output")
+	}
+
+	// DEBATE_REAL_AI=1 marks the opt-in real-AI smoke mode (e2e/tests/
+	// 13-debate-real-ai.spec.js). It drives the debate UI against live
+	// provider APIs, so it is mutually exclusive with the fake refiners.
+	debateRealAI := os.Getenv("DEBATE_REAL_AI") == "1"
+	if debateRealAI && debateRefinerMode == debateRefinerModeFake {
+		log.Fatal("DEBATE_REAL_AI=1 and DEBATE_REFINER_MODE=fake are mutually exclusive — choose real providers or fakes, not both")
 	}
 
 	debateRefiners := map[string]ai.Refiner{}
@@ -165,7 +174,7 @@ func main() {
 	}
 	// Swap in fakes for E2E tests when explicitly opted in (guarded
 	// against production above).
-	if debateRefinerMode == "fake" {
+	if debateRefinerMode == debateRefinerModeFake {
 		debateRefiners = buildFakeDebateRefiners()
 	}
 	var debateScorer ai.Scorer
@@ -177,6 +186,13 @@ func main() {
 	debateCfg := handlers.DefaultDebateConfig()
 	debateH := handlers.NewDebateHandler(db, engine, debateRefiners, debateScorer, debateCfg)
 	log.Printf("Feature Debate Mode wired (%d refiners, scorer=%v)", len(debateRefiners), debateScorer != nil)
+
+	if debateRealAI {
+		if len(debateRefiners) == 0 {
+			log.Fatal("DEBATE_REAL_AI=1 but no provider API keys configured — set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY")
+		}
+		log.Printf("WARNING: DEBATE_REAL_AI=1 — debate refiners and scorer make REAL, billable provider calls (%d providers, scorer=%v)", len(debateRefiners), debateScorer != nil)
+	}
 
 	// Rate limiter for auth endpoints (0.5 req/s, burst 5)
 	authLimiter := middleware.NewRateLimiter(0.5, 5)

--- a/docker-compose.real-ai.yml
+++ b/docker-compose.real-ai.yml
@@ -1,0 +1,25 @@
+# Overlay for the opt-in real-AI debate smoke (issue #81, Part B).
+#
+# Runs the app from docker-compose.test.yml against LIVE provider APIs
+# instead of the fake refiner. Provider keys are read from your shell
+# environment (no secrets live in this file). Usage:
+#
+#   export ANTHROPIC_API_KEY=... OPENAI_API_KEY=... GEMINI_API_KEY=...
+#   docker compose -f docker-compose.test.yml -f docker-compose.real-ai.yml up -d --build app
+#   (cd e2e && npm run e2e:real-ai)
+#
+# Costs a few cents per run. The default models are the cheapest tier per
+# provider (gpt-5-mini, gemini-2.5-flash); set ANTHROPIC_MODEL to a Haiku
+# tier to cut the Anthropic cost further. Never run this in per-PR CI.
+services:
+  app:
+    environment:
+      # Disable the fake refiner (base file sets it to "fake") and turn on
+      # the real-AI marker so the server logs the billable-calls warning.
+      DEBATE_REFINER_MODE: ""
+      DEBATE_REAL_AI: "1"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      GEMINI_API_KEY: "${GEMINI_API_KEY:-}"
+      # Optional cheaper Anthropic tier; falls back to the app default.
+      ANTHROPIC_MODEL: "${ANTHROPIC_MODEL:-}"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,9 @@
     "test:projects": "npx playwright test 03-projects",
     "test:tickets": "npx playwright test 04-tickets",
     "test:admin": "npx playwright test 05-admin",
-    "test:org-management": "npx playwright test 07-org-management"
+    "test:org-management": "npx playwright test 07-org-management",
+    "test:debate": "npx playwright test 11-debate 12-debate-fake",
+    "e2e:real-ai": "DEBATE_REAL_AI=1 npx playwright test 13-debate-real-ai.spec.js"
   },
   "keywords": [],
   "author": "",

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -2,7 +2,11 @@ const { defineConfig } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: './tests',
-  timeout: 30000,
+  // Base timeout per test AND for beforeAll/afterAll hooks. The debate specs'
+  // bootstrap (register → rate-limit pause → login → 2FA → org/project/ticket)
+  // runs well past the old 30s on a loaded machine or a slow CI runner, and
+  // test.use({timeout}) does NOT extend hook timeouts — only this does.
+  timeout: 120000,
   retries: 0,
   workers: 1,  // Sequential — tests share state (auth cookies)
   use: {

--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -37,10 +37,8 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
     await page.request.post('/orgs/debate-fake-org/projects', { form: { name: 'Debate Fake Project' } });
 
     await page.goto('/orgs/debate-fake-org/projects/debate-fake-project/features');
-    const html = await page.content();
-    const match = html.match(/project_id[^>]*value="([^"]+)"/);
-    const projectID = match ? match[1] : '';
-    expect(projectID, 'project id must be discoverable').not.toEqual('');
+    const projectID = await page.locator("input[name='project_id']").first().getAttribute('value');
+    expect(projectID, 'project id must be discoverable').toBeTruthy();
 
     const resp = await page.request.post('/tickets', {
       form: {
@@ -55,9 +53,8 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
     expect(resp.status(), 'create-ticket response').toBeLessThan(400);
 
     await page.goto('/orgs/debate-fake-org/projects/debate-fake-project/features');
-    const linkHTML = await page.content();
-    const linkMatch = linkHTML.match(/href="\/tickets\/([0-9a-f-]{36})"/);
-    ticketID = linkMatch ? linkMatch[1] : '';
+    const href = await page.locator("a[href^='/tickets/']").first().getAttribute('href');
+    ticketID = href ? href.split('/').pop() : '';
     expect(ticketID, 'ticket id must be discoverable on features tab').not.toEqual('');
 
     await page.close();

--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -1,0 +1,169 @@
+const { test, expect } = require('@playwright/test');
+const { registerUser, loginUser, setup2FA } = require('./helpers');
+
+// Fake-backed debate coverage that complements 11-debate.spec.js. Spec 11
+// drives the happy path (start → suggest → accept → approve, dismiss,
+// restore-original, abandon). This spec covers the branches it doesn't:
+//   - reject (dismiss) leaves current_text untouched + pre-fills feedback
+//   - a suggestion with an empty feedback box still works
+//   - the multi-round undo cascade via the versions rail (restore vN)
+//
+// Runs against DEBATE_REFINER_MODE=fake (docker-compose.test.yml), so the
+// refiner returns canned output:
+//   "Refactored by <provider>:\n\n<input>\n\n- added by fake refiner"
+const testUser = {
+  name: 'Debate Fake Tester',
+  email: 'e2e-debate-fake@forgedesk.test',
+  password: 'E2ETestPassword123!',
+};
+const INITIAL_DESCRIPTION = 'Initial description for the fake debate E2E test';
+let ticketID = '';
+let authCookies = [];
+
+test.describe('Feature Debate Mode — fake refiner branches', () => {
+  test.use({ timeout: 120000 });
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await registerUser(page, testUser);
+    // Pause so the auth rate limiter (0.5 req/s, burst 5) doesn't block the
+    // TOTP verify POST — registration + login + 2FA hit several limited routes.
+    await page.waitForTimeout(4000);
+    await loginUser(page, testUser);
+    await setup2FA(page);
+    authCookies = await page.context().cookies();
+
+    await page.request.post('/orgs', { form: { name: 'Debate Fake Org' } });
+    await page.request.post('/orgs/debate-fake-org/projects', { form: { name: 'Debate Fake Project' } });
+
+    await page.goto('/orgs/debate-fake-org/projects/debate-fake-project/features');
+    const html = await page.content();
+    const match = html.match(/project_id[^>]*value="([^"]+)"/);
+    const projectID = match ? match[1] : '';
+    expect(projectID, 'project id must be discoverable').not.toEqual('');
+
+    const resp = await page.request.post('/tickets', {
+      form: {
+        project_id: projectID,
+        title: 'E2E fake debate feature',
+        type: 'feature',
+        priority: 'medium',
+        description: INITIAL_DESCRIPTION,
+      },
+      headers: { Referer: '/orgs/debate-fake-org/projects/debate-fake-project/features' },
+    });
+    expect(resp.status(), 'create-ticket response').toBeLessThan(400);
+
+    await page.goto('/orgs/debate-fake-org/projects/debate-fake-project/features');
+    const linkHTML = await page.content();
+    const linkMatch = linkHTML.match(/href="\/tickets\/([0-9a-f-]{36})"/);
+    ticketID = linkMatch ? linkMatch[1] : '';
+    expect(ticketID, 'ticket id must be discoverable on features tab').not.toEqual('');
+
+    await page.close();
+  });
+
+  async function authenticatedDebatePage(page, path) {
+    if (authCookies.length > 0) {
+      await page.context().addCookies(authCookies);
+    }
+    await page.goto(path);
+    await page.waitForLoadState('networkidle');
+  }
+
+  // Ensure the debate is in the composer state (active, no pending suggestion),
+  // starting it if the page is still showing the empty state.
+  async function ensureComposer(page) {
+    const startBtn = page.locator('[data-testid="debate-start"]');
+    if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await startBtn.click();
+      await page.waitForLoadState('networkidle');
+    }
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+  }
+
+  test('reject (dismiss) leaves current text unchanged and pre-fills feedback', async ({ page }) => {
+    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
+
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    // Document starts at the original text (no accepted rounds yet).
+    await expect(page.locator('[data-testid="debate-current-text"]')).toContainText(INITIAL_DESCRIPTION);
+
+    // Suggest with a distinctive feedback string, then dismiss (= reject).
+    const feedback = 'Tighten the wording please';
+    await page.fill('[data-testid="debate-feedback"]', feedback);
+    await page.click('[data-testid="debate-suggest"]');
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+
+    await page.click('[data-testid="debate-dismiss"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+
+    // Reject must NOT touch the document — current text is still the original.
+    await expect(page.locator('[data-testid="debate-current-text"]')).toContainText(INITIAL_DESCRIPTION);
+    await expect(page.locator('[data-testid="debate-current-text"]')).not.toContainText('added by fake refiner');
+
+    // The rejected round's feedback is pre-filled back into the composer so the
+    // user can tweak and retry (RejectRound → renderWorkspaceUpdate).
+    await expect(page.locator('[data-testid="debate-feedback"]')).toHaveValue(feedback);
+
+    // Versions rail records the dismissed suggestion.
+    await expect(page.locator('[data-testid="debate-versions"]')).toContainText('dismissed');
+
+    // Approve stays enabled — a dismissed suggestion is not pending.
+    await expect(page.getByTestId('debate-approve')).toBeEnabled();
+  });
+
+  test('a suggestion with empty feedback still works', async ({ page }) => {
+    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
+
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    // Clear any pre-filled feedback and suggest with an empty box.
+    await page.fill('[data-testid="debate-feedback"]', '');
+    await page.click('[data-testid="debate-suggest"]');
+
+    // The fake refiner returns output regardless of feedback — suggestion shows.
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+    await expect(page.locator('[data-testid="debate-preview-pane"]')).toContainText('Refactored by');
+
+    // Clean up so the next test starts from the composer.
+    await page.click('[data-testid="debate-dismiss"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('undo cascade: accept 3 rounds then restore v1 removes v2 and v3', async ({ page }) => {
+    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
+
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    // Accept three rounds in sequence. Each suggest uses the fake refiner; each
+    // accept swaps the composer back so the next suggest can fire.
+    for (let i = 1; i <= 3; i++) {
+      await page.fill('[data-testid="debate-feedback"]', `round ${i}`);
+      await page.click('[data-testid="debate-suggest"]');
+      await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+      await page.click('[data-testid="debate-accept"]');
+      await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+    }
+
+    // Three accepted versions; v3 is current.
+    await expect(page.locator('[data-testid="debate-version-3"]')).toContainText('current');
+    await expect(page.locator('[data-testid="debate-version-1"]')).toBeVisible();
+    await expect(page.locator('[data-testid="debate-version-2"]')).toBeVisible();
+
+    // Restore v1 (hx-confirm → undo?from=2). Deletes rounds 2 and 3, leaving v1.
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.click('[data-testid="debate-restore-1"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+
+    // v1 is now the current/only accepted version; v2 and v3 are gone (undo
+    // deletes the rolled-back rounds, it does not mark them rejected).
+    await expect(page.locator('[data-testid="debate-version-1"]')).toContainText('current');
+    await expect(page.locator('[data-testid="debate-version-2"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="debate-version-3"]')).toHaveCount(0);
+  });
+});

--- a/e2e/tests/13-debate-real-ai.spec.js
+++ b/e2e/tests/13-debate-real-ai.spec.js
@@ -42,10 +42,8 @@ test.describe('Feature Debate Mode — real AI smoke', () => {
     await page.request.post('/orgs/debate-real-org/projects', { form: { name: 'Debate Real Project' } });
 
     await page.goto('/orgs/debate-real-org/projects/debate-real-project/features');
-    const html = await page.content();
-    const match = html.match(/project_id[^>]*value="([^"]+)"/);
-    const projectID = match ? match[1] : '';
-    expect(projectID, 'project id must be discoverable').not.toEqual('');
+    const projectID = await page.locator("input[name='project_id']").first().getAttribute('value');
+    expect(projectID, 'project id must be discoverable').toBeTruthy();
 
     const resp = await page.request.post('/tickets', {
       form: {
@@ -60,9 +58,8 @@ test.describe('Feature Debate Mode — real AI smoke', () => {
     expect(resp.status(), 'create-ticket response').toBeLessThan(400);
 
     await page.goto('/orgs/debate-real-org/projects/debate-real-project/features');
-    const linkHTML = await page.content();
-    const linkMatch = linkHTML.match(/href="\/tickets\/([0-9a-f-]{36})"/);
-    ticketID = linkMatch ? linkMatch[1] : '';
+    const href = await page.locator("a[href^='/tickets/']").first().getAttribute('href');
+    ticketID = href ? href.split('/').pop() : '';
     expect(ticketID, 'ticket id must be discoverable').not.toEqual('');
 
     await page.close();

--- a/e2e/tests/13-debate-real-ai.spec.js
+++ b/e2e/tests/13-debate-real-ai.spec.js
@@ -1,0 +1,161 @@
+const { test, expect } = require('@playwright/test');
+const { registerUser, loginUser, setup2FA } = require('./helpers');
+
+// Opt-in real-AI smoke for Feature Debate Mode (issue #81, Part B).
+//
+// Unlike 12-debate-fake.spec.js, this drives the debate UI against LIVE
+// provider APIs (Anthropic / OpenAI / Gemini) to catch vendor-side drift —
+// SDK/response-shape changes that the fake refiner can't surface. It is
+// gated behind DEBATE_REAL_AI=1 so it never runs in the per-PR CI suite:
+//
+//   # bring the app up with real provider keys (NOT fake mode), then:
+//   npm run e2e:real-ai     # (sets DEBATE_REAL_AI=1)
+//
+// Cost is a few cents per run on the cheapest model tier per provider
+// (Gemini Flash, GPT-5-mini, Claude Haiku). Serialized (workers:1).
+const REAL = process.env.DEBATE_REAL_AI === '1';
+
+const testUser = {
+  name: 'Debate Real Tester',
+  email: 'e2e-debate-real@forgedesk.test',
+  password: 'E2ETestPassword123!',
+};
+const INITIAL_DESCRIPTION = 'Add a CSV export button to the invoices list page.';
+let ticketID = '';
+let authCookies = [];
+
+test.describe('Feature Debate Mode — real AI smoke', () => {
+  // Live API calls are slow; allow generous per-test budget.
+  test.use({ timeout: 240000 });
+
+  test.skip(!REAL, 'real-AI smoke is opt-in — set DEBATE_REAL_AI=1 and run against an app with live provider keys');
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await registerUser(page, testUser);
+    await page.waitForTimeout(4000);
+    await loginUser(page, testUser);
+    await setup2FA(page);
+    authCookies = await page.context().cookies();
+
+    await page.request.post('/orgs', { form: { name: 'Debate Real Org' } });
+    await page.request.post('/orgs/debate-real-org/projects', { form: { name: 'Debate Real Project' } });
+
+    await page.goto('/orgs/debate-real-org/projects/debate-real-project/features');
+    const html = await page.content();
+    const match = html.match(/project_id[^>]*value="([^"]+)"/);
+    const projectID = match ? match[1] : '';
+    expect(projectID, 'project id must be discoverable').not.toEqual('');
+
+    const resp = await page.request.post('/tickets', {
+      form: {
+        project_id: projectID,
+        title: 'E2E real-AI debate feature',
+        type: 'feature',
+        priority: 'medium',
+        description: INITIAL_DESCRIPTION,
+      },
+      headers: { Referer: '/orgs/debate-real-org/projects/debate-real-project/features' },
+    });
+    expect(resp.status(), 'create-ticket response').toBeLessThan(400);
+
+    await page.goto('/orgs/debate-real-org/projects/debate-real-project/features');
+    const linkHTML = await page.content();
+    const linkMatch = linkHTML.match(/href="\/tickets\/([0-9a-f-]{36})"/);
+    ticketID = linkMatch ? linkMatch[1] : '';
+    expect(ticketID, 'ticket id must be discoverable').not.toEqual('');
+
+    await page.close();
+  });
+
+  async function authenticatedDebatePage(page, path) {
+    if (authCookies.length > 0) {
+      await page.context().addCookies(authCookies);
+    }
+    await page.goto(path);
+    await page.waitForLoadState('networkidle');
+  }
+
+  async function ensureComposer(page) {
+    const startBtn = page.locator('[data-testid="debate-start"]');
+    if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await startBtn.click();
+      await page.waitForLoadState('networkidle');
+    }
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+  }
+
+  // Select a provider radio (visually hidden; click its label) and suggest.
+  async function suggestWith(page, provider, feedback) {
+    await page.locator(`label[data-provider="${provider}"]`).click();
+    if (feedback !== undefined) {
+      await page.fill('[data-testid="debate-feedback"]', feedback);
+    }
+    await page.click('[data-testid="debate-suggest"]');
+    // Real provider latency — wait up to 90s for the suggestion card.
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible({ timeout: 90000 });
+  }
+
+  test('each configured provider returns a non-empty real suggestion', async ({ page }) => {
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    const providers = await page.locator('input[name="provider"]').evaluateAll((els) => els.map((e) => e.value));
+    expect(providers.length, 'at least one provider must be configured').toBeGreaterThan(0);
+
+    for (const provider of providers) {
+      await suggestWith(page, provider, 'Add acceptance criteria and edge cases.');
+
+      // Preview pane must contain real, non-trivial output.
+      const preview = page.locator('[data-testid="debate-preview-pane"]');
+      await expect(preview).toBeVisible();
+      const text = (await preview.innerText()).trim();
+      expect(text.length, `provider ${provider} returned empty output`).toBeGreaterThan(20);
+
+      // The word-level diff must render at least one change.
+      await page.click('[data-testid="debate-tab-changes"]');
+      await expect(page.locator('[data-testid="debate-changes-pane"]')).toBeVisible();
+      const changes = await page.locator('[data-testid="debate-changes-pane"] ins, [data-testid="debate-changes-pane"] del').count();
+      expect(changes, `provider ${provider} produced no diff`).toBeGreaterThan(0);
+
+      // Dismiss so the next provider starts from the composer.
+      await page.click('[data-testid="debate-dismiss"]');
+      await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+    }
+  });
+
+  test('golden journey with provider rotation + scorer populates the effort chip', async ({ page }) => {
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    const providers = await page.locator('input[name="provider"]').evaluateAll((els) => els.map((e) => e.value));
+    // Rotate through up to two distinct providers across two accepted rounds.
+    const rotation = providers.slice(0, 2);
+
+    for (const provider of rotation) {
+      await suggestWith(page, provider, `Refine using ${provider}.`);
+      await page.click('[data-testid="debate-accept"]');
+      await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 12000 });
+    }
+
+    // Scorer integration: after a real accept the effort chip self-polls
+    // (hx-get every 3s) until the Gemini scorer returns. Wait for the score
+    // badge to replace the "appears after" / "estimating…" states.
+    const chip = page.locator('[data-testid="debate-effort-chip"]');
+    await expect(chip).toContainText('/10', { timeout: 120000 });
+    const chipText = await chip.innerText();
+    const m = chipText.match(/Effort\s+(\d+)\/10/);
+    expect(m, `effort chip text was: ${chipText}`).not.toBeNull();
+    const score = parseInt(m[1], 10);
+    expect(score, 'effort score must be 1..10').toBeGreaterThanOrEqual(1);
+    expect(score, 'effort score must be 1..10').toBeLessThanOrEqual(10);
+    expect(chipText, 'effort chip must include an hours estimate').toMatch(/~\d+h/);
+
+    // Approve writes the accepted text back to the ticket.
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.click('[data-testid="debate-approve"]');
+    await page.waitForURL(new RegExp(`/tickets/${ticketID}$`), { timeout: 15000 });
+    // The ticket body now reflects refined (not the original) text.
+    await expect(page.locator('body')).not.toContainText('Stop refining');
+  });
+});

--- a/internal/handlers/debate_empty_providers_test.go
+++ b/internal/handlers/debate_empty_providers_test.go
@@ -49,9 +49,13 @@ func TestShowDebate_NoProvidersConfigured(t *testing.T) {
 	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
 
 	// Start a debate so ShowDebate renders the composer partial.
+	startRec := httptest.NewRecorder()
 	startReq := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/debate/start", http.NoBody)
 	startReq.AddCookie(cookie)
-	r.ServeHTTP(httptest.NewRecorder(), startReq)
+	r.ServeHTTP(startRec, startReq)
+	if startRec.Code != http.StatusSeeOther {
+		t.Fatalf("start debate status = %d, want 303; body = %q", startRec.Code, startRec.Body.String())
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/tickets/"+ticket.ID+"/debate", http.NoBody)
 	req.AddCookie(cookie)

--- a/internal/handlers/debate_empty_providers_test.go
+++ b/internal/handlers/debate_empty_providers_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/madalin/forgedesk/internal/ai"
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/middleware"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/render"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// TestShowDebate_NoProvidersConfigured verifies that an active debate
+// served by an instance with NO refiners configured (no provider API keys)
+// renders the "No AI providers are configured" composer message instead of
+// a provider picker — and that the rest of the workspace still renders
+// (no partial-render truncation).
+//
+// This covers issue #81's empty-providers scenario at the render layer,
+// where it is deterministic. An e2e version would require booting a second
+// app instance with empty provider config (the compose stack runs
+// DEBATE_REFINER_MODE=fake, which always injects three fake providers), so
+// a render test is the right tool here.
+func TestShowDebate_NoProvidersConfigured(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	sessions := auth.NewSessionStore(pool)
+	engine, err := render.NewEngine(testutil.ProjectRoot()+"/templates", nil)
+	if err != nil {
+		t.Fatalf("loading templates: %v", err)
+	}
+
+	// Empty refiner registry == no provider API keys configured.
+	h := NewDebateHandler(db, engine, map[string]ai.Refiner{}, nil, DefaultDebateConfig())
+
+	r := chi.NewRouter()
+	r.Use(middleware.Recover)
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.AuthMiddleware(sessions, db))
+		r.Get("/tickets/{ticketID}/debate", h.ShowDebate)
+		r.Post("/tickets/{ticketID}/debate/start", h.StartDebate)
+	})
+
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	// Start a debate so ShowDebate renders the composer partial.
+	startReq := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/debate/start", http.NoBody)
+	startReq.AddCookie(cookie)
+	r.ServeHTTP(httptest.NewRecorder(), startReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/tickets/"+ticket.ID+"/debate", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "No AI providers are configured") {
+		t.Errorf("expected empty-providers message in composer; not found")
+	}
+	// No provider radio picker when the refiner registry is empty.
+	if strings.Contains(body, `name="provider"`) {
+		t.Errorf("provider picker rendered despite empty refiner registry")
+	}
+	// The rest of the workspace still renders — guards against a partial
+	// template that truncates when the provider list is empty.
+	for _, marker := range []string{
+		`data-testid="debate-composer"`,
+		`data-testid="debate-approve"`,
+	} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("missing marker %q — partial-render regression?", marker)
+		}
+	}
+}

--- a/internal/handlers/debate_provider_error_test.go
+++ b/internal/handlers/debate_provider_error_test.go
@@ -57,9 +57,13 @@ func TestCreateRound_ProviderErrorRendersErrorBanner(t *testing.T) {
 
 	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
 
+	startRec := httptest.NewRecorder()
 	startReq := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/debate/start", http.NoBody)
 	startReq.AddCookie(cookie)
-	r.ServeHTTP(httptest.NewRecorder(), startReq)
+	r.ServeHTTP(startRec, startReq)
+	if startRec.Code != http.StatusSeeOther {
+		t.Fatalf("start debate status = %d, want 303; body = %q", startRec.Code, startRec.Body.String())
+	}
 
 	form := url.Values{"provider": {"claude"}, "feedback": {"tighten it"}}
 	roundReq := httptest.NewRequest(http.MethodPost,

--- a/internal/handlers/debate_provider_error_test.go
+++ b/internal/handlers/debate_provider_error_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/madalin/forgedesk/internal/ai"
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/middleware"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/render"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// TestCreateRound_ProviderErrorRendersErrorBanner verifies that when a
+// refiner fails (e.g. a bad API key or provider outage), the round request
+// surfaces a 502 error banner and creates NO round — i.e. the UI shows an
+// error rather than a silent empty success.
+//
+// This covers issue #81's "error-classification" scenario deterministically.
+// The real-AI smoke spec drives live providers with valid keys; reproducing
+// a bad-key failure there would require booting a second app instance with a
+// deliberately-broken key, so the failure path is exercised here instead.
+func TestCreateRound_ProviderErrorRendersErrorBanner(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	sessions := auth.NewSessionStore(pool)
+	engine, err := render.NewEngine(testutil.ProjectRoot()+"/templates", nil)
+	if err != nil {
+		t.Fatalf("loading templates: %v", err)
+	}
+
+	// A refiner that always fails — simulates an invalid API key / outage.
+	refiners := map[string]ai.Refiner{
+		"claude": &ai.FakeRefiner{
+			NameVal: "claude", ModelVal: ai.ModelClaudeSonnet46,
+			OutputFunc: func(_ ai.RefineInput) (string, string, error) {
+				return "", "", errors.New("401 unauthorized: invalid api key")
+			},
+		},
+	}
+	h := NewDebateHandler(db, engine, refiners, nil, DefaultDebateConfig())
+
+	r := chi.NewRouter()
+	r.Use(middleware.Recover)
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.AuthMiddleware(sessions, db))
+		r.Post("/tickets/{ticketID}/debate/start", h.StartDebate)
+		r.Post("/tickets/{ticketID}/debate/rounds", h.CreateRound)
+	})
+
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	startReq := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/debate/start", http.NoBody)
+	startReq.AddCookie(cookie)
+	r.ServeHTTP(httptest.NewRecorder(), startReq)
+
+	form := url.Values{"provider": {"claude"}, "feedback": {"tighten it"}}
+	roundReq := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticket.ID+"/debate/rounds", strings.NewReader(form.Encode()))
+	roundReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	roundReq.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, roundReq)
+
+	// A failed provider must surface a 502 banner — not a 2xx empty success.
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body = %q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "couldn't produce a suggestion") {
+		t.Errorf("expected provider-failure banner, got: %q", rec.Body.String())
+	}
+
+	// The failure must not leave a phantom round behind.
+	deb, err := db.GetActiveDebate(context.Background(), ticket.ID)
+	if err != nil {
+		t.Fatalf("GetActiveDebate: %v", err)
+	}
+	rounds, err := db.GetDebateRounds(context.Background(), deb.ID)
+	if err != nil {
+		t.Fatalf("GetDebateRounds: %v", err)
+	}
+	if len(rounds) != 0 {
+		t.Errorf("expected 0 rounds after provider failure, got %d", len(rounds))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #81. Adds debate-mode e2e coverage that handler unit tests can't provide (real template rendering + the full HTMX state machine), and the **first CI job that runs any e2e** — directly targeting the bug class #81 was filed for (the v0.2.1 provider-chip render bug that passed unit tests because the DOM was truncated).

## Part A — fake-backed e2e (runs in CI on every PR)

- **`e2e/tests/12-debate-fake.spec.js`** (`DEBATE_REFINER_MODE=fake`): reject/dismiss leaves `current_text` unchanged + pre-fills feedback; empty-feedback suggest still works; undo cascade (accept 3 → restore v1 deletes v2+v3). Complements the existing `11-debate` golden path + abandon.
- **`.github/workflows/e2e.yml`**: boots `docker-compose.test.yml` (fake refiner, no API keys), waits for `/health`, runs the fake debate spec, uploads Playwright traces on failure. Job-capped at 30 min.
- **Go render tests** for the cases that fight the fake harness (deterministic there):
  - `TestShowDebate_NoProvidersConfigured` — empty-providers composer message renders, no provider picker, no partial truncation.
  - `TestCreateRound_ProviderErrorRendersErrorBanner` — a failing provider returns a 502 banner and creates **no** round (the error-classification scenario).
  - CAS-409 stays covered by the existing `TestApproveDebate_CASRejectsExternalEdit`.

## Part B — opt-in real-AI smoke (manual, never in per-PR CI)

- **`e2e/tests/13-debate-real-ai.spec.js`** — gated on `DEBATE_REAL_AI=1`; drives live providers: per-provider real suggestion + word-diff, golden journey with provider rotation, and the Gemini scorer populating the effort chip (1–10 + hours).
- **`cmd/server/main.go`** — `DEBATE_REAL_AI=1` startup marker, mutually exclusive with `DEBATE_REFINER_MODE=fake`, requires ≥1 provider key.
- **`docker-compose.real-ai.yml`** overlay (env-interpolated keys, no secrets in the file) + **`npm run e2e:real-ai`** script.

**Verified green** against live Anthropic / OpenAI / Gemini on the cheapest tiers (gpt-5-mini, gemini-2.5-flash) — 2/2 real-AI tests pass.

## Notes / decisions

- Empty-providers, CAS-409, and provider-error are covered by **Go tests** rather than e2e: each needs a differently-configured server (empty refiners / a bad key) that fake mode can't produce, and they're deterministic at the handler layer. e2e earns its keep on the multi-step UI flow.
- `playwright.config.js` base timeout raised 30s→120s: the auth bootstrap runs past the old 30s `beforeAll` hook budget on a loaded/slow runner, and `test.use({timeout})` does **not** extend hook timeouts.
- Per-PR CI runs **only** the fake spec — the real-AI suite is opt-in (cost + keys) per the issue's design.

## Local review

Codex + Vibe both reviewed and returned **shippable**, 0 Critical. Addressed: added a job-level CI timeout cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)