### PR TITLE
feat(ai): OpenAI + Anthropic scorer adapters, widen Scorer interface (#63)

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -84,7 +84,7 @@ func NewAnthropicRefiner(c *AnthropicClient, model string) *AnthropicRefiner {
 	return &AnthropicRefiner{client: c, model: model}
 }
 
-func (r *AnthropicRefiner) Name() string  { return "claude" }
+func (r *AnthropicRefiner) Name() string  { return ProviderClaude }
 func (r *AnthropicRefiner) Model() string { return r.model }
 
 // Refine sends one refactoring request and returns the model's output

--- a/internal/ai/anthropic_scorer.go
+++ b/internal/ai/anthropic_scorer.go
@@ -49,7 +49,7 @@ func NewAnthropicScorer(c *AnthropicClient, model string) *AnthropicScorer {
 	return &AnthropicScorer{client: c, model: model}
 }
 
-func (s *AnthropicScorer) Name() string  { return "claude" }
+func (s *AnthropicScorer) Name() string  { return ProviderClaude }
 func (s *AnthropicScorer) Model() string { return s.model }
 
 // buildAnthropicScoreParams assembles the scoring request for a model.

--- a/internal/ai/anthropic_scorer.go
+++ b/internal/ai/anthropic_scorer.go
@@ -1,0 +1,144 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+)
+
+// scorerToolName is the forced tool Claude must call to return a score.
+//
+// Anthropic has no JSON-mode / response_format equivalent, so structured
+// output is expressed as a single-tool schema plus tool_choice pinned to
+// that tool: the model cannot reply with prose, it can only "call" this
+// tool, and the call's arguments ARE the structured payload.
+const scorerToolName = "record_effort_score"
+
+// scorerAnthropicProperties is the tool input schema for the
+// {score, hours, reasoning} payload.
+//
+// Type-only, matching the OpenAI schema: Anthropic does not enforce
+// numeric bounds in tool input schemas any more than OpenAI strict mode
+// does, so clampScoreFields is the enforcement. Declared as a Go map
+// rather than a JSON literal because ToolInputSchemaParam.Properties is
+// an `any` marshaled by the SDK.
+var scorerAnthropicProperties = map[string]any{
+	"score":     map[string]any{"type": "integer", "description": "Complexity score from 1 (trivial) to 10 (major project)."},
+	"hours":     map[string]any{"type": "integer", "description": "Total human-hours estimate, at least 1."},
+	"reasoning": map[string]any{"type": "string", "description": "One sentence naming the biggest risk or scope driver."},
+}
+
+// AnthropicScorer adapts Anthropic's forced tool-use to the debate Scorer
+// interface. Lives in package ai so it can reach the unexported SDK
+// client field on AnthropicClient, same as AnthropicRefiner.
+type AnthropicScorer struct {
+	client *AnthropicClient
+	model  string
+}
+
+// NewAnthropicScorer constructs a Scorer over the shared AnthropicClient.
+// The model should be one of the ai.Model* constants so the pricing table
+// lookup finds a rate; main.go binds it to SCORER_MODEL_CLAUDE.
+//
+// Note this is the most expensive of the three scorers: the pricing table
+// has no cheap Claude tier, so the default is claude-sonnet-4-6 rather
+// than a Haiku-class model.
+func NewAnthropicScorer(c *AnthropicClient, model string) *AnthropicScorer {
+	return &AnthropicScorer{client: c, model: model}
+}
+
+func (s *AnthropicScorer) Name() string  { return "claude" }
+func (s *AnthropicScorer) Model() string { return s.model }
+
+// buildAnthropicScoreParams assembles the scoring request for a model.
+// Split out as a pure function so the forced-tool wiring is testable
+// without a network round-trip.
+func buildAnthropicScoreParams(model, text string) anthropic.MessageNewParams {
+	return anthropic.MessageNewParams{
+		Model:       anthropic.Model(model),
+		MaxTokens:   scorerMaxTokens,
+		Temperature: anthropic.Float(scorerTemperature),
+		System: []anthropic.TextBlockParam{
+			{Text: debateScoreSystemPrompt},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(text)),
+		},
+		Tools: []anthropic.ToolUnionParam{{OfTool: &anthropic.ToolParam{
+			Name:        scorerToolName,
+			Description: anthropic.String("Record the effort score for the feature description."),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: scorerAnthropicProperties,
+				Required:   []string{"score", "hours", "reasoning"},
+			},
+		}}},
+		// Pin the model to this one tool. DisableParallelToolUse makes it
+		// emit exactly one call, so extraction below can take the first
+		// matching block without worrying about duplicates.
+		ToolChoice: anthropic.ToolChoiceUnionParam{OfTool: &anthropic.ToolChoiceToolParam{
+			Name:                   scorerToolName,
+			DisableParallelToolUse: anthropic.Bool(true),
+		}},
+	}
+}
+
+// extractAnthropicToolInput returns the arguments of the first tool_use
+// block for the scoring tool.
+//
+// Pure function over the response so the "model returned prose despite a
+// forced tool choice" path is testable without a network call. That case
+// should be impossible given the ToolChoice pin above, which is exactly
+// why it deserves a distinct error rather than being folded into a parse
+// failure — if it ever fires, the forced-tool contract has broken.
+//
+// The tool name is matched explicitly rather than accepting the first
+// tool_use block of any kind: a future second tool on this request must
+// not be silently parsed as a score.
+func extractAnthropicToolInput(content []anthropic.ContentBlockUnion) (json.RawMessage, error) {
+	for _, block := range content {
+		if block.Type == "tool_use" && block.Name == scorerToolName {
+			return block.Input, nil
+		}
+	}
+	return nil, fmt.Errorf("no %q tool_use block in response", scorerToolName)
+}
+
+// Score returns {score, hours, reasoning} for the given description.
+func (s *AnthropicScorer) Score(ctx context.Context, text string) (ScoreResult, error) {
+	if s.client == nil {
+		return ScoreResult{}, fmt.Errorf("anthropic scorer: client not configured")
+	}
+
+	resp, err := s.client.client.Messages.New(ctx, buildAnthropicScoreParams(s.model, text))
+	if err != nil {
+		return ScoreResult{}, fmt.Errorf("anthropic scorer: %w", err)
+	}
+
+	input, err := extractAnthropicToolInput(resp.Content)
+	if err != nil {
+		return ScoreResult{}, fmt.Errorf("anthropic scorer: %w", err)
+	}
+
+	out, err := parseScorePayload(string(input))
+	if err != nil {
+		return ScoreResult{}, fmt.Errorf("anthropic scorer: %w", err)
+	}
+
+	inputTok := int(resp.Usage.InputTokens)
+	outputTok := int(resp.Usage.OutputTokens)
+	score, hours := clampScoreFields(out.Score, out.Hours)
+
+	return ScoreResult{
+		Score:     score,
+		Hours:     hours,
+		Reasoning: out.Reasoning,
+		Usage: RefineUsage{
+			InputTokens:  inputTok,
+			OutputTokens: outputTok,
+			CostMicros:   ComputeCostMicros(s.model, inputTok, outputTok),
+			Model:        s.model,
+		},
+	}, nil
+}

