### PR TITLE
deploy: pin server & orchestrator images to v0.4.0

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.3.1
+          image: registry.k3s.vlah.sh/smartpm:v0.4.0
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.3.1
+          image: registry.k3s.vlah.sh/smartpm:v0.4.0
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Records the completed v0.4.0 production rollout. The cluster is already running `smartpm:v0.4.0` (server ×2 + orchestrator, healthy, 0 restarts); this syncs the manifests so a future `kubectl apply -f deploy/k8s/` from `main` won't silently revert production to v0.3.1.

Deploy summary:
- migration `000033` applied (schema 32→33, additive)
- image built from v0.4.0 tag (`1a2b61a`) and pushed
- rolled out with zero downtime; login smoke = HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYdZ22AYw7Ha4jgDpMd6Bb