### PR TITLE
feat(debate): auto-save feedback draft to localStorage (#65)

### DIFF
--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -186,4 +186,26 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
     await ensureComposer(page);
     await expect(page.locator('[data-testid="debate-feedback"]')).toHaveValue('');
   });
+
+  test('a successful suggestion clears the saved feedback draft', async ({ page }) => {
+    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
+
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    // Type feedback and send it. On a SUCCESSFUL suggest the draft must be
+    // cleared, so consumed feedback doesn't resurface on a later reload.
+    await page.fill('[data-testid="debate-feedback"]', 'sent feedback that should clear');
+    await page.click('[data-testid="debate-suggest"]');
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+    await page.click('[data-testid="debate-dismiss"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+
+    // Reload from a clean GET: the consumed draft is gone (cleared on the
+    // successful suggest), so nothing is restored into the empty composer.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await ensureComposer(page);
+    await expect(page.locator('[data-testid="debate-feedback"]')).toHaveValue('');
+  });
 });

--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -163,4 +163,27 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
     await expect(page.locator('[data-testid="debate-version-2"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="debate-version-3"]')).toHaveCount(0);
   });
+
+  test('feedback draft is auto-saved to localStorage and restored after reload', async ({ page }) => {
+    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
+
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    // Type a draft, then reload — issue #65 stashes it to localStorage so a
+    // failed AI call or an accidental navigation doesn't lose typed feedback.
+    const draft = 'remember this feedback draft';
+    await page.fill('[data-testid="debate-feedback"]', draft);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await ensureComposer(page);
+    await expect(page.locator('[data-testid="debate-feedback"]')).toHaveValue(draft);
+
+    // Emptying the box clears the stored draft, so it does not restore later.
+    await page.fill('[data-testid="debate-feedback"]', '');
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await ensureComposer(page);
+    await expect(page.locator('[data-testid="debate-feedback"]')).toHaveValue('');
+  });
 });

--- a/templates/components/debate_composer.html
+++ b/templates/components/debate_composer.html
@@ -16,15 +16,19 @@
         {{/* Persist the feedback draft to localStorage (issue #65) so it
              survives a failed AI call or an accidental reload. Keyed by
              ticket so drafts don't bleed across debates. Restore only when
-             the box is empty — a server pre-fill (e.g. a rejected round's
-             feedback) takes precedence. */}}
+             the box is empty so a server pre-fill (e.g. a rejected round's
+             feedback) takes precedence. Cleared once the suggest request
+             succeeds — listened on the window so the handler outlives the
+             form swap — so consumed feedback doesn't resurface. Expressions
+             are kept pure: Alpine x-on does not allow try/catch statements. */}}
         <textarea name="feedback" rows="2" maxlength="2000"
                   placeholder="Optional: tell the AI what to focus on, e.g. 'add acceptance criteria'"
                   class="textarea textarea-bordered w-full text-sm"
                   data-testid="debate-feedback"
                   x-data="{ storeKey: 'debate-feedback:{{.TicketID}}' }"
                   x-init="if (!$el.value) { const draft = localStorage.getItem(storeKey); if (draft) { $el.value = draft; } }"
-                  x-on:input="$el.value.trim() ? localStorage.setItem(storeKey, $el.value) : localStorage.removeItem(storeKey)">{{.Feedback}}</textarea>
+                  x-on:input="$el.value.trim() ? localStorage.setItem(storeKey, $el.value) : localStorage.removeItem(storeKey)"
+                  x-on:htmx:after-request.window="$event.detail.successful && $event.detail.requestConfig && $event.detail.requestConfig.path && $event.detail.requestConfig.path.endsWith('/debate/rounds') && localStorage.removeItem(storeKey)">{{.Feedback}}</textarea>
         <div role="radiogroup" aria-label="AI provider" class="flex flex-wrap items-center gap-2">
           {{range $p := .Providers}}
             <label class="cursor-pointer" data-provider="{{$p}}">

--- a/templates/components/debate_composer.html
+++ b/templates/components/debate_composer.html
@@ -13,10 +13,18 @@
             hx-on::before-request="const p = this.querySelector('input[name=provider]:checked'); const t = document.getElementById('debate-thinking-provider'); if (p && t) { t.textContent = p.dataset.label || p.value; }"
             class="flex flex-col gap-3">
         {{csrfField}}
+        {{/* Persist the feedback draft to localStorage (issue #65) so it
+             survives a failed AI call or an accidental reload. Keyed by
+             ticket so drafts don't bleed across debates. Restore only when
+             the box is empty — a server pre-fill (e.g. a rejected round's
+             feedback) takes precedence. */}}
         <textarea name="feedback" rows="2" maxlength="2000"
                   placeholder="Optional: tell the AI what to focus on, e.g. 'add acceptance criteria'"
                   class="textarea textarea-bordered w-full text-sm"
-                  data-testid="debate-feedback">{{.Feedback}}</textarea>
+                  data-testid="debate-feedback"
+                  x-data="{ storeKey: 'debate-feedback:{{.TicketID}}' }"
+                  x-init="if (!$el.value) { const draft = localStorage.getItem(storeKey); if (draft) { $el.value = draft; } }"
+                  x-on:input="$el.value.trim() ? localStorage.setItem(storeKey, $el.value) : localStorage.removeItem(storeKey)">{{.Feedback}}</textarea>
         <div role="radiogroup" aria-label="AI provider" class="flex flex-wrap items-center gap-2">
           {{range $p := .Providers}}
             <label class="cursor-pointer" data-provider="{{$p}}">


### PR DESCRIPTION
## Summary

Closes #65. A typed feedback draft was lost if the AI call failed or the page reloaded. This persists it to `localStorage` (keyed by ticket so drafts don't bleed across debates) on input, and restores it on load **only when the box is empty** — so a server pre-fill (e.g. a rejected round's feedback) still wins. Emptying the box clears the stored draft.

~10 lines of Alpine on the feedback textarea; no JS bundle change (inline directives, matching the composer's existing inline script).

## Tests

`e2e/tests/12-debate-fake.spec.js` adds: type → reload → restored, and empty → reload → stays empty. Full Go suite + `golangci-lint` green; the fake-e2e CI job (added in #81) runs spec 12.

## Local review

Codex + Vibe both reviewed and returned **shippable**, 0 Critical/Important.

🤖 Generated with [Claude Code](https://claude.com/claude-code)