--- a/internal/ai/gemini_refiner.go
+++ b/internal/ai/gemini_refiner.go
@@ -24,7 +24,7 @@ func NewGeminiRefiner(c *GeminiClient, model string) *GeminiRefiner {
 	return &GeminiRefiner{client: c, model: model}
 }
 
-func (r *GeminiRefiner) Name() string  { return "gemini" }
+func (r *GeminiRefiner) Name() string  { return ProviderGemini }
 func (r *GeminiRefiner) Model() string { return r.model }
 
 // Refine sends one refactoring request and maps the response back to

--- a/internal/ai/gemini_scorer.go
+++ b/internal/ai/gemini_scorer.go
@@ -2,7 +2,6 @@ package ai
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"google.golang.org/genai"
@@ -19,12 +18,15 @@ type GeminiScorer struct {
 }
 
 // NewGeminiScorer constructs a Scorer over the shared GeminiClient.
-// The model string should be a flash-class Gemini model for cost — the
-// v1 handler always uses this scorer regardless of which provider ran
-// the refiner.
+// The model string should be a flash-class Gemini model for cost — this
+// is the default scorer for projects that have not configured another
+// provider (issue #63).
 func NewGeminiScorer(c *GeminiClient, model string) *GeminiScorer {
 	return &GeminiScorer{client: c, model: model}
 }
+
+func (s *GeminiScorer) Name() string  { return "gemini" }
+func (s *GeminiScorer) Model() string { return s.model }
 
 // Score returns {score, hours, reasoning} for the given description.
 // Temperature is pinned low (0.2) so repeated scoring of the same text
@@ -65,21 +67,16 @@ func (s *GeminiScorer) Score(ctx context.Context, text string) (ScoreResult, err
 		return ScoreResult{}, fmt.Errorf("gemini scorer: empty response from model %s", s.model)
 	}
 
-	var out struct {
-		Score     int    `json:"score"`
-		Hours     int    `json:"hours"`
-		Reasoning string `json:"reasoning"`
-	}
-	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return ScoreResult{}, fmt.Errorf("gemini scorer JSON parse: %w (raw: %q)", err, raw)
+	out, err := parseScorePayload(raw)
+	if err != nil {
+		return ScoreResult{}, fmt.Errorf("gemini scorer: %w", err)
 	}
 
 	// Defensive clamps. ResponseSchema should enforce the bounds server-
 	// side, but a wayward model or SDK quirk could still return an
 	// out-of-range value. Clamping means a bad response never reaches
 	// the effort chip's display logic with an out-of-range score.
