### PR TITLE
fix(config): trim whitespace on model + credential env values (#111)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,7 @@ func Load() (*Config, error) {
 		AnthropicContentInputPrice:  envInt64("ANTHROPIC_CONTENT_INPUT_PRICE", 1500),
 		AnthropicContentOutputPrice: envInt64("ANTHROPIC_CONTENT_OUTPUT_PRICE", 7500),
 
-		S3Endpoint:        os.Getenv("S3_ENDPOINT"),
+		S3Endpoint:        envTrimmed("S3_ENDPOINT"),
 		S3AccessKeyID:     envTrimmed("S3_ACCESS_KEY_ID"),
 		S3SecretAccessKey: envTrimmed("S3_SECRET_ACCESS_KEY"),
 		S3Region:          envOrDefault("S3_REGION", "us-east-1"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,15 +69,25 @@ func envInt64(key string, fallback int64) int64 {
 	return fallback
 }
 
+// envTrimmed reads an env var and strips leading/trailing whitespace. Use for
+// values whose format can never legitimately contain surrounding whitespace
+// (model names, API keys, URLs, hex keys) so a stray newline from a base64 or
+// heredoc typo in a Secret/.env is absorbed rather than silently corrupting the
+// value (issue #111). Do NOT use for passwords/secrets that may contain
+// intentional edge whitespace (SESSION_SECRET, SMTP_PASSWORD).
+func envTrimmed(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
 func envOrDefault(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		return v
 	}
 	return fallback
 }
 
 func Load() (*Config, error) {
-	dbURL := os.Getenv("DATABASE_URL")
+	dbURL := envTrimmed("DATABASE_URL")
 	if dbURL == "" {
 		return nil, fmt.Errorf("DATABASE_URL is required")
 	}
@@ -134,7 +144,7 @@ func Load() (*Config, error) {
 		workspacesDir = home + "/forgedesk-workspaces"
 	}
 
-	aesKey := os.Getenv("AES_ENCRYPTION_KEY")
+	aesKey := envTrimmed("AES_ENCRYPTION_KEY")
 	if aesKey == "" {
 		return nil, fmt.Errorf("AES_ENCRYPTION_KEY is required (hex-encoded 32-byte key)")
 	}
@@ -158,7 +168,7 @@ func Load() (*Config, error) {
 		RPDisplayName:        "ForgeDesk",
 		RPID:                 rpID,
 		RPOrigins:            []string{baseURL},
-		GeminiAPIKey:         os.Getenv("GEMINI_API_KEY"),
+		GeminiAPIKey:         envTrimmed("GEMINI_API_KEY"),
 		GeminiModel:          envOrDefault("GEMINI_MODEL", "gemini-2.5-flash"),
 		GeminiModelChat:      envOrDefault("GEMINI_MODEL_CHAT", "gemini-2.5-flash"),
 		GeminiModelPro:       envOrDefault("GEMINI_MODEL_PRO", "gemini-2.5-pro"),
@@ -177,10 +187,10 @@ func Load() (*Config, error) {
 		GeminiImageProTextOutPrice:  envInt64("GEMINI_MODEL_IMAGE_PRO_TEXT_OUTPUT_PRICE", 1200),
 		GeminiImageProImageOutPrice: envInt64("GEMINI_MODEL_IMAGE_PRO_IMAGE_OUTPUT_PRICE", 12000),
 
-		AnthropicAPIKey:             os.Getenv("ANTHROPIC_API_KEY"),
+		AnthropicAPIKey:             envTrimmed("ANTHROPIC_API_KEY"),
 		AnthropicModel:              envOrDefault("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
 		AnthropicModelContent:       envOrDefault("ANTHROPIC_MODEL_CONTENT", "claude-opus-4-6"),
-		OpenAIAPIKey:                os.Getenv("OPENAI_API_KEY"),
+		OpenAIAPIKey:                envTrimmed("OPENAI_API_KEY"),
 		OpenAIModel:                 envOrDefault("OPENAI_MODEL", "gpt-5-mini"),
 		AnthropicInputPrice:         envInt64("ANTHROPIC_INPUT_PRICE", 300),
 		AnthropicOutputPrice:        envInt64("ANTHROPIC_OUTPUT_PRICE", 1500),
@@ -188,8 +198,8 @@ func Load() (*Config, error) {
 		AnthropicContentOutputPrice: envInt64("ANTHROPIC_CONTENT_OUTPUT_PRICE", 7500),
 
 		S3Endpoint:        os.Getenv("S3_ENDPOINT"),
-		S3AccessKeyID:     os.Getenv("S3_ACCESS_KEY_ID"),
-		S3SecretAccessKey: os.Getenv("S3_SECRET_ACCESS_KEY"),
+		S3AccessKeyID:     envTrimmed("S3_ACCESS_KEY_ID"),
+		S3SecretAccessKey: envTrimmed("S3_SECRET_ACCESS_KEY"),
 		S3Region:          envOrDefault("S3_REGION", "us-east-1"),
 		S3Bucket:          os.Getenv("S3_PUBLIC_BUCKET"),
 		S3ForcePathStyle:  os.Getenv("S3_FORCE_PATH_STYLE") == "true",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,6 +98,7 @@ func TestLoad_TrimsSafeCredentials(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-openai-123\n")
 	t.Setenv("ANTHROPIC_API_KEY", "  sk-anthropic-456")
 	t.Setenv("GEMINI_API_KEY", "gemini-789\n")
+	t.Setenv("S3_ENDPOINT", "https://s3.example.com\n")
 	t.Setenv("S3_ACCESS_KEY_ID", "AKIA123\n")
 	t.Setenv("S3_SECRET_ACCESS_KEY", "s3secret456\n")
 
@@ -116,6 +117,7 @@ func TestLoad_TrimsSafeCredentials(t *testing.T) {
 		{"OpenAIAPIKey", cfg.OpenAIAPIKey, "sk-openai-123"},
 		{"AnthropicAPIKey", cfg.AnthropicAPIKey, "sk-anthropic-456"},
 		{"GeminiAPIKey", cfg.GeminiAPIKey, "gemini-789"},
+		{"S3Endpoint", cfg.S3Endpoint, "https://s3.example.com"},
 		{"S3AccessKeyID", cfg.S3AccessKeyID, "AKIA123"},
 		{"S3SecretAccessKey", cfg.S3SecretAccessKey, "s3secret456"},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,126 @@ func TestEnvOrDefault(t *testing.T) {
 	})
 }
 
+func TestEnvOrDefault_TrimsWhitespace(t *testing.T) {
+	t.Run("strips trailing newline", func(t *testing.T) {
+		t.Setenv("TEST_TRIM_KEY", "gpt-5.4\n")
+		if got := envOrDefault("TEST_TRIM_KEY", "fallback"); got != "gpt-5.4" {
+			t.Errorf("envOrDefault() = %q, want %q", got, "gpt-5.4")
+		}
+	})
+
+	t.Run("strips surrounding spaces and tabs", func(t *testing.T) {
+		t.Setenv("TEST_TRIM_KEY", "  gemini-2.5-pro \t")
+		if got := envOrDefault("TEST_TRIM_KEY", "fallback"); got != "gemini-2.5-pro" {
+			t.Errorf("envOrDefault() = %q, want %q", got, "gemini-2.5-pro")
+		}
+	})
+
+	t.Run("whitespace-only value falls back to default", func(t *testing.T) {
+		t.Setenv("TEST_TRIM_KEY", " \n\t ")
+		if got := envOrDefault("TEST_TRIM_KEY", "fallback"); got != "fallback" {
+			t.Errorf("envOrDefault() = %q, want %q", got, "fallback")
+		}
+	})
+}
+
+// TestLoad_TrimsModelWhitespace is the regression test for issue #111: a
+// trailing newline in OPENAI_MODEL (from a base64/heredoc typo in the k8s
+// Secret) made cfg.OpenAIModel = "gpt-5.4\n", which missed the pricing-table
+// key and was sent verbatim to the OpenAI API.
+func TestLoad_TrimsModelWhitespace(t *testing.T) {
+	setRequired(t)
+	t.Setenv("OPENAI_MODEL", "gpt-5.4\n")
+	t.Setenv("ANTHROPIC_MODEL", "  claude-sonnet-4-6  ")
+	t.Setenv("GEMINI_MODEL", "gemini-2.5-flash\n")
+	t.Setenv("S3_REGION", " eu-central-1\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"OpenAIModel", cfg.OpenAIModel, "gpt-5.4"},
+		{"AnthropicModel", cfg.AnthropicModel, "claude-sonnet-4-6"},
+		{"GeminiModel", cfg.GeminiModel, "gemini-2.5-flash"},
+		{"S3Region", cfg.S3Region, "eu-central-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_TrimsSafeCredentials covers the credentials whose formats can never
+// legitimately contain surrounding whitespace, so a stray newline is always a
+// typo we should absorb (issue #111).
+func TestLoad_TrimsSafeCredentials(t *testing.T) {
+	setRequired(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost/testdb\n")
+	t.Setenv("AES_ENCRYPTION_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n")
+	t.Setenv("OPENAI_API_KEY", "sk-openai-123\n")
+	t.Setenv("ANTHROPIC_API_KEY", "  sk-anthropic-456")
+	t.Setenv("GEMINI_API_KEY", "gemini-789\n")
+	t.Setenv("S3_ACCESS_KEY_ID", "AKIA123\n")
+	t.Setenv("S3_SECRET_ACCESS_KEY", "s3secret456\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"DatabaseURL", cfg.DatabaseURL, "postgres://localhost/testdb"},
+		{"AESKey", cfg.AESKey, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		{"OpenAIAPIKey", cfg.OpenAIAPIKey, "sk-openai-123"},
+		{"AnthropicAPIKey", cfg.AnthropicAPIKey, "sk-anthropic-456"},
+		{"GeminiAPIKey", cfg.GeminiAPIKey, "gemini-789"},
+		{"S3AccessKeyID", cfg.S3AccessKeyID, "AKIA123"},
+		{"S3SecretAccessKey", cfg.S3SecretAccessKey, "s3secret456"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_PreservesPasswordWhitespace guards the deliberate decision to NOT
+// trim SESSION_SECRET or SMTP_PASSWORD: those are the only values where edge
+// whitespace could be an intentional part of the secret (issue #111).
+func TestLoad_PreservesPasswordWhitespace(t *testing.T) {
+	setRequired(t)
+	const secret = "  test-secret-key-that-is-32-bytes!  "
+	const smtpPass = " smtp-pass-with-space "
+	t.Setenv("SESSION_SECRET", secret)
+	t.Setenv("SMTP_PASSWORD", smtpPass)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.SessionSecret != secret {
+		t.Errorf("SessionSecret = %q, want %q (must not be trimmed)", cfg.SessionSecret, secret)
+	}
+	if cfg.SMTPPassword != smtpPass {
+		t.Errorf("SMTPPassword = %q, want %q (must not be trimmed)", cfg.SMTPPassword, smtpPass)
+	}
+}
+
 func TestLoad_MissingRequired(t *testing.T) {
 	t.Run("fails without DATABASE_URL", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "")


### PR DESCRIPTION
## Summary

Closes #111. Prevents the class of typo that broke OpenAI cost tracking in the v0.4.0 rollout: `OPENAI_MODEL` in the `forgedesk-env` Secret carried a trailing newline (`gpt-5.4\n`), so:

- `cfg.OpenAIModel` missed the `pricingTable` key → OpenAI debate/scorer cost recorded **$0** (the exact bug #108 was meant to fix, still broken for OpenAI).
- The malformed model string was sent verbatim to the OpenAI API.

The #109 startup pricing guard *detected* it in prod (fixed live by patching the Secret). This PR is the durable **prevention** in code.

## Change

Trim leading/trailing whitespace on env values whose format can **never** legitimately contain it:

| Route | Values |
|-------|--------|
| `envOrDefault` (now trims) | all 8 `*_MODEL` reads, `S3_REGION` |
| new `envTrimmed` helper | `DATABASE_URL`, `AES_ENCRYPTION_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` |

**Deliberately left untrimmed:** `SESSION_SECRET` and `SMTP_PASSWORD` — the only values where edge whitespace could be an intentional part of the secret. A whitespace-only value now correctly falls back to its default (previously `envOrDefault` returned the whitespace).

> `S3_ENDPOINT` was added in a review follow-up commit: it is a URL sitting next to the trimmed S3 keys and matches the `envTrimmed` "URLs" category (same as `DATABASE_URL`), with no password-like reason to preserve whitespace.

### Why the AES key is safe to trim
A valid `AES_ENCRYPTION_KEY` is 64 hex chars; a whitespace-containing value fails `hex.DecodeString`, so it could never have produced valid ciphertext — trimming cannot invalidate existing TOTP-secret decryption. It also silences the spurious `length is 65` startup warning the incident produced.

## Tests
Test-first (RED observed before implementing):
- `TestEnvOrDefault_TrimsWhitespace` — trailing newline, surrounding spaces/tabs, whitespace-only → default
- `TestLoad_TrimsModelWhitespace` — regression test for the OPENAI_MODEL newline
- `TestLoad_TrimsSafeCredentials` — all trimmed credentials (incl. `S3_ENDPOINT`)
- `TestLoad_PreservesPasswordWhitespace` — characterization test pinning that `SESSION_SECRET`/`SMTP_PASSWORD` are **not** trimmed

`go build ./...`, `go vet`, `gofmt`, full-repo `golangci-lint` (0 issues), and `go test ./internal/config/` all pass. Reviewed locally by code-reviewer (0 high-severity findings; the S3_ENDPOINT consistency gap it flagged is now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)