-	score := min(max(out.Score, 1), 10)
-	hours := max(out.Hours, 1)
+	score, hours := clampScoreFields(out.Score, out.Hours)
 
 	inputTok, outputTok := 0, 0
 	if resp.UsageMetadata != nil {

--- a/internal/ai/gemini_scorer.go
+++ b/internal/ai/gemini_scorer.go
@@ -25,7 +25,7 @@ func NewGeminiScorer(c *GeminiClient, model string) *GeminiScorer {
 	return &GeminiScorer{client: c, model: model}
 }
 
-func (s *GeminiScorer) Name() string  { return "gemini" }
+func (s *GeminiScorer) Name() string  { return ProviderGemini }
 func (s *GeminiScorer) Model() string { return s.model }
 
 // Score returns {score, hours, reasoning} for the given description.

--- a/internal/ai/live_test.go
+++ b/internal/ai/live_test.go
@@ -196,33 +196,74 @@ func TestLive_GeminiScorer(t *testing.T) {
 	s := NewGeminiScorer(client, model)
 
 	res, err := s.Score(ctx, liveText)
+	assertLiveScore(t, s.Name(), res, err)
+}
+
+// TestLive_OpenAIScorer is the only check that OpenAI actually ACCEPTS
+// our strict json_schema. Strict mode rejects a schema that omits
+// additionalProperties:false or leaves a property out of required, and
+// it rejects numeric constraints outright — all of which surface as a
+// 400 at call time, invisible to every offline test. The unit tests pin
+// the schema's shape; this one proves the server agrees.
+func TestLive_OpenAIScorer(t *testing.T) {
+	key := liveKey(t, "OPENAI_API_KEY")
+	model := liveEnvOr("SCORER_MODEL_OPENAI", ModelGPT5Mini)
+	s := NewOpenAIScorer(NewOpenAIClient(key, model))
+
+	ctx, cancel := context.WithTimeout(t.Context(), liveCallTimeout)
+	defer cancel()
+	res, err := s.Score(ctx, liveText)
+	assertLiveScore(t, s.Name(), res, err)
+}
+
+// TestLive_AnthropicScorer proves the forced-tool contract holds against
+// the real API: that Claude returns a tool_use block for our tool rather
+// than prose, and that its arguments parse into the score payload.
+func TestLive_AnthropicScorer(t *testing.T) {
+	key := liveKey(t, "ANTHROPIC_API_KEY")
+	model := liveEnvOr("SCORER_MODEL_CLAUDE", ModelClaudeSonnet46)
+	client := NewAnthropicClient(key, AnthropicModels{Default: model, Content: model})
+	s := NewAnthropicScorer(client, model)
+
+	ctx, cancel := context.WithTimeout(t.Context(), liveCallTimeout)
+	defer cancel()
+	res, err := s.Score(ctx, liveText)
+	assertLiveScore(t, s.Name(), res, err)
+}
+
+// assertLiveScore is the shared post-call assertion for every Scorer.
+//
+// Score/Hours range checks are documentation rather than live signal —
+// clampScoreFields already bounds them in the adapter. The real
+// assertions are that the provider's structured output parsed at all
+// (err == nil), Reasoning survived the round trip, and usage metadata is
+// populated so cost tracking works.
+func assertLiveScore(t *testing.T, provider string, res ScoreResult, err error) {
+	t.Helper()
 	if err != nil {
-		// This branch also covers the structured-output JSON failing to
-		// parse — Score wraps json.Unmarshal errors with the raw payload.
-		t.Fatalf("gemini live score: %v", err)
+		// Also covers structured output failing to parse — Score wraps
+		// unmarshal errors with the raw payload — and, for OpenAI, a
+		// strict-schema rejection from the API.
+		t.Fatalf("%s live score: %v", provider, err)
 	}
-	// Score/Hours are clamped in the adapter, so the range checks below
-	// are documentation rather than live signal; the real assertions are
-	// that the schema-enforced JSON parsed (err == nil above), Reasoning
-	// survived the round trip, and usage metadata is populated.
 	if res.Score < 1 || res.Score > 10 {
-		t.Errorf("score out of range: %d", res.Score)
+		t.Errorf("%s: score out of range: %d", provider, res.Score)
 	}
 	if res.Hours < 1 {
-		t.Errorf("hours out of range: %d", res.Hours)
+		t.Errorf("%s: hours out of range: %d", provider, res.Hours)
 	}
 	if strings.TrimSpace(res.Reasoning) == "" {
-		t.Error("empty reasoning in live scorer response")
+		t.Errorf("%s: empty reasoning in live scorer response", provider)
 	}
 	if res.Usage.Model == "" {
-		t.Error("empty Usage.Model in live scorer response")
+		t.Errorf("%s: empty Usage.Model in live scorer response", provider)
 	}
 	if res.Usage.InputTokens <= 0 || res.Usage.OutputTokens <= 0 {
-		t.Errorf("non-positive scorer token counts: in=%d out=%d",
-			res.Usage.InputTokens, res.Usage.OutputTokens)
+		t.Errorf("%s: non-positive scorer token counts: in=%d out=%d",
+			provider, res.Usage.InputTokens, res.Usage.OutputTokens)
 	}
-	checkLivePricing(t, "scorer", res.Usage)
-	t.Logf("scorer ok: model=%s score=%d hours=%d in=%d out=%d cost=%dµ$ reasoning=%q",
-		res.Usage.Model, res.Score, res.Hours,
+	checkLivePricing(t, provider+" scorer", res.Usage)
+	t.Logf("%s scorer ok: model=%s score=%d hours=%d in=%d out=%d cost=%dµ$ reasoning=%q",
+		provider, res.Usage.Model, res.Score, res.Hours,
 		res.Usage.InputTokens, res.Usage.OutputTokens, res.Usage.CostMicros, res.Reasoning)
 }

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -37,7 +37,7 @@ type OpenAIRefiner struct{ c *OpenAIClient }
 // and Model() for the audit trail.
 func NewOpenAIRefiner(c *OpenAIClient) *OpenAIRefiner { return &OpenAIRefiner{c: c} }
 
-func (r *OpenAIRefiner) Name() string { return "openai" }
+func (r *OpenAIRefiner) Name() string { return ProviderOpenAI }
 func (r *OpenAIRefiner) Model() string {
 	if r.c == nil {
 		return ""

--- a/internal/ai/openai_scorer.go
+++ b/internal/ai/openai_scorer.go
@@ -1,0 +1,136 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// scorerOpenAISchema is the strict structured-output schema for the
+// {score, hours, reasoning} response.
+//
+// Deliberately type-only. OpenAI's strict structured outputs accept only
+// a subset of JSON Schema and reject numeric constraints (minimum /
+// maximum, as with minItems / maxItems), so the 1..10 and >=1 bounds
+// CANNOT be expressed here the way Gemini's ResponseSchema expresses
+// them. clampScoreFields is the enforcement instead.
+//
+// The two rules strict mode does impose are both satisfied below:
+// additionalProperties must be false, and every property must appear in
+// required. Violating either is a 400 from the API, not a local error.
+const scorerOpenAISchema = `{
+  "type": "object",
+  "properties": {
+    "score": {"type": "integer"},
+    "hours": {"type": "integer"},
+    "reasoning": {"type": "string"}
+  },
+  "required": ["score", "hours", "reasoning"],
+  "additionalProperties": false
+}`
+
+// scorerOpenAISchemaName labels the schema in the API request; it is not
+// part of the response shape.
+const scorerOpenAISchemaName = "debate_effort_score"
+
+// OpenAIScorer adapts OpenAI's strict structured outputs to the debate
+// Scorer interface. The third scorer of three; selected per project via
+// projects.scorer_provider (issue #63).
+type OpenAIScorer struct{ c *OpenAIClient }
+
+// NewOpenAIScorer wraps an OpenAIClient as a Scorer. The client is bound
+// to a model at construction, so main.go builds a client dedicated to
+// SCORER_MODEL_OPENAI rather than reusing the refiner's — scoring runs on
+// every accept plus the retry sweep and defaults to a cheaper model.
+func NewOpenAIScorer(c *OpenAIClient) *OpenAIScorer { return &OpenAIScorer{c: c} }
+
+func (s *OpenAIScorer) Name() string { return "openai" }
+func (s *OpenAIScorer) Model() string {
+	if s.c == nil {
+		return ""
+	}
+	return s.c.model
+}
+
+// buildOpenAIScoreRequest assembles the scoring request for a model.
+//
+// Split out as a pure function so the reasoning-model branch is testable
+// without a network round-trip: go-openai's ReasoningValidator rejects
+// MaxTokens on gpt-5*/o1*/o3*/o4* and requires Temperature to be 0 or
+// exactly 1, and the default scorer model (gpt-5-mini) IS a reasoning
+// model — so getting this wrong breaks every OpenAI-scored project.
+// Mirrors OpenAIRefiner.Refine's branch; see isReasoningOpenAIModel.
+func buildOpenAIScoreRequest(model, text string) openai.ChatCompletionRequest {
+	req := openai.ChatCompletionRequest{
+		Model: model,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: debateScoreSystemPrompt},
+			{Role: openai.ChatMessageRoleUser, Content: text},
+		},
+		ResponseFormat: &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+			JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+				Name:   scorerOpenAISchemaName,
+				Schema: json.RawMessage(scorerOpenAISchema),
+				Strict: true,
+			},
+		},
+	}
+	if isReasoningOpenAIModel(model) {
+		req.MaxCompletionTokens = scorerMaxTokens
+		// Temperature left at zero-value; SDK omits it (default 1).
+	} else {
+		req.MaxTokens = scorerMaxTokens
+		req.Temperature = scorerTemperature
+	}
+	return req
+}
+
+// Score returns {score, hours, reasoning} for the given description.
+func (s *OpenAIScorer) Score(ctx context.Context, text string) (ScoreResult, error) {
+	if s.c == nil || s.c.client == nil {
+		return ScoreResult{}, fmt.Errorf("openai scorer: client not configured")
+	}
+
+	resp, err := s.c.client.CreateChatCompletion(ctx, buildOpenAIScoreRequest(s.c.model, text))
+	if err != nil {
+		return ScoreResult{}, fmt.Errorf("openai scorer: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return ScoreResult{}, fmt.Errorf("openai scorer: no choices returned for model %s", s.c.model)
+	}
+
+	// A refusal is distinct from an empty completion: the model
+	// understood the request and declined it, which is worth its own log
+	// line rather than being reported as a malformed response.
+	choice := resp.Choices[0]
+	if refusal := strings.TrimSpace(choice.Message.Refusal); refusal != "" {
+		return ScoreResult{}, fmt.Errorf("openai scorer: model %s refused: %s", s.c.model, refusal)
+	}
+
+	raw := strings.TrimSpace(choice.Message.Content)
+	if raw == "" {
+		return ScoreResult{}, fmt.Errorf("openai scorer: empty response from model %s", s.c.model)
+	}
+
+	out, err := parseScorePayload(raw)
+	if err != nil {
+		return ScoreResult{}, fmt.Errorf("openai scorer: %w", err)
+	}
+
+	score, hours := clampScoreFields(out.Score, out.Hours)
+	return ScoreResult{
+		Score:     score,
+		Hours:     hours,
+		Reasoning: out.Reasoning,
+		Usage: RefineUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+			CostMicros:   ComputeCostMicros(s.c.model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens),
+			Model:        s.c.model,
+		},
+	}, nil
+}

--- a/internal/ai/openai_scorer.go
+++ b/internal/ai/openai_scorer.go
@@ -47,7 +47,7 @@ type OpenAIScorer struct{ c *OpenAIClient }
 // every accept plus the retry sweep and defaults to a cheaper model.
 func NewOpenAIScorer(c *OpenAIClient) *OpenAIScorer { return &OpenAIScorer{c: c} }
 
-func (s *OpenAIScorer) Name() string { return "openai" }
+func (s *OpenAIScorer) Name() string { return ProviderOpenAI }
 func (s *OpenAIScorer) Model() string {
 	if s.c == nil {
 		return ""

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -4,6 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+)
+
+// Provider keys. These identify a provider across every layer: the
+// Refiner/Scorer Name() methods, the registry maps in cmd/server, the
+// per-round provider column, and projects.scorer_provider with its CHECK
+// constraint. Adding a fourth provider means touching all of those, so
+// naming the set once here keeps the compiler in the loop for the Go
+// half of it.
+const (
+	ProviderClaude = "claude"
+	ProviderGemini = "gemini"
+	ProviderOpenAI = "openai"
 )
 
 // Refiner refactors a feature description for one round of debate mode.
@@ -168,12 +181,18 @@ func parseScorePayload(raw string) (scorePayload, error) {
 
 // truncateForError bounds raw provider output included in error
 // messages, so a runaway response can't dump kilobytes into the logs.
+//
+// The cap is in bytes, so the cut can land in the middle of a multi-byte
+// character — client feature text is frequently non-ASCII, and a
+// provider echoing it back in a malformed reply is exactly when this
+// fires. ToValidUTF8 drops the partial trailing rune so the message
+// stays well-formed.
 func truncateForError(s string) string {
 	const maxLen = 200
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "…"
+	return strings.ToValidUTF8(s[:maxLen], "") + "…"
 }
 
 // ScoreResult is the structured scorer output consumed by the accept flow

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -1,6 +1,10 @@
 package ai
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
 
 // Refiner refactors a feature description for one round of debate mode.
 // Implementations MUST be safe to call concurrently.
@@ -88,11 +92,88 @@ type RefineUsage struct {
 }
 
 // Scorer judges the complexity of a feature description.
-// v1 uses GeminiScorer with structured output so the JSON shape is
-// schema-enforced; defensive clamps in the adapter guarantee
-// out-of-range values never reach the UI.
+//
+// Each adapter uses its provider's own structured-output mechanism —
+// Gemini a ResponseSchema, OpenAI a strict json_schema response_format,
+// Anthropic a forced tool call — and normalizes the result into
+// ScoreResult. Defensive clamps guarantee out-of-range values never
+// reach the UI.
+//
+// Name and Model mirror Refiner. Model matters beyond audit: the startup
+// pricing guard iterates the configured scorer registry calling Model()
+// so an un-priced scorer surfaces as a loud WARNING instead of silently
+// recording every score at $0 (issue #108). Implementations MUST be safe
+// to call concurrently.
+//
+// Which scorer runs is configured per project (issue #63); see
+// internal/handlers/debate.go's scorerForProject.
 type Scorer interface {
+	Name() string  // "claude" | "gemini" | "openai"
+	Model() string // specific model ID used, for the pricing guard and audit
 	Score(ctx context.Context, text string) (ScoreResult, error)
+}
+
+// Scorer request defaults, centralized like the refiner ones above so
+// the three adapters cannot drift.
+//
+// scorerMaxTokens is small: the response is a {score, hours, reasoning}
+// object whose reasoning is capped at one sentence by the prompt.
+//
+// scorerTemperature is pinned low so repeated scoring of the same text
+// returns stable values — small drifts in the effort bar across
+// re-scores are confusing to users.
+const (
+	scorerMaxTokens   = 512
+	scorerTemperature = 0.2
+)
+
+// clampScoreFields bounds a model's raw score/hours into the range the
+// UI can render: score 1..10, hours >= 1.
+//
+// This is shared rather than per-adapter because it is the ONLY
+// enforcement for two of the three providers. Gemini applies the bounds
+// server-side via ResponseSchema, but OpenAI's strict structured outputs
+// reject numeric constraints such as minimum/maximum, and Anthropic tool
+// input schemas do not enforce them either — so for those adapters a
+// wayward model's 47 or 0 would otherwise reach the effort chip intact.
+func clampScoreFields(score, hours int) (clampedScore, clampedHours int) {
+	return min(max(score, 1), 10), max(hours, 1)
+}
+
+// scorePayload is the raw JSON shape every provider is asked to return.
+// Shared so the three adapters cannot drift on field names — each
+// provider enforces the shape by its own mechanism (Gemini
+// ResponseSchema, OpenAI strict json_schema, Anthropic tool input
+// schema), but they all unmarshal into this.
+type scorePayload struct {
+	Score     int    `json:"score"`
+	Hours     int    `json:"hours"`
+	Reasoning string `json:"reasoning"`
+}
+
+// parseScorePayload unmarshals a provider's structured output.
+//
+// The raw text is included in the error (truncated) because a parse
+// failure here is almost always a provider returning prose or a fenced
+// code block instead of bare JSON, and the first 200 characters make
+// that immediately obvious in a log line. Callers prefix the provider
+// name.
+func parseScorePayload(raw string) (scorePayload, error) {
+	var out scorePayload
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return scorePayload{}, fmt.Errorf("JSON parse: %w (raw: %q)", err, truncateForError(raw))
+	}
+	return out, nil
+}
+
+// truncateForError bounds raw provider output included in error
+// messages, so a runaway response can't dump kilobytes into the logs.
+func truncateForError(s string) string {
+	const maxLen = 200
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
 }
 
 // ScoreResult is the structured scorer output consumed by the accept flow

--- a/internal/ai/refiner_fake.go
+++ b/internal/ai/refiner_fake.go
@@ -52,12 +52,21 @@ func (f *FakeRefiner) Refine(_ context.Context, in RefineInput) (RefineOutput, e
 // the success path, Err for the failure path. Delay (optional) is called
 // inside Score before returning — use it to simulate a slow scorer in
 // out-of-order race tests.
+//
+// NameVal/ModelVal back the interface's Name/Model. Set NameVal to a real
+// provider key ("claude"/"gemini"/"openai") when the test builds a scorer
+// registry, so per-project provider selection can be exercised without
+// real API calls (issue #63).
 type FakeScorer struct {
-	Result    ScoreResult
-	Err       error
-	Delay     func()
-	CallCount int
+	NameVal, ModelVal string
+	Result            ScoreResult
+	Err               error
+	Delay             func()
+	CallCount         int
 }
+
+func (f *FakeScorer) Name() string  { return f.NameVal }
+func (f *FakeScorer) Model() string { return f.ModelVal }
 
 func (f *FakeScorer) Score(_ context.Context, _ string) (ScoreResult, error) {
 	f.CallCount++

--- a/internal/ai/scorer_test.go
+++ b/internal/ai/scorer_test.go
@@ -1,0 +1,309 @@
+package ai
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// Compile-time interface assertions for every Scorer implementation.
+// Signature drift fails the build before any test runs.
+var (
+	_ Scorer = (*GeminiScorer)(nil)
+	_ Scorer = (*OpenAIScorer)(nil)
+	_ Scorer = (*AnthropicScorer)(nil)
+)
+
+func TestClampScoreFields(t *testing.T) {
+	cases := []struct {
+		name                 string
+		score, hours         int
+		wantScore, wantHours int
+	}{
+		{"in range passes through", 7, 12, 7, 12},
+		{"lower bounds", 1, 1, 1, 1},
+		{"upper score bound", 10, 900, 10, 900},
+		{"score above range clamps to 10", 47, 5, 10, 5},
+		{"score below range clamps to 1", 0, 5, 1, 5},
+		{"negative score clamps to 1", -3, 5, 1, 5},
+		{"zero hours clamps to 1", 5, 0, 5, 1},
+		{"negative hours clamps to 1", 5, -8, 5, 1},
+		{"both out of range", 99, 0, 10, 1},
+		// A model returning nothing parses to the zero value; clamping
+		// keeps that off the effort chip as 1/1 rather than 0/0.
+		{"zero value", 0, 0, 1, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotScore, gotHours := clampScoreFields(c.score, c.hours)
+			if gotScore != c.wantScore || gotHours != c.wantHours {
+				t.Errorf("clampScoreFields(%d, %d) = (%d, %d), want (%d, %d)",
+					c.score, c.hours, gotScore, gotHours, c.wantScore, c.wantHours)
+			}
+		})
+	}
+}
+
+// The startup pricing guard (issue #108/#109) iterates the scorer registry
+// calling Model(), so every adapter must report the model it will actually
+// bill against — including the nil-client case, which must not panic.
+func TestScorer_NameAndModel(t *testing.T) {
+	t.Run("gemini", func(t *testing.T) {
+		s := NewGeminiScorer(nil, ModelGeminiFlash)
+		if s.Name() != "gemini" {
+			t.Errorf("Name() = %q, want gemini", s.Name())
+		}
+		if s.Model() != ModelGeminiFlash {
+			t.Errorf("Model() = %q, want %s", s.Model(), ModelGeminiFlash)
+		}
+	})
+
+	t.Run("openai", func(t *testing.T) {
+		s := NewOpenAIScorer(NewOpenAIClient("fake-key", ModelGPT5Mini))
+		if s.Name() != "openai" {
+			t.Errorf("Name() = %q, want openai", s.Name())
+		}
+		if s.Model() != ModelGPT5Mini {
+			t.Errorf("Model() = %q, want %s", s.Model(), ModelGPT5Mini)
+		}
+	})
+
+	t.Run("openai model empty when client nil", func(t *testing.T) {
+		s := &OpenAIScorer{c: nil}
+		if s.Model() != "" {
+			t.Errorf("Model() with nil client = %q, want empty", s.Model())
+		}
+	})
+
+	t.Run("anthropic", func(t *testing.T) {
+		s := NewAnthropicScorer(nil, ModelClaudeSonnet46)
+		if s.Name() != "claude" {
+			t.Errorf("Name() = %q, want claude", s.Name())
+		}
+		if s.Model() != ModelClaudeSonnet46 {
+			t.Errorf("Model() = %q, want %s", s.Model(), ModelClaudeSonnet46)
+		}
+	})
+
+	t.Run("fake", func(t *testing.T) {
+		f := &FakeScorer{NameVal: "gemini", ModelVal: ModelGeminiFlash}
+		if f.Name() != "gemini" {
+			t.Errorf("Name() = %q, want gemini", f.Name())
+		}
+		if f.Model() != ModelGeminiFlash {
+			t.Errorf("Model() = %q, want %s", f.Model(), ModelGeminiFlash)
+		}
+	})
+}
+
+// The default OpenAI scorer model (gpt-5-mini) is a reasoning model, and
+// go-openai's ReasoningValidator rejects MaxTokens / a non-0-or-1
+// Temperature for those CLIENT-SIDE. Getting this branch wrong breaks
+// every OpenAI-scored project, so assert both shapes directly.
+func TestBuildOpenAIScoreRequest_ModelBranch(t *testing.T) {
+	t.Run("reasoning model uses MaxCompletionTokens and omits Temperature", func(t *testing.T) {
+		req := buildOpenAIScoreRequest(ModelGPT5Mini, "some feature")
+		if req.MaxCompletionTokens != scorerMaxTokens {
+			t.Errorf("MaxCompletionTokens = %d, want %d", req.MaxCompletionTokens, scorerMaxTokens)
+		}
+		if req.MaxTokens != 0 {
+			t.Errorf("MaxTokens = %d, want 0 for a reasoning model", req.MaxTokens)
+		}
+		if req.Temperature != 0 {
+			t.Errorf("Temperature = %v, want unset for a reasoning model", req.Temperature)
+		}
+	})
+
+	t.Run("legacy model uses MaxTokens and a low Temperature", func(t *testing.T) {
+		req := buildOpenAIScoreRequest("gpt-4o-mini", "some feature")
+		if req.MaxTokens != scorerMaxTokens {
+			t.Errorf("MaxTokens = %d, want %d", req.MaxTokens, scorerMaxTokens)
+		}
+		if req.MaxCompletionTokens != 0 {
+			t.Errorf("MaxCompletionTokens = %d, want 0 for a legacy model", req.MaxCompletionTokens)
+		}
+		if req.Temperature != scorerTemperature {
+			t.Errorf("Temperature = %v, want %v", req.Temperature, scorerTemperature)
+		}
+	})
+}
+
+func TestBuildOpenAIScoreRequest_StructuredOutput(t *testing.T) {
+	req := buildOpenAIScoreRequest(ModelGPT5Mini, "some feature")
+
+	if req.Model != ModelGPT5Mini {
+		t.Errorf("Model = %q, want %q", req.Model, ModelGPT5Mini)
+	}
+	if len(req.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2 (system + user)", len(req.Messages))
+	}
+	if req.Messages[0].Content != debateScoreSystemPrompt {
+		t.Error("first message should carry the embedded scorer system prompt")
+	}
+	if req.Messages[1].Content != "some feature" {
+		t.Errorf("user message = %q, want the text under test", req.Messages[1].Content)
+	}
+	if req.ResponseFormat == nil {
+		t.Fatal("ResponseFormat must be set — without it the model may return prose")
+	}
+	if req.ResponseFormat.Type != openai.ChatCompletionResponseFormatTypeJSONSchema {
+		t.Errorf("ResponseFormat.Type = %q, want json_schema", req.ResponseFormat.Type)
+	}
+	if req.ResponseFormat.JSONSchema == nil {
+		t.Fatal("JSONSchema must be set")
+	}
+	if !req.ResponseFormat.JSONSchema.Strict {
+		t.Error("Strict must be true — otherwise the schema is advisory only")
+	}
+	if req.ResponseFormat.JSONSchema.Name != scorerOpenAISchemaName {
+		t.Errorf("schema Name = %q, want %q", req.ResponseFormat.JSONSchema.Name, scorerOpenAISchemaName)
+	}
+}
+
+// OpenAI rejects a strict schema that omits additionalProperties:false or
+// leaves any property out of required — with a 400 at call time, which no
+// unit test of ours would otherwise catch. Pin both invariants here.
+func TestScorerOpenAISchema_StrictModeInvariants(t *testing.T) {
+	var schema struct {
+		Type                 string                     `json:"type"`
+		Properties           map[string]json.RawMessage `json:"properties"`
+		Required             []string                   `json:"required"`
+		AdditionalProperties *bool                      `json:"additionalProperties"`
+	}
+	if err := json.Unmarshal([]byte(scorerOpenAISchema), &schema); err != nil {
+		t.Fatalf("scorerOpenAISchema is not valid JSON: %v", err)
+	}
+
+	if schema.AdditionalProperties == nil || *schema.AdditionalProperties {
+		t.Error("strict mode requires additionalProperties:false")
+	}
+	if len(schema.Required) != len(schema.Properties) {
+		t.Errorf("strict mode requires every property in required: %d properties, %d required",
+			len(schema.Properties), len(schema.Required))
+	}
+	for _, field := range []string{"score", "hours", "reasoning"} {
+		if _, ok := schema.Properties[field]; !ok {
+			t.Errorf("schema missing property %q", field)
+		}
+		if !slices.Contains(schema.Required, field) {
+			t.Errorf("schema missing %q in required", field)
+		}
+	}
+}
+
+func TestParseScorePayload(t *testing.T) {
+	t.Run("valid JSON", func(t *testing.T) {
+		got, err := parseScorePayload(`{"score":7,"hours":12,"reasoning":"Touches auth."}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Score != 7 || got.Hours != 12 || got.Reasoning != "Touches auth." {
+			t.Errorf("parsed = %+v, want {7 12 Touches auth.}", got)
+		}
+	})
+
+	t.Run("prose instead of JSON errors", func(t *testing.T) {
+		_, err := parseScorePayload("I think this is about a 7.")
+		if err == nil {
+			t.Fatal("expected a parse error")
+		}
+		if !strings.Contains(err.Error(), "I think this is about a 7.") {
+			t.Errorf("error should include the raw text for diagnosis, got: %v", err)
+		}
+	})
+
+	// A runaway response must not dump kilobytes into the logs.
+	t.Run("long raw text is truncated in the error", func(t *testing.T) {
+		_, err := parseScorePayload(strings.Repeat("x", 5000))
+		if err == nil {
+			t.Fatal("expected a parse error")
+		}
+		if len(err.Error()) > 400 {
+			t.Errorf("error message is %d chars, want it truncated", len(err.Error()))
+		}
+	})
+}
+
+func TestBuildAnthropicScoreParams(t *testing.T) {
+	params := buildAnthropicScoreParams(ModelClaudeSonnet46, "some feature")
+
+	if len(params.Tools) != 1 {
+		t.Fatalf("len(Tools) = %d, want exactly 1 (the forced scoring tool)", len(params.Tools))
+	}
+	tool := params.Tools[0].OfTool
+	if tool == nil {
+		t.Fatal("Tools[0].OfTool must be set")
+	}
+	if tool.Name != scorerToolName {
+		t.Errorf("tool Name = %q, want %q", tool.Name, scorerToolName)
+	}
+
+	// Without tool_choice pinned to our tool, Claude may answer in prose
+	// and there is no structured output at all.
+	if params.ToolChoice.OfTool == nil {
+		t.Fatal("ToolChoice must pin the scoring tool")
+	}
+	if params.ToolChoice.OfTool.Name != scorerToolName {
+		t.Errorf("ToolChoice name = %q, want %q", params.ToolChoice.OfTool.Name, scorerToolName)
+	}
+	if len(tool.InputSchema.Required) != 3 {
+		t.Errorf("InputSchema.Required = %v, want all three fields", tool.InputSchema.Required)
+	}
+	if params.MaxTokens != scorerMaxTokens {
+		t.Errorf("MaxTokens = %d, want %d", params.MaxTokens, scorerMaxTokens)
+	}
+}
+
+func TestExtractAnthropicToolInput(t *testing.T) {
+	t.Run("returns the matching tool_use input", func(t *testing.T) {
+		content := []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "Let me score that."},
+			{Type: "tool_use", Name: scorerToolName, Input: json.RawMessage(`{"score":4}`)},
+		}
+		got, err := extractAnthropicToolInput(content)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got) != `{"score":4}` {
+			t.Errorf("input = %s, want {\"score\":4}", got)
+		}
+	})
+
+	// Should be impossible given the forced ToolChoice — which is exactly
+	// why it gets its own error rather than surfacing as a parse failure.
+	t.Run("prose-only response errors", func(t *testing.T) {
+		content := []anthropic.ContentBlockUnion{{Type: "text", Text: "About a 7, I'd say."}}
+		if _, err := extractAnthropicToolInput(content); err == nil {
+			t.Fatal("expected an error when no tool_use block is present")
+		}
+	})
+
+	t.Run("ignores a tool_use block for a different tool", func(t *testing.T) {
+		content := []anthropic.ContentBlockUnion{
+			{Type: "tool_use", Name: "some_other_tool", Input: json.RawMessage(`{"score":9}`)},
+		}
+		if _, err := extractAnthropicToolInput(content); err == nil {
+			t.Fatal("expected an error when only a different tool was called")
+		}
+	})
+}
+
+func TestScorer_ScoreWithoutClientErrors(t *testing.T) {
+	t.Run("openai", func(t *testing.T) {
+		s := &OpenAIScorer{c: nil}
+		if _, err := s.Score(t.Context(), "text"); err == nil {
+			t.Fatal("expected error when client is nil")
+		}
+	})
+
+	t.Run("anthropic", func(t *testing.T) {
+		s := &AnthropicScorer{client: nil, model: ModelClaudeSonnet46}
+		if _, err := s.Score(t.Context(), "text"); err == nil {
+			t.Fatal("expected error when client is nil")
+		}
+	})
+}

--- a/internal/ai/scorer_test.go
+++ b/internal/ai/scorer_test.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	openai "github.com/sashabaranov/go-openai"
@@ -224,6 +225,48 @@ func TestParseScorePayload(t *testing.T) {
 		}
 		if len(err.Error()) > 400 {
 			t.Errorf("error message is %d chars, want it truncated", len(err.Error()))
+		}
+	})
+}
+
+// Truncation is byte-bounded, so a cut landing mid-character must not
+// emit a broken rune. Client feature text is often non-ASCII (EU
+// customers), and a provider echoing it back in a malformed reply is
+// exactly when this fires.
+//
+// Asserted on truncateForError directly rather than through
+// parseScorePayload: that formats with %q, which escapes invalid bytes
+// as \xNN and would mask the corruption behind a valid-looking string.
+func TestTruncateForError(t *testing.T) {
+	t.Run("short input passes through unchanged", func(t *testing.T) {
+		if got := truncateForError("hello"); got != "hello" {
+			t.Errorf("truncateForError() = %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("long ASCII input is bounded", func(t *testing.T) {
+		got := truncateForError(strings.Repeat("x", 5000))
+		if len(got) > 250 {
+			t.Errorf("result is %d bytes, want it bounded near 200", len(got))
+		}
+	})
+
+	t.Run("does not split a multi-byte rune", func(t *testing.T) {
+		// "é" is 2 bytes, so a 200-byte cut lands mid-character.
+		got := truncateForError(strings.Repeat("é", 5000))
+		if !utf8.ValidString(got) {
+			t.Errorf("result is not valid UTF-8: %q", got)
+		}
+		if len(got) > 250 {
+			t.Errorf("result is %d bytes, want it bounded near 200", len(got))
+		}
+	})
+
+	// A 3-byte rune straddling the boundary differently than a 2-byte one.
+	t.Run("does not split a 3-byte rune", func(t *testing.T) {
+		got := truncateForError(strings.Repeat("→", 5000))
+		if !utf8.ValidString(got) {
+			t.Errorf("result is not valid UTF-8: %q", got)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,16 @@ type Config struct {
 	DatabaseURL           string
 	AnthropicAPIKey       string
 	// OpenAI (used by Feature Debate Mode's ChatGPT refiner).
-	OpenAIAPIKey                string
-	OpenAIModel                 string
+	OpenAIAPIKey string
+	OpenAIModel  string
+	// Per-provider debate scorer models (issue #63). The scorer runs on
+	// every accepted round plus the background retry sweep, so each
+	// provider defaults to its cheapest priced model rather than reusing
+	// the refiner's — except Gemini, whose refiner model is already
+	// flash-class, so the scorer follows GEMINI_MODEL.
+	ScorerModelGemini           string
+	ScorerModelOpenAI           string
+	ScorerModelClaude           string
 	ProtectedSuperadmins        []string
 	RPOrigins                   []string
 	GeminiImageTextOutPrice     int64
@@ -144,6 +152,12 @@ func Load() (*Config, error) {
 		workspacesDir = home + "/forgedesk-workspaces"
 	}
 
+	// Hoisted out of the Config literal below because ScorerModelGemini
+	// defaults to it: production pins GEMINI_MODEL to a preview flash
+	// model, and a scorer silently running a different Gemini model than
+	// everything else would be a surprising split.
+	geminiModel := envOrDefault("GEMINI_MODEL", "gemini-2.5-flash")
+
 	aesKey := envTrimmed("AES_ENCRYPTION_KEY")
 	if aesKey == "" {
 		return nil, fmt.Errorf("AES_ENCRYPTION_KEY is required (hex-encoded 32-byte key)")
@@ -169,7 +183,7 @@ func Load() (*Config, error) {
 		RPID:                 rpID,
 		RPOrigins:            []string{baseURL},
 		GeminiAPIKey:         envTrimmed("GEMINI_API_KEY"),
-		GeminiModel:          envOrDefault("GEMINI_MODEL", "gemini-2.5-flash"),
+		GeminiModel:          geminiModel,
 		GeminiModelChat:      envOrDefault("GEMINI_MODEL_CHAT", "gemini-2.5-flash"),
 		GeminiModelPro:       envOrDefault("GEMINI_MODEL_PRO", "gemini-2.5-pro"),
 		GeminiModelImage:     envOrDefault("GEMINI_MODEL_IMAGE", "gemini-2.5-flash"),
@@ -187,11 +201,20 @@ func Load() (*Config, error) {
 		GeminiImageProTextOutPrice:  envInt64("GEMINI_MODEL_IMAGE_PRO_TEXT_OUTPUT_PRICE", 1200),
 		GeminiImageProImageOutPrice: envInt64("GEMINI_MODEL_IMAGE_PRO_IMAGE_OUTPUT_PRICE", 12000),
 
-		AnthropicAPIKey:             envTrimmed("ANTHROPIC_API_KEY"),
-		AnthropicModel:              envOrDefault("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
-		AnthropicModelContent:       envOrDefault("ANTHROPIC_MODEL_CONTENT", "claude-opus-4-6"),
-		OpenAIAPIKey:                envTrimmed("OPENAI_API_KEY"),
-		OpenAIModel:                 envOrDefault("OPENAI_MODEL", "gpt-5-mini"),
+		AnthropicAPIKey:       envTrimmed("ANTHROPIC_API_KEY"),
+		AnthropicModel:        envOrDefault("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
+		AnthropicModelContent: envOrDefault("ANTHROPIC_MODEL_CONTENT", "claude-opus-4-6"),
+		OpenAIAPIKey:          envTrimmed("OPENAI_API_KEY"),
+		OpenAIModel:           envOrDefault("OPENAI_MODEL", "gpt-5-mini"),
+
+		// Scorer models (issue #63). Literals rather than ai.Model*
+		// constants: internal/config does not import internal/ai, and
+		// the refiner model defaults above are literals for the same
+		// reason. Constants named in comments so a grep finds both.
+		ScorerModelGemini: envOrDefault("SCORER_MODEL_GEMINI", geminiModel),
+		ScorerModelOpenAI: envOrDefault("SCORER_MODEL_OPENAI", "gpt-5-mini"),        // ai.ModelGPT5Mini
+		ScorerModelClaude: envOrDefault("SCORER_MODEL_CLAUDE", "claude-sonnet-4-6"), // ai.ModelClaudeSonnet46
+
 		AnthropicInputPrice:         envInt64("ANTHROPIC_INPUT_PRICE", 300),
 		AnthropicOutputPrice:        envInt64("ANTHROPIC_OUTPUT_PRICE", 1500),
 		AnthropicContentInputPrice:  envInt64("ANTHROPIC_CONTENT_INPUT_PRICE", 1500),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,6 +152,94 @@ func TestLoad_PreservesPasswordWhitespace(t *testing.T) {
 	}
 }
 
+// TestLoad_ScorerModels covers the per-provider debate scorer models
+// (issue #63). Scoring runs on every accept plus the background retry
+// sweep, so each provider defaults to its cheapest priced model rather
+// than reusing the (pricier) refiner model — except Gemini, whose refiner
+// model is already flash-class and is therefore the sensible default.
+func TestLoad_ScorerModels(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("GEMINI_MODEL", "")
+		t.Setenv("SCORER_MODEL_GEMINI", "")
+		t.Setenv("SCORER_MODEL_OPENAI", "")
+		t.Setenv("SCORER_MODEL_CLAUDE", "")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error: %v", err)
+		}
+		if cfg.ScorerModelGemini != "gemini-2.5-flash" {
+			t.Errorf("ScorerModelGemini = %q, want %q", cfg.ScorerModelGemini, "gemini-2.5-flash")
+		}
+		if cfg.ScorerModelOpenAI != "gpt-5-mini" {
+			t.Errorf("ScorerModelOpenAI = %q, want %q", cfg.ScorerModelOpenAI, "gpt-5-mini")
+		}
+		if cfg.ScorerModelClaude != "claude-sonnet-4-6" {
+			t.Errorf("ScorerModelClaude = %q, want %q", cfg.ScorerModelClaude, "claude-sonnet-4-6")
+		}
+	})
+
+	// The Gemini scorer tracks GEMINI_MODEL rather than a hardcoded
+	// default: production pins gemini-3-flash-preview, and a scorer
+	// silently scoring on 2.5-flash while everything else used the pinned
+	// model would be a surprising split.
+	t.Run("gemini scorer follows a customized GEMINI_MODEL", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("GEMINI_MODEL", "gemini-3-flash-preview")
+		t.Setenv("SCORER_MODEL_GEMINI", "")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error: %v", err)
+		}
+		if cfg.ScorerModelGemini != "gemini-3-flash-preview" {
+			t.Errorf("ScorerModelGemini = %q, want it to follow GEMINI_MODEL", cfg.ScorerModelGemini)
+		}
+	})
+
+	t.Run("explicit values win over defaults", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("GEMINI_MODEL", "gemini-3-flash-preview")
+		t.Setenv("SCORER_MODEL_GEMINI", "gemini-2.5-flash")
+		t.Setenv("SCORER_MODEL_OPENAI", "gpt-5")
+		t.Setenv("SCORER_MODEL_CLAUDE", "claude-opus-4-6")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error: %v", err)
+		}
+		if cfg.ScorerModelGemini != "gemini-2.5-flash" {
+			t.Errorf("ScorerModelGemini = %q, want gemini-2.5-flash", cfg.ScorerModelGemini)
+		}
+		if cfg.ScorerModelOpenAI != "gpt-5" {
+			t.Errorf("ScorerModelOpenAI = %q, want gpt-5", cfg.ScorerModelOpenAI)
+		}
+		if cfg.ScorerModelClaude != "claude-opus-4-6" {
+			t.Errorf("ScorerModelClaude = %q, want claude-opus-4-6", cfg.ScorerModelClaude)
+		}
+	})
+
+	// Same trailing-newline class of typo that broke OPENAI_MODEL in
+	// production (issue #111) — these reads must trim too.
+	t.Run("trims whitespace", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("SCORER_MODEL_OPENAI", "gpt-5-mini\n")
+		t.Setenv("SCORER_MODEL_CLAUDE", "  claude-sonnet-4-6  ")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error: %v", err)
+		}
+		if cfg.ScorerModelOpenAI != "gpt-5-mini" {
+			t.Errorf("ScorerModelOpenAI = %q, want it trimmed", cfg.ScorerModelOpenAI)
+		}
+		if cfg.ScorerModelClaude != "claude-sonnet-4-6" {
+			t.Errorf("ScorerModelClaude = %q, want it trimmed", cfg.ScorerModelClaude)
+		}
+	})
+}
+
 func TestLoad_MissingRequired(t *testing.T) {
 	t.Run("fails without DATABASE_URL", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "")


### PR DESCRIPTION
## Summary

First of three implementation PRs for issue #63 (per-project scorer provider), per the plan in `docs/superpowers/plans/2026-08-16-per-project-scorer-provider.md` (#115).

**Purely additive — no behavior change.** Nothing constructs the new adapters yet; that lands in PR 3 (migration + wiring). Merging this cannot affect production.

Refs #63.

## Why two new adapters and not a model swap

Only `GeminiScorer` existed, and neither `internal/ai/openai.go` nor `anthropic.go` had *any* structured-output code. Each provider expresses it differently:

| Provider | Mechanism |
|---|---|
| Gemini | `ResponseSchema` (already existed) |
| OpenAI | strict `json_schema` `response_format` |
| Anthropic | forced single tool-use (`tool_choice` pinned, parallel tool use disabled) |

**OpenAI schema constraints, verified against the docs:** strict mode rejects numeric constraints (`minimum`/`maximum`, as with `minItems`/`maxItems`) and requires `additionalProperties: false` with every property listed in `required`. So the schema is type-only, and `clampScoreFields` is the real enforcement — pinned by `TestScorerOpenAISchema_StrictModeInvariants`, because violating either rule is a **400 at call time** that no offline test would catch.

## Interface change

`Scorer` gains `Name()`/`Model()`, mirroring `Refiner`. `Model()` is load-bearing beyond audit: the startup pricing guard (#108/#109) iterates the scorer registry to catch un-priced models, and the alternative — a parallel `map[string]string` in `main.go` — would drift from the registry silently, which is exactly the #108 failure mode.

Shared so the three adapters can't drift: `scorePayload`/`parseScorePayload`, `clampScoreFields`, `scorerMaxTokens`/`scorerTemperature`. `GeminiScorer` was refactored onto them.

> The clamps matter more than they look. Gemini enforces `1..10` / `hours >= 1` server-side via `ResponseSchema`, but **neither** OpenAI strict mode **nor** Anthropic tool schemas enforce numeric bounds — so for those two the clamps are the only thing keeping an out-of-range score off the effort chip.

## Config

Adds `SCORER_MODEL_GEMINI` / `SCORER_MODEL_OPENAI` / `SCORER_MODEL_CLAUDE`. Scoring runs on every accept plus the background retry sweep, so each defaults to its cheapest priced model rather than the refiner's:

- `SCORER_MODEL_GEMINI` → follows `GEMINI_MODEL` (already flash-class; production pins `gemini-3-flash-preview`)
- `SCORER_MODEL_OPENAI` → `gpt-5-mini` ($0.50/$2 per 1M)
- `SCORER_MODEL_CLAUDE` → `claude-sonnet-4-6` ($3/$15) — **the pricing table has no cheap Claude tier**, and inventing a Haiku rate isn't acceptable. Adding a verified Haiku entry is a tracked follow-up; Claude is the expensive scorer until then.

All three read through the trimming helpers from #111.

## Testing

Follows this package's existing pattern — pure functions + nil-client paths + the live suite — rather than introducing network mocking, which no adapter here uses. The request builders (`buildOpenAIScoreRequest`, `buildAnthropicScoreParams`) are extracted precisely so the highest-risk logic is testable offline: **gpt-5-mini is a reasoning model**, and go-openai's `ReasoningValidator` rejects `MaxTokens`/a non-0-or-1 `Temperature` for those *client-side*.

Some assertions were written after their implementation, so each was **mutation-verified**: inverting the reasoning branch, dropping `additionalProperties`, matching any `tool_use` block regardless of name, and removing the `ToolChoice` pin each produced the expected failure, and all four reverted clean.

Live tests for both adapters behind `//go:build integration_ai` (never in per-PR CI) — the only check that OpenAI actually *accepts* the strict schema and that Claude really returns the forced tool block.

**Verification:** `go build ./...`, `go vet`, `go vet -tags integration_ai`, `gofmt`, full-repo `golangci-lint` (0 issues), and the complete `go test ./internal/... -p 1` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)