### PR TITLE
feat(debate): per-project scorer provider selection (#63)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -177,15 +177,35 @@ func main() {
 	if debateRefinerMode == debateRefinerModeFake {
 		debateRefiners = buildFakeDebateRefiners()
 	}
-	var debateScorer ai.Scorer
+	// Scorer registry, keyed like the refiners above. Which one runs is a
+	// per-project setting (issue #63); projects default to gemini, which
+	// is what v1 hardcoded. Each provider uses its own SCORER_MODEL_*
+	// (defaulting to that vendor's cheapest priced model) because scoring
+	// fires on every accepted round plus the background retry sweep.
+	debateScorers := map[string]ai.Scorer{}
+	if cfg.AnthropicAPIKey != "" {
+		// A second client bound to the scorer model: AnthropicClient is
+		// model-bound at construction and the scorer model may differ
+		// from the refiner's.
+		debateScorers[ai.ProviderClaude] = ai.NewAnthropicScorer(
+			ai.NewAnthropicClient(cfg.AnthropicAPIKey, ai.AnthropicModels{
+				Default: cfg.ScorerModelClaude,
+				Content: cfg.AnthropicModelContent,
+			}), cfg.ScorerModelClaude)
+	}
 	if geminiClient != nil {
-		// v1 hardcodes Gemini as the scorer (spec §3.2); phase-2 issue
-		// #63 makes this configurable per project.
-		debateScorer = ai.NewGeminiScorer(geminiClient, cfg.GeminiModel)
+		debateScorers[ai.ProviderGemini] = ai.NewGeminiScorer(geminiClient, cfg.ScorerModelGemini)
+	}
+	if cfg.OpenAIAPIKey != "" {
+		debateScorers[ai.ProviderOpenAI] = ai.NewOpenAIScorer(
+			ai.NewOpenAIClient(cfg.OpenAIAPIKey, cfg.ScorerModelOpenAI))
+	}
+	if debateRefinerMode == debateRefinerModeFake {
+		debateScorers = buildFakeDebateScorers()
 	}
 	debateCfg := handlers.DefaultDebateConfig()
-	debateH := handlers.NewDebateHandler(db, engine, debateRefiners, debateScorer, debateCfg)
-	log.Printf("Feature Debate Mode wired (%d refiners, scorer=%v)", len(debateRefiners), debateScorer != nil)
+	debateH := handlers.NewDebateHandler(db, engine, debateRefiners, debateScorers, debateCfg)
+	log.Printf("Feature Debate Mode wired (%d refiners, %d scorers)", len(debateRefiners), len(debateScorers))
 
 	// Cost-tracking guard (issue #108). A model absent from the pricing
 	// table prices every call at $0 silently; warn loudly at startup so a
@@ -199,8 +219,14 @@ func main() {
 				unpriced[m] = struct{}{}
 			}
 		}
-		if debateScorer != nil && cfg.GeminiModel != "" && !ai.HasPricing(cfg.GeminiModel) {
-			unpriced[cfg.GeminiModel] = struct{}{}
+		// Every configured scorer, not just Gemini: with per-project
+		// selection (#63) any of the three can bill, and each uses its
+		// own SCORER_MODEL_*. This iteration is why Scorer carries
+		// Model() at all.
+		for _, s := range debateScorers {
+			if m := s.Model(); m != "" && !ai.HasPricing(m) {
+				unpriced[m] = struct{}{}
+			}
 		}
 		for m := range unpriced {
 			log.Printf("WARNING: debate model %q has no pricing-table entry — its AI calls record $0 cost (issue #108, internal/ai/pricing.go)", m)
@@ -211,7 +237,7 @@ func main() {
 		if len(debateRefiners) == 0 {
 			log.Fatal("DEBATE_REAL_AI=1 but no provider API keys configured — set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY")
 		}
-		log.Printf("WARNING: DEBATE_REAL_AI=1 — debate refiners and scorer make REAL, billable provider calls (%d providers, scorer=%v)", len(debateRefiners), debateScorer != nil)
+		log.Printf("WARNING: DEBATE_REAL_AI=1 — debate refiners and scorers make REAL, billable provider calls (%d providers, %d scorers)", len(debateRefiners), len(debateScorers))
 	}
 
 	// Rate limiter for auth endpoints (0.5 req/s, burst 5)
@@ -389,9 +415,9 @@ func main() {
 	// stuck on its empty state. Runs in-process on each replica;
 	// ClaimStaleEffortScores uses FOR UPDATE SKIP LOCKED + a backoff lease
 	// so the two forgedesk-server replicas never double-score (double-bill)
-	// the same debate. Guarded on the scorer being configured — without
-	// GEMINI_API_KEY there is nothing to call.
-	if debateScorer != nil {
+	// the same debate. Guarded on at least one scorer being configured —
+	// with no provider API keys there is nothing to call.
+	if len(debateScorers) > 0 {
 		go func() {
 			ticker := time.NewTicker(debateCfg.EffortRetrySweepInterval)
 			defer ticker.Stop()
@@ -470,8 +496,39 @@ func buildFakeDebateRefiners() map[string]ai.Refiner {
 		}
 	}
 	return map[string]ai.Refiner{
-		"claude": mk("claude", ai.ModelClaudeSonnet46),
-		"gemini": mk("gemini", ai.ModelGeminiFlash),
-		"openai": mk("openai", ai.ModelGPT5Mini),
+		ai.ProviderClaude: mk(ai.ProviderClaude, ai.ModelClaudeSonnet46),
+		ai.ProviderGemini: mk(ai.ProviderGemini, ai.ModelGeminiFlash),
+		ai.ProviderOpenAI: mk(ai.ProviderOpenAI, ai.ModelGPT5Mini),
+	}
+}
+
+// buildFakeDebateScorers mirrors buildFakeDebateRefiners for the scorer
+// registry. Without fake scorers the E2E stack could not exercise
+// per-project provider selection at all (issue #63) — which is the whole
+// feature — since every real scorer needs a billable API key.
+//
+// Each fake names its provider in Reasoning so a test can assert which
+// one actually ran, and reports the matching real model so the cost
+// accounting path behaves as it does in production.
+func buildFakeDebateScorers() map[string]ai.Scorer {
+	mk := func(name, model string) ai.Scorer {
+		return &ai.FakeScorer{
+			NameVal: name, ModelVal: model,
+			Result: ai.ScoreResult{
+				Score:     5,
+				Hours:     8,
+				Reasoning: "Scored by fake " + name + " scorer.",
+				Usage: ai.RefineUsage{
+					InputTokens: 100, OutputTokens: 20,
+					CostMicros: ai.ComputeCostMicros(model, 100, 20),
+					Model:      model,
+				},
+			},
+		}
+	}
+	return map[string]ai.Scorer{
+		ai.ProviderClaude: mk(ai.ProviderClaude, ai.ModelClaudeSonnet46),
+		ai.ProviderGemini: mk(ai.ProviderGemini, ai.ModelGeminiFlash),
+		ai.ProviderOpenAI: mk(ai.ProviderOpenAI, ai.ModelGPT5Mini),
 	}
 }

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -106,18 +106,44 @@ type DebateHandler struct {
 	db       *models.DB
 	engine   *render.Engine
 	refiners map[string]ai.Refiner
-	scorer   ai.Scorer
+	scorers  map[string]ai.Scorer
 	cfg      DebateConfig
 }
 
-// NewDebateHandler constructs the handler. refiners are keyed by
-// Refiner.Name() ("claude", "gemini", "openai"); the scorer can be
-// nil if GEMINI_API_KEY isn't configured (scoring then silently skips
-// and the sidebar shows the empty state).
+// NewDebateHandler constructs the handler. refiners and scorers are both
+// keyed by provider name ("claude", "gemini", "openai") and may be
+// smaller than 3 — or empty — when an operator deployment is missing API
+// keys. Which scorer runs is chosen per project (issue #63); an empty
+// scorers map means scoring silently skips and the sidebar shows the
+// empty state, matching the pre-#63 nil-scorer behavior.
 func NewDebateHandler(db *models.DB, engine *render.Engine,
-	refiners map[string]ai.Refiner, scorer ai.Scorer, cfg DebateConfig,
+	refiners map[string]ai.Refiner, scorers map[string]ai.Scorer, cfg DebateConfig,
 ) *DebateHandler {
-	return &DebateHandler{db: db, engine: engine, refiners: refiners, scorer: scorer, cfg: cfg}
+	return &DebateHandler{db: db, engine: engine, refiners: refiners, scorers: scorers, cfg: cfg}
+}
+
+// errScorerNotConfigured means the project names a provider that has no
+// registered scorer — almost always a missing API key for that vendor.
+// Distinct from a DB failure so the two get different log lines and an
+// operator can tell a misconfiguration from an outage.
+var errScorerNotConfigured = errors.New("no scorer registered for provider")
+
+// scorerForProject resolves the scorer a project is configured to use.
+//
+// Returns the provider name alongside the scorer so callers can name it
+// in logs and record it with the score. Three outcomes are deliberately
+// kept distinct: a DB error (infrastructure), an unregistered provider
+// (operator configuration), and success.
+func (h *DebateHandler) scorerForProject(ctx context.Context, projectID string) (ai.Scorer, string, error) {
+	provider, err := h.db.GetProjectScorerProvider(ctx, projectID)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving scorer provider for project %s: %w", projectID, err)
+	}
+	scorer, ok := h.scorers[provider]
+	if !ok {
+		return nil, provider, errScorerNotConfigured
+	}
+	return scorer, provider, nil
 }
 
 // debateContext bundles the three things every endpoint looks up in
@@ -653,7 +679,10 @@ func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
 	// goroutine runs, causing the scorer to evaluate stale content
 	// while the result is still associated with this round's ID. The
 	// direct-pass path guarantees scorer input == round output.
-	if h.scorer != nil {
+	//
+	// The provider lookup happens inside the goroutine, not here: it is a
+	// database round-trip and the accept response must not wait on it.
+	if len(h.scorers) > 0 {
 		go h.scoreAfterAccept(context.WithoutCancel(r.Context()),
 			deb.ID, round.ID, dctx.ticket.ProjectID, round.OutputText)
 	}
@@ -732,13 +761,30 @@ func (h *DebateHandler) scoreAfterAccept(ctx context.Context, debateID, roundID,
 	callCtx, cancel := context.WithTimeout(ctx, h.cfg.AICallTimeout)
 	defer cancel()
 
-	res, err := h.scorer.Score(callCtx, textToScore)
-	if err != nil {
-		log.Printf("debate scoreAfterAccept: scorer failed for debate %s round %s: %v", debateID, roundID, err)
+	scorer, provider, err := h.scorerForProject(callCtx, projectID)
+	switch {
+	case errors.Is(err, errScorerNotConfigured):
+		// No silent fallback to another vendor (spec §3.2): the score is
+		// skipped and the sidebar keeps its empty state. The retry sweep
+		// will keep trying and backing off until an operator either
+		// configures the key or changes the project's provider.
+		log.Printf("WARNING: debate scoreAfterAccept: project %s is configured for scorer provider %q "+
+			"but no such scorer is registered (missing API key?) — debate %s round %s left unscored",
+			projectID, provider, debateID, roundID)
+		return
+	case err != nil:
+		log.Printf("debate scoreAfterAccept: %v", err)
 		return
 	}
 
-	if applyErr := h.applyScoreResult(ctx, debateID, roundID, projectID, res); applyErr != nil {
+	res, err := scorer.Score(callCtx, textToScore)
+	if err != nil {
+		log.Printf("debate scoreAfterAccept: scorer %q failed for debate %s round %s: %v",
+			provider, debateID, roundID, err)
+		return
+	}
+
+	if applyErr := h.applyScoreResult(ctx, debateID, roundID, projectID, provider, res); applyErr != nil {
 		log.Printf("debate scoreAfterAccept: %v", applyErr)
 	}
 }
@@ -760,7 +806,7 @@ const effortScoreWriteTimeout = 15 * time.Second
 // Shared by the accept path (scoreAfterAccept) and the background retry
 // sweep (retryOneEffortScore) so the cost-accounting write lives in
 // exactly one place. Returns a wrapped error for the caller to log.
-func (h *DebateHandler) applyScoreResult(ctx context.Context, debateID, roundID, projectID string, res ai.ScoreResult) error {
+func (h *DebateHandler) applyScoreResult(ctx context.Context, debateID, roundID, projectID, provider string, res ai.ScoreResult) error {
 	// Both callers pass an un-deadlined context (accept: context.WithoutCancel;
 	// sweep: context.Background). Bound the write so a stuck FOR UPDATE lock
 	// or a slow database can't wedge the goroutine and leak a pooled
@@ -786,7 +832,8 @@ func (h *DebateHandler) applyScoreResult(ctx context.Context, debateID, roundID,
 	if uErr := h.db.UpdateScorerCostMicros(dbCtx, tx, roundID, res.Usage.CostMicros); uErr != nil {
 		return fmt.Errorf("update scorer cost on round %s: %w", roundID, uErr)
 	}
-	if uErr := h.db.UpdateEffortScoreCondTx(dbCtx, tx, debateID, roundID, res.Score, res.Hours, res.Reasoning); uErr != nil {
+	if uErr := h.db.UpdateEffortScoreCondTx(dbCtx, tx, debateID, roundID,
+		res.Score, res.Hours, res.Reasoning, provider, res.Usage.Model); uErr != nil {
 		return fmt.Errorf("UpdateEffortScoreCondTx debate %s: %w", debateID, uErr)
 	}
 
@@ -819,10 +866,10 @@ func (h *DebateHandler) applyScoreResult(ctx context.Context, debateID, roundID,
 //
 // Safe to run on every server replica concurrently: the claim's
 // FOR UPDATE SKIP LOCKED plus the backoff lease guarantees each debate is
-// scored by at most one replica per window. A nil scorer (no
-// GEMINI_API_KEY) makes it a no-op, matching the accept path.
+// scored by at most one replica per window. An empty scorer registry (no
+// provider API keys) makes it a no-op, matching the accept path.
 func (h *DebateHandler) RetryStaleEffortScores(ctx context.Context) {
-	if h.scorer == nil {
+	if len(h.scorers) == 0 {
 		return
 	}
 	claimed, err := h.db.ClaimStaleEffortScores(ctx, time.Now(),
@@ -847,12 +894,23 @@ func (h *DebateHandler) retryOneEffortScore(ctx context.Context, d models.StaleE
 	callCtx, cancel := context.WithTimeout(ctx, h.cfg.AICallTimeout)
 	defer cancel()
 
-	res, err := h.scorer.Score(callCtx, d.OutputText)
-	if err != nil {
-		log.Printf("debate RetryStaleEffortScores: scorer failed for debate %s round %s: %v", d.DebateID, d.RoundID, err)
+	// The claim joined in the project's configured provider, so this is a
+	// map lookup rather than another query per claimed row.
+	scorer, ok := h.scorers[d.ScorerProvider]
+	if !ok {
+		log.Printf("WARNING: debate RetryStaleEffortScores: project %s is configured for scorer provider %q "+
+			"but no such scorer is registered (missing API key?) — debate %s round %s left unscored",
+			d.ProjectID, d.ScorerProvider, d.DebateID, d.RoundID)
 		return
 	}
-	if applyErr := h.applyScoreResult(ctx, d.DebateID, d.RoundID, d.ProjectID, res); applyErr != nil {
+
+	res, err := scorer.Score(callCtx, d.OutputText)
+	if err != nil {
+		log.Printf("debate RetryStaleEffortScores: scorer %q failed for debate %s round %s: %v",
+			d.ScorerProvider, d.DebateID, d.RoundID, err)
+		return
+	}
+	if applyErr := h.applyScoreResult(ctx, d.DebateID, d.RoundID, d.ProjectID, d.ScorerProvider, res); applyErr != nil {
 		log.Printf("debate RetryStaleEffortScores: %v", applyErr)
 	}
 }

--- a/internal/handlers/debate_retry_test.go
+++ b/internal/handlers/debate_retry_test.go
@@ -16,13 +16,22 @@ import (
 // newScorerHandler builds a DebateHandler with no refiners and the given
 // scorer (which may be nil) — enough to exercise the background retry
 // sweep, which never touches the HTTP layer.
+//
+// The scorer is registered under the "gemini" key because seeded test
+// projects take the schema default for scorer_provider (issue #63), so
+// this is the scorer per-project resolution will actually pick. A nil
+// scorer yields an empty registry, matching the pre-#63 no-scorer case.
 func newScorerHandler(t *testing.T, db *models.DB, scorer ai.Scorer) *DebateHandler {
 	t.Helper()
 	engine, err := render.NewEngine(testutil.ProjectRoot()+"/templates", nil)
 	if err != nil {
 		t.Fatalf("loading templates: %v", err)
 	}
-	return NewDebateHandler(db, engine, map[string]ai.Refiner{}, scorer, DefaultDebateConfig())
+	scorers := map[string]ai.Scorer{}
+	if scorer != nil {
+		scorers[ai.ProviderGemini] = scorer
+	}
+	return NewDebateHandler(db, engine, map[string]ai.Refiner{}, scorers, DefaultDebateConfig())
 }
 
 // seedStaleScorableDebate creates a debate with one accepted round whose

--- a/internal/handlers/debate_scorer_provider_test.go
+++ b/internal/handlers/debate_scorer_provider_test.go
@@ -2,8 +2,12 @@ package handlers
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/madalin/forgedesk/internal/ai"
 	"github.com/madalin/forgedesk/internal/models"
@@ -157,6 +161,116 @@ func TestRetryStaleEffortScores_EmptyRegistryIsNoOp(t *testing.T) {
 	}
 	if attempts != 0 {
 		t.Errorf("effort_retry_attempts = %d, want 0 (nothing was claimed)", attempts)
+	}
+}
+
+// acceptRoundOK POSTs the accept endpoint and requires a 200. Accepting
+// must succeed regardless of whether scoring can run afterwards — the
+// score is fire-and-forget.
+func acceptRoundOK(t *testing.T, r *chi.Mux, cookie *http.Cookie, ticketID, roundID string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticketID+"/debate/rounds/"+roundID+"/accept", http.NoBody)
+	req.Header.Set("Hx-Request", "true")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("accept: got %d, want 200 — body: %s", w.Code, w.Body.String())
+	}
+}
+
+// waitForEffortScore polls until the accept path's fire-and-forget
+// scoring goroutine has written a score for the given round.
+func waitForEffortScore(t *testing.T, db *models.DB, ticketID, roundID string) bool {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		deb, err := db.GetActiveDebate(context.Background(), ticketID)
+		if err != nil {
+			return false
+		}
+		if deb.LastScoredRoundID != nil && *deb.LastScoredRoundID == roundID {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// The accept path resolves the provider inside its scoring goroutine,
+// reading dctx.ticket.ProjectID — plumbing unique to this call site and
+// not covered by the sweep tests. Asserts the configured provider runs
+// and is what gets recorded against the score.
+func TestAcceptRound_UsesProjectConfiguredProvider(t *testing.T) {
+	openaiScorer := fakeScorerFor(ai.ProviderOpenAI, ai.ModelGPT5Mini)
+	geminiScorer := fakeScorerFor(ai.ProviderGemini, ai.ModelGeminiFlash)
+
+	r, db, sessions := setupDebateTestEnvWithRegistry(t, map[string]ai.Scorer{
+		ai.ProviderOpenAI: openaiScorer,
+		ai.ProviderGemini: geminiScorer,
+	})
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	if err := db.UpdateProjectScorerProvider(context.Background(), ticket.ProjectID, ai.ProviderOpenAI); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+	deb, round := insertInReviewRound(t, db, cookie, r, ticket.ID, "scored text")
+
+	acceptRoundOK(t, r, cookie, ticket.ID, round.ID)
+
+	if !waitForEffortScore(t, db, ticket.ID, round.ID) {
+		t.Fatal("scorer did not write a score within 5s")
+	}
+	if openaiScorer.CallCount != 1 {
+		t.Errorf("openai scorer CallCount = %d, want 1", openaiScorer.CallCount)
+	}
+	if geminiScorer.CallCount != 0 {
+		t.Errorf("gemini scorer CallCount = %d, want 0 (project selected openai)", geminiScorer.CallCount)
+	}
+
+	provider, model, score := readEffortScorer(t, db, deb.ID)
+	if score == nil {
+		t.Fatal("effort_score is NULL, want it written")
+	}
+	if provider == nil || *provider != ai.ProviderOpenAI {
+		t.Errorf("effort_scorer_provider = %s, want openai", derefOrNull(provider))
+	}
+	if model == nil || *model != ai.ModelGPT5Mini {
+		t.Errorf("effort_scorer_model = %s, want %s", derefOrNull(model), ai.ModelGPT5Mini)
+	}
+}
+
+// Accept must still succeed when the project names a provider with no
+// registered scorer — the round is accepted, the score is simply skipped
+// with a WARNING, and no other vendor is substituted.
+func TestAcceptRound_UnregisteredProviderStillAcceptsWithoutScoring(t *testing.T) {
+	geminiScorer := fakeScorerFor(ai.ProviderGemini, ai.ModelGeminiFlash)
+	r, db, sessions := setupDebateTestEnvWithRegistry(t, map[string]ai.Scorer{
+		ai.ProviderGemini: geminiScorer,
+	})
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	// Claude configured but absent from the registry: a deployment with
+	// no ANTHROPIC_API_KEY.
+	if err := db.UpdateProjectScorerProvider(context.Background(), ticket.ProjectID, ai.ProviderClaude); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+	deb, round := insertInReviewRound(t, db, cookie, r, ticket.ID, "scored text")
+
+	// The accept itself must not fail just because scoring can't run.
+	acceptRoundOK(t, r, cookie, ticket.ID, round.ID)
+
+	// Give the goroutine a chance to (not) score.
+	time.Sleep(300 * time.Millisecond)
+
+	if geminiScorer.CallCount != 0 {
+		t.Errorf("gemini scorer CallCount = %d, want 0 — no silent fallback", geminiScorer.CallCount)
+	}
+	provider, _, score := readEffortScorer(t, db, deb.ID)
+	if score != nil {
+		t.Errorf("effort_score = %d, want NULL", *score)
+	}
+	if provider != nil {
+		t.Errorf("effort_scorer_provider = %q, want NULL", *provider)
 	}
 }
 

--- a/internal/handlers/debate_scorer_provider_test.go
+++ b/internal/handlers/debate_scorer_provider_test.go
@@ -1,0 +1,188 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/madalin/forgedesk/internal/ai"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/render"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// newMultiScorerHandler builds a handler with an explicit scorer
+// registry, so a test can control exactly which providers are available
+// and which one the project selects (issue #63).
+func newMultiScorerHandler(t *testing.T, db *models.DB, scorers map[string]ai.Scorer) *DebateHandler {
+	t.Helper()
+	engine, err := render.NewEngine(testutil.ProjectRoot()+"/templates", nil)
+	if err != nil {
+		t.Fatalf("loading templates: %v", err)
+	}
+	return NewDebateHandler(db, engine, map[string]ai.Refiner{}, scorers, DefaultDebateConfig())
+}
+
+func fakeScorerFor(provider, model string) *ai.FakeScorer {
+	return &ai.FakeScorer{
+		NameVal: provider, ModelVal: model,
+		Result: ai.ScoreResult{
+			Score: 6, Hours: 9, Reasoning: "scored by " + provider,
+			Usage: ai.RefineUsage{CostMicros: 4000, Model: model},
+		},
+	}
+}
+
+// readEffortScorer returns the recorded provider/model for a debate.
+func readEffortScorer(t *testing.T, db *models.DB, debateID string) (provider, model *string, score *int) {
+	t.Helper()
+	if err := db.Pool.QueryRow(context.Background(),
+		`SELECT effort_scorer_provider, effort_scorer_model, effort_score
+		   FROM feature_debates WHERE id = $1`, debateID,
+	).Scan(&provider, &model, &score); err != nil {
+		t.Fatalf("read debate effort scorer: %v", err)
+	}
+	return provider, model, score
+}
+
+// The whole point of #63: the project's configured provider decides which
+// scorer runs, and the score records who produced it.
+func TestRetryStaleEffortScores_UsesProjectConfiguredProvider(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	ctx := context.Background()
+
+	debateID, _, projectID := seedStaleScorableDebate(t, db, time.Now().Add(-10*time.Minute), "the accepted text")
+	if err := db.UpdateProjectScorerProvider(ctx, projectID, ai.ProviderOpenAI); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+
+	openaiScorer := fakeScorerFor(ai.ProviderOpenAI, ai.ModelGPT5Mini)
+	geminiScorer := fakeScorerFor(ai.ProviderGemini, ai.ModelGeminiFlash)
+	h := newMultiScorerHandler(t, db, map[string]ai.Scorer{
+		ai.ProviderOpenAI: openaiScorer,
+		ai.ProviderGemini: geminiScorer,
+	})
+
+	h.RetryStaleEffortScores(ctx)
+
+	if openaiScorer.CallCount != 1 {
+		t.Errorf("openai scorer CallCount = %d, want 1", openaiScorer.CallCount)
+	}
+	// The default provider must NOT have been consulted — this is the
+	// assertion that fails if resolution silently falls back to gemini.
+	if geminiScorer.CallCount != 0 {
+		t.Errorf("gemini scorer CallCount = %d, want 0 (project selected openai)", geminiScorer.CallCount)
+	}
+
+	provider, model, score := readEffortScorer(t, db, debateID)
+	if score == nil {
+		t.Fatal("effort_score is NULL, want it written")
+	}
+	if provider == nil || *provider != ai.ProviderOpenAI {
+		t.Errorf("effort_scorer_provider = %s, want openai", derefOrNull(provider))
+	}
+	if model == nil || *model != ai.ModelGPT5Mini {
+		t.Errorf("effort_scorer_model = %s, want %s", derefOrNull(model), ai.ModelGPT5Mini)
+	}
+}
+
+// derefOrNull renders a nullable column for failure messages — %v on a
+// *string prints the pointer address, which says nothing useful.
+func derefOrNull(s *string) string {
+	if s == nil {
+		return "NULL"
+	}
+	return *s
+}
+
+// Spec §3.2: a provider with no registered scorer is skipped with a
+// warning, never silently swapped for a different vendor. Recording a
+// Gemini score on a project that asked for Claude would misattribute both
+// the estimate and its cost.
+func TestRetryStaleEffortScores_UnregisteredProviderSkipsWithoutFallback(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	ctx := context.Background()
+
+	debateID, _, projectID := seedStaleScorableDebate(t, db, time.Now().Add(-10*time.Minute), "the accepted text")
+	if err := db.UpdateProjectScorerProvider(ctx, projectID, ai.ProviderClaude); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+
+	// Claude is configured on the project but absent from the registry —
+	// the shape of a deployment missing ANTHROPIC_API_KEY.
+	geminiScorer := fakeScorerFor(ai.ProviderGemini, ai.ModelGeminiFlash)
+	h := newMultiScorerHandler(t, db, map[string]ai.Scorer{ai.ProviderGemini: geminiScorer})
+
+	h.RetryStaleEffortScores(ctx)
+
+	if geminiScorer.CallCount != 0 {
+		t.Errorf("gemini scorer CallCount = %d, want 0 — no silent fallback", geminiScorer.CallCount)
+	}
+	provider, _, score := readEffortScorer(t, db, debateID)
+	if score != nil {
+		t.Errorf("effort_score = %d, want NULL (nothing should have scored)", *score)
+	}
+	if provider != nil {
+		t.Errorf("effort_scorer_provider = %q, want NULL", *provider)
+	}
+}
+
+// An empty registry (no provider API keys at all) must be a no-op rather
+// than a nil-map panic — this guards the len() gate that replaced the old
+// nil-scorer check.
+func TestRetryStaleEffortScores_EmptyRegistryIsNoOp(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	ctx := context.Background()
+
+	debateID, _, _ := seedStaleScorableDebate(t, db, time.Now().Add(-10*time.Minute), "the accepted text")
+	h := newMultiScorerHandler(t, db, map[string]ai.Scorer{})
+
+	h.RetryStaleEffortScores(ctx)
+
+	_, _, score := readEffortScorer(t, db, debateID)
+	if score != nil {
+		t.Errorf("effort_score = %d, want NULL", *score)
+	}
+
+	// The sweep must not have burned a retry attempt either: with no
+	// scorer there was nothing to try, and consuming backoff would delay
+	// real scoring once a key is configured.
+	var attempts int
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT effort_retry_attempts FROM feature_debates WHERE id = $1`, debateID).Scan(&attempts); err != nil {
+		t.Fatalf("read attempts: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("effort_retry_attempts = %d, want 0 (nothing was claimed)", attempts)
+	}
+}
+
+// ClaimStaleEffortScores joins the project's provider into each claimed
+// row so the sweep needs no extra query. Pinned directly because a
+// regression here would silently degrade to the zero value "", which
+// looks exactly like an unregistered provider.
+func TestClaimStaleEffortScores_ReturnsProjectScorerProvider(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	ctx := context.Background()
+
+	_, _, projectID := seedStaleScorableDebate(t, db, time.Now().Add(-10*time.Minute), "text")
+	if err := db.UpdateProjectScorerProvider(ctx, projectID, ai.ProviderClaude); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+
+	claimed, err := db.ClaimStaleEffortScores(ctx, time.Now(),
+		5*time.Minute, time.Minute, time.Hour, 10)
+	if err != nil {
+		t.Fatalf("ClaimStaleEffortScores: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("claimed %d debates, want 1", len(claimed))
+	}
+	if claimed[0].ScorerProvider != ai.ProviderClaude {
+		t.Errorf("ScorerProvider = %q, want claude", claimed[0].ScorerProvider)
+	}
+}

--- a/internal/handlers/debate_test.go
+++ b/internal/handlers/debate_test.go
@@ -30,6 +30,22 @@ import (
 // This lets TestAccept_ReturnsBeforeScorerCompletes inject a blocking FakeScorer.
 func setupDebateTestEnv(t *testing.T, scorerOpt ...ai.Scorer) (*chi.Mux, *models.DB, *auth.SessionStore) {
 	t.Helper()
+	// Registered under "gemini": seeded projects take the schema default
+	// for scorer_provider, so this is the scorer per-project resolution
+	// picks (issue #63).
+	scorers := map[string]ai.Scorer{}
+	if len(scorerOpt) > 0 && scorerOpt[0] != nil {
+		scorers[ai.ProviderGemini] = scorerOpt[0]
+	}
+	return setupDebateTestEnvWithRegistry(t, scorers)
+}
+
+// setupDebateTestEnvWithRegistry is setupDebateTestEnv with an explicit
+// scorer registry, so accept-path tests can register scorers under
+// providers other than the default — or deliberately omit one to
+// exercise the unregistered-provider path (issue #63).
+func setupDebateTestEnvWithRegistry(t *testing.T, scorers map[string]ai.Scorer) (*chi.Mux, *models.DB, *auth.SessionStore) {
+	t.Helper()
 
 	pool := testutil.SetupTestDB(t)
 	db := models.NewDB(pool)
@@ -46,13 +62,6 @@ func setupDebateTestEnv(t *testing.T, scorerOpt ...ai.Scorer) (*chi.Mux, *models
 				return "refactored description from claude", ai.FinishReasonStop, nil
 			},
 		},
-	}
-	// Registered under "gemini": seeded projects take the schema default
-	// for scorer_provider, so this is the scorer per-project resolution
-	// picks (issue #63).
-	scorers := map[string]ai.Scorer{}
-	if len(scorerOpt) > 0 && scorerOpt[0] != nil {
-		scorers[ai.ProviderGemini] = scorerOpt[0]
 	}
 	h := NewDebateHandler(db, engine, refiners, scorers, DefaultDebateConfig())
 

--- a/internal/handlers/debate_test.go
+++ b/internal/handlers/debate_test.go
@@ -47,11 +47,14 @@ func setupDebateTestEnv(t *testing.T, scorerOpt ...ai.Scorer) (*chi.Mux, *models
 			},
 		},
 	}
-	var scorer ai.Scorer
-	if len(scorerOpt) > 0 {
-		scorer = scorerOpt[0]
+	// Registered under "gemini": seeded projects take the schema default
+	// for scorer_provider, so this is the scorer per-project resolution
+	// picks (issue #63).
+	scorers := map[string]ai.Scorer{}
+	if len(scorerOpt) > 0 && scorerOpt[0] != nil {
+		scorers[ai.ProviderGemini] = scorerOpt[0]
 	}
-	h := NewDebateHandler(db, engine, refiners, scorer, DefaultDebateConfig())
+	h := NewDebateHandler(db, engine, refiners, scorers, DefaultDebateConfig())
 
 	r := chi.NewRouter()
 	r.Use(middleware.Recover)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -78,6 +78,10 @@ type Project struct {
 	Slug          string    `db:"slug"`
 	BriefMarkdown string    `db:"brief_markdown"`
 	RepoURL       string    `db:"repo_url"`
+	// ScorerProvider selects which AI provider scores this project's
+	// feature debates: claude | gemini | openai (issue #63). Staff-only
+	// setting; defaults to gemini, which is what v1 hardcoded.
+	ScorerProvider string `db:"scorer_provider"`
 }
 
 type Ticket struct {
@@ -238,26 +242,33 @@ type PlatformSettings struct {
 }
 
 type FeatureDebate struct {
-	CreatedAt                 time.Time  `db:"created_at"`
-	UpdatedAt                 time.Time  `db:"updated_at"`
-	InFlightStartedAt         *time.Time `db:"in_flight_started_at"`
-	EffortScoredAt            *time.Time `db:"effort_scored_at"`
-	InFlightRequestID         *string    `db:"in_flight_request_id"`
-	EffortScore               *int       `db:"effort_score"`
-	EffortHours               *int       `db:"effort_hours"`
-	EffortReasoning           *string    `db:"effort_reasoning"`
-	LastScoredRoundID         *string    `db:"last_scored_round_id"`
-	ApprovedText              *string    `db:"approved_text"`
-	ID                        string     `db:"id"`
-	TicketID                  string     `db:"ticket_id"`
-	ProjectID                 string     `db:"project_id"`
-	OrgID                     string     `db:"org_id"`
-	StartedBy                 string     `db:"started_by"`
-	Status                    string     `db:"status"` // active | approved | abandoned
-	SeedDescription           string     `db:"seed_description"`
-	CurrentText               string     `db:"current_text"`
-	OriginalTicketDescription string     `db:"original_ticket_description"`
-	TotalCostMicros           int64      `db:"total_cost_micros"`
+	CreatedAt         time.Time  `db:"created_at"`
+	UpdatedAt         time.Time  `db:"updated_at"`
+	InFlightStartedAt *time.Time `db:"in_flight_started_at"`
+	EffortScoredAt    *time.Time `db:"effort_scored_at"`
+	InFlightRequestID *string    `db:"in_flight_request_id"`
+	EffortScore       *int       `db:"effort_score"`
+	EffortHours       *int       `db:"effort_hours"`
+	EffortReasoning   *string    `db:"effort_reasoning"`
+	LastScoredRoundID *string    `db:"last_scored_round_id"`
+	ApprovedText      *string    `db:"approved_text"`
+	// EffortScorer* record which provider/model produced the CURRENT
+	// effort_* snapshot (issue #63). Not derivable from the project's
+	// live scorer_provider: flipping that dropdown must not retroactively
+	// relabel scores an older provider produced. NULL until first scored;
+	// the model is also NULL for scores backfilled by migration 000034.
+	EffortScorerProvider      *string `db:"effort_scorer_provider"`
+	EffortScorerModel         *string `db:"effort_scorer_model"`
+	ID                        string  `db:"id"`
+	TicketID                  string  `db:"ticket_id"`
+	ProjectID                 string  `db:"project_id"`
+	OrgID                     string  `db:"org_id"`
+	StartedBy                 string  `db:"started_by"`
+	Status                    string  `db:"status"` // active | approved | abandoned
+	SeedDescription           string  `db:"seed_description"`
+	CurrentText               string  `db:"current_text"`
+	OriginalTicketDescription string  `db:"original_ticket_description"`
+	TotalCostMicros           int64   `db:"total_cost_micros"`
 }
 
 type DebateRound struct {

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -817,13 +817,33 @@ func (db *DB) UpdateOrgCurrency(ctx context.Context, orgID, currencyCode string)
 
 // ── Projects ──────────────────────────────────────────────────────
 
+// projectColumns lists the column order used by every project SELECT /
+// RETURNING clause, and scanProject reads that order back. Keeping the
+// pair in one place is what makes adding a column (e.g. scorer_provider
+// in #63) a single edit instead of four synchronized ones — a mismatch
+// between the column list and the scan targets is a RUNTIME error, not a
+// compile error. Same pattern as featureDebateColumns below.
+const projectColumns = `id, org_id, name, slug, brief_markdown, repo_url,
+	scorer_provider, created_at, updated_at`
+
+type projectScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanProject(row projectScanner, p *Project) error {
+	return row.Scan(
+		&p.ID, &p.OrgID, &p.Name, &p.Slug, &p.BriefMarkdown, &p.RepoURL,
+		&p.ScorerProvider, &p.CreatedAt, &p.UpdatedAt,
+	)
+}
+
 func (db *DB) CreateProject(ctx context.Context, orgID, name, slug string) (*Project, error) {
 	p := &Project{}
-	err := db.Pool.QueryRow(ctx,
+	err := scanProject(db.Pool.QueryRow(ctx,
 		`INSERT INTO projects (org_id, name, slug) VALUES ($1, $2, $3)
-		 RETURNING id, org_id, name, slug, brief_markdown, repo_url, created_at, updated_at`,
+		 RETURNING `+projectColumns,
 		orgID, name, slug,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.Slug, &p.BriefMarkdown, &p.RepoURL, &p.CreatedAt, &p.UpdatedAt)
+	), p)
 	if err != nil {
 		return nil, fmt.Errorf("creating project: %w", err)
 	}
@@ -832,10 +852,10 @@ func (db *DB) CreateProject(ctx context.Context, orgID, name, slug string) (*Pro
 
 func (db *DB) GetProject(ctx context.Context, orgID, slug string) (*Project, error) {
 	p := &Project{}
-	err := db.Pool.QueryRow(ctx,
-		`SELECT id, org_id, name, slug, brief_markdown, repo_url, created_at, updated_at
+	err := scanProject(db.Pool.QueryRow(ctx,
+		`SELECT `+projectColumns+`
 		 FROM projects WHERE org_id = $1 AND slug = $2`, orgID, slug,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.Slug, &p.BriefMarkdown, &p.RepoURL, &p.CreatedAt, &p.UpdatedAt)
+	), p)
 	if err != nil {
 		return nil, fmt.Errorf("getting project: %w", err)
 	}
@@ -844,10 +864,10 @@ func (db *DB) GetProject(ctx context.Context, orgID, slug string) (*Project, err
 
 func (db *DB) GetProjectByID(ctx context.Context, id string) (*Project, error) {
 	p := &Project{}
-	err := db.Pool.QueryRow(ctx,
-		`SELECT id, org_id, name, slug, brief_markdown, repo_url, created_at, updated_at
+	err := scanProject(db.Pool.QueryRow(ctx,
+		`SELECT `+projectColumns+`
 		 FROM projects WHERE id = $1`, id,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.Slug, &p.BriefMarkdown, &p.RepoURL, &p.CreatedAt, &p.UpdatedAt)
+	), p)
 	if err != nil {
 		return nil, fmt.Errorf("getting project by id: %w", err)
 	}
@@ -856,7 +876,7 @@ func (db *DB) GetProjectByID(ctx context.Context, id string) (*Project, error) {
 
 func (db *DB) ListProjects(ctx context.Context, orgID string) ([]Project, error) {
 	rows, err := db.Pool.Query(ctx,
-		`SELECT id, org_id, name, slug, brief_markdown, repo_url, created_at, updated_at
+		`SELECT `+projectColumns+`
 		 FROM projects WHERE org_id = $1 ORDER BY name`, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("listing projects: %w", err)
@@ -866,7 +886,7 @@ func (db *DB) ListProjects(ctx context.Context, orgID string) ([]Project, error)
 	var projects []Project
 	for rows.Next() {
 		var p Project
-		if err := rows.Scan(&p.ID, &p.OrgID, &p.Name, &p.Slug, &p.BriefMarkdown, &p.RepoURL, &p.CreatedAt, &p.UpdatedAt); err != nil {
+		if err := scanProject(rows, &p); err != nil {
 			return nil, fmt.Errorf("scanning project: %w", err)
 		}
 		projects = append(projects, p)
@@ -890,6 +910,38 @@ func (db *DB) UpdateProjectRepoURL(ctx context.Context, projectID, repoURL strin
 		return fmt.Errorf("updating project repo url: %w", err)
 	}
 	return nil
+}
+
+// UpdateProjectScorerProvider sets which AI provider scores this
+// project's debates (issue #63). Callers MUST validate the provider
+// against the configured registry first; the CHECK constraint from
+// migration 000034 is only the backstop.
+func (db *DB) UpdateProjectScorerProvider(ctx context.Context, projectID, provider string) error {
+	_, err := db.Pool.Exec(ctx,
+		`UPDATE projects SET scorer_provider = $1, updated_at = now() WHERE id = $2`, provider, projectID)
+	if err != nil {
+		return fmt.Errorf("updating project scorer provider: %w", err)
+	}
+	return nil
+}
+
+// GetProjectScorerProvider reads just the configured scorer provider.
+//
+// A dedicated one-column query rather than GetProjectByID because the
+// accept path calls this from a background scoring goroutine that needs
+// one word — pulling brief_markdown (which can be many KB) along with it
+// would be wasteful on every accepted round.
+//
+// Returns a wrapped pgx.ErrNoRows for an unknown project so callers can
+// distinguish "project vanished" from "provider not configured".
+func (db *DB) GetProjectScorerProvider(ctx context.Context, projectID string) (string, error) {
+	var provider string
+	err := db.Pool.QueryRow(ctx,
+		`SELECT scorer_provider FROM projects WHERE id = $1`, projectID).Scan(&provider)
+	if err != nil {
+		return "", fmt.Errorf("getting project scorer provider: %w", err)
+	}
+	return provider, nil
 }
 
 func (db *DB) TransferProject(ctx context.Context, projectID, targetOrgID string) error {
@@ -2187,6 +2239,7 @@ const featureDebateColumns = `id, ticket_id, project_id, org_id, started_by, sta
 	seed_description, current_text, original_ticket_description,
 	in_flight_request_id, in_flight_started_at, total_cost_micros,
 	effort_score, effort_hours, effort_reasoning, effort_scored_at,
+	effort_scorer_provider, effort_scorer_model,
 	last_scored_round_id, approved_text, created_at, updated_at`
 
 // scanFeatureDebate reads one row from a pgx.Row or pgx.Rows into a *FeatureDebate.
@@ -2200,6 +2253,7 @@ func scanFeatureDebate(row featureDebateScanner, deb *FeatureDebate) error {
 		&deb.SeedDescription, &deb.CurrentText, &deb.OriginalTicketDescription,
 		&deb.InFlightRequestID, &deb.InFlightStartedAt, &deb.TotalCostMicros,
 		&deb.EffortScore, &deb.EffortHours, &deb.EffortReasoning, &deb.EffortScoredAt,
+		&deb.EffortScorerProvider, &deb.EffortScorerModel,
 		&deb.LastScoredRoundID, &deb.ApprovedText, &deb.CreatedAt, &deb.UpdatedAt,
 	)
 }
@@ -2708,10 +2762,15 @@ func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, 
 // Out-of-order scorer responses (scorer for round N finishes after
 // scorer for round N+1) are silently discarded — the freshest
 // accepted round's score always wins. See spec §4.3 step 8.
+//
+// provider and model record who produced this snapshot (issue #63); they
+// are written in the same statement as the score so the effort chip can
+// never label a score with a provider that did not produce it.
 func (db *DB) UpdateEffortScoreCondTx(
 	ctx context.Context, tx pgx.Tx,
 	debateID, scoredRoundID string,
 	score, hours int, reasoning string,
+	provider, model string,
 ) error {
 	_, err := tx.Exec(ctx, `
 		UPDATE feature_debates
@@ -2719,14 +2778,16 @@ func (db *DB) UpdateEffortScoreCondTx(
 		       effort_hours = $2,
 		       effort_reasoning = $3,
 		       effort_scored_at = now(),
-		       last_scored_round_id = $4,
+		       effort_scorer_provider = $4,
+		       effort_scorer_model = $5,
+		       last_scored_round_id = $6,
 		       updated_at = now()
-		 WHERE id = $5
+		 WHERE id = $7
 		   AND status IN ('active','approved')
 		   AND (last_scored_round_id IS NULL
 		     OR (SELECT round_number FROM feature_debate_rounds WHERE id = last_scored_round_id)
-		      < (SELECT round_number FROM feature_debate_rounds WHERE id = $4))`,
-		score, hours, reasoning, scoredRoundID, debateID,
+		      < (SELECT round_number FROM feature_debate_rounds WHERE id = $6))`,
+		score, hours, reasoning, provider, model, scoredRoundID, debateID,
 	)
 	return err
 }
@@ -2748,10 +2809,14 @@ func (db *DB) UpdateScorerCostMicros(ctx context.Context, tx pgx.Tx, roundID str
 // sweep: enough to re-run the scorer (OutputText) and write the result
 // back to the right round (RoundID) and project (ProjectID).
 type StaleEffortDebate struct {
-	DebateID   string
-	ProjectID  string
-	RoundID    string
-	OutputText string
+	DebateID  string
+	ProjectID string
+	RoundID   string
+	// ScorerProvider is the owning project's configured provider, joined
+	// in by the claim so the sweep can resolve a scorer without a second
+	// query per claimed row (issue #63).
+	ScorerProvider string
+	OutputText     string
 }
 
 // ClaimStaleEffortScores atomically claims up to limit debates whose
@@ -2826,6 +2891,12 @@ func (db *DB) ClaimStaleEffortScores(
 		    (SELECT r.id FROM feature_debate_rounds r
 		      WHERE r.debate_id = fd.id AND r.status = 'accepted'
 		      ORDER BY r.round_number DESC LIMIT 1),
+		    -- Correlated read of the owning project's configured scorer
+		    -- (issue #63). Joined here so the sweep needs no extra query
+		    -- per row; projects is not locked by the claim above, so this
+		    -- does not affect the FOR UPDATE SKIP LOCKED semantics that
+		    -- keep two replicas from double-billing the same debate.
+		    (SELECT p.scorer_provider FROM projects p WHERE p.id = fd.project_id),
 		    (SELECT r.output_text FROM feature_debate_rounds r
 		      WHERE r.debate_id = fd.id AND r.status = 'accepted'
 		      ORDER BY r.round_number DESC LIMIT 1)`,
@@ -2839,7 +2910,7 @@ func (db *DB) ClaimStaleEffortScores(
 	var claimed []StaleEffortDebate
 	for rows.Next() {
 		var d StaleEffortDebate
-		if scanErr := rows.Scan(&d.DebateID, &d.ProjectID, &d.RoundID, &d.OutputText); scanErr != nil {
+		if scanErr := rows.Scan(&d.DebateID, &d.ProjectID, &d.RoundID, &d.ScorerProvider, &d.OutputText); scanErr != nil {
 			return nil, scanErr
 		}
 		claimed = append(claimed, d)

--- a/internal/models/queries_scorer_provider_test.go
+++ b/internal/models/queries_scorer_provider_test.go
@@ -1,0 +1,125 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// Issue #63: projects.scorer_provider selects which AI provider scores a
+// project's debates. Every project read path must round-trip it — a missed
+// Scan target is a runtime error, not a compile error, so all four are
+// asserted here rather than trusting the shared column list.
+func TestProjectScorerProvider_DefaultsAndRoundTrips(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	org, _ := db.CreateOrg(ctx, "Scorer Org", "scorer-org")
+	proj, err := db.CreateProject(ctx, org.ID, "Scorer Project", "scorer-proj")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Existing behavior must be preserved: v1 always scored with Gemini,
+	// so a project nobody has configured keeps doing exactly that.
+	if proj.ScorerProvider != "gemini" {
+		t.Errorf("CreateProject ScorerProvider = %q, want gemini", proj.ScorerProvider)
+	}
+
+	if err := db.UpdateProjectScorerProvider(ctx, proj.ID, "openai"); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+
+	t.Run("GetProject", func(t *testing.T) {
+		got, err := db.GetProject(ctx, org.ID, "scorer-proj")
+		if err != nil {
+			t.Fatalf("GetProject: %v", err)
+		}
+		if got.ScorerProvider != "openai" {
+			t.Errorf("ScorerProvider = %q, want openai", got.ScorerProvider)
+		}
+	})
+
+	t.Run("GetProjectByID", func(t *testing.T) {
+		got, err := db.GetProjectByID(ctx, proj.ID)
+		if err != nil {
+			t.Fatalf("GetProjectByID: %v", err)
+		}
+		if got.ScorerProvider != "openai" {
+			t.Errorf("ScorerProvider = %q, want openai", got.ScorerProvider)
+		}
+	})
+
+	t.Run("ListProjects", func(t *testing.T) {
+		projects, err := db.ListProjects(ctx, org.ID)
+		if err != nil {
+			t.Fatalf("ListProjects: %v", err)
+		}
+		if len(projects) != 1 {
+			t.Fatalf("expected 1 project, got %d", len(projects))
+		}
+		if projects[0].ScorerProvider != "openai" {
+			t.Errorf("ScorerProvider = %q, want openai", projects[0].ScorerProvider)
+		}
+	})
+
+	t.Run("GetProjectScorerProvider", func(t *testing.T) {
+		got, err := db.GetProjectScorerProvider(ctx, proj.ID)
+		if err != nil {
+			t.Fatalf("GetProjectScorerProvider: %v", err)
+		}
+		if got != "openai" {
+			t.Errorf("provider = %q, want openai", got)
+		}
+	})
+}
+
+// The accept path resolves the provider by project ID in a background
+// goroutine; a deleted project must surface as ErrNoRows rather than an
+// empty provider string that would silently look like "unconfigured".
+func TestGetProjectScorerProvider_UnknownProject(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	_, err := db.GetProjectScorerProvider(ctx, "00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Fatal("expected an error for an unknown project")
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("error should wrap pgx.ErrNoRows, got: %v", err)
+	}
+}
+
+// Cheap proof the CHECK constraint from migration 000034 is actually live:
+// the handler validates provider names before writing, but the constraint
+// is the backstop if a future call site forgets.
+func TestUpdateProjectScorerProvider_RejectsUnknownProvider(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	org, _ := db.CreateOrg(ctx, "Check Org", "check-org")
+	proj, err := db.CreateProject(ctx, org.ID, "Check Project", "check-proj")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	if updErr := db.UpdateProjectScorerProvider(ctx, proj.ID, "llama"); updErr == nil {
+		t.Fatal("expected the CHECK constraint to reject an unknown provider")
+	}
+
+	// The rejected write must not have changed anything.
+	got, err := db.GetProjectScorerProvider(ctx, proj.ID)
+	if err != nil {
+		t.Fatalf("GetProjectScorerProvider: %v", err)
+	}
+	if got != "gemini" {
+		t.Errorf("provider = %q, want it unchanged at gemini", got)
+	}
+}

--- a/migrations/000034_project_scorer_provider.down.sql
+++ b/migrations/000034_project_scorer_provider.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE feature_debates
+    DROP COLUMN IF EXISTS effort_scorer_model,
+    DROP COLUMN IF EXISTS effort_scorer_provider;
+
+ALTER TABLE projects
+    DROP COLUMN IF EXISTS scorer_provider;

--- a/migrations/000034_project_scorer_provider.down.sql
+++ b/migrations/000034_project_scorer_provider.down.sql
@@ -1,3 +1,12 @@
+-- WARNING: this is lossy once non-Gemini scores exist. Dropping
+-- effort_scorer_provider discards which provider produced each score, and
+-- the up migration's backfill then stamps every scored debate as 'gemini'
+-- — so a down+up cycle SILENTLY RELABELS Claude/OpenAI scores as Gemini.
+-- Harmless before any project switches provider (everything really was
+-- Gemini then). After that, do not reach for down+up as a "safe reset";
+-- roll the application back instead and leave the schema alone, which is
+-- safe because these columns are additive and old code ignores them.
+
 ALTER TABLE feature_debates
     DROP COLUMN IF EXISTS effort_scorer_model,
     DROP COLUMN IF EXISTS effort_scorer_provider;

--- a/migrations/000034_project_scorer_provider.up.sql
+++ b/migrations/000034_project_scorer_provider.up.sql
@@ -1,0 +1,49 @@
+-- Phase-2 issue #63: per-project configurable debate scorer provider.
+--
+-- v1 hardcoded Gemini as the scorer (spec §3.2, cmd/server/main.go). This
+-- migration adds the two pieces of state that per-project selection needs:
+--
+--   projects.scorer_provider          which provider runs the scorer for
+--                                     debates on this project. Staff-only
+--                                     setting; clients never see it.
+--   feature_debates.effort_scorer_*   which provider/model actually produced
+--                                     the CURRENT effort_* snapshot.
+--
+-- The second one is not redundant with the first. The effort chip labels a
+-- score with the provider that produced it; if it read the project's live
+-- setting instead, flipping the dropdown would retroactively relabel every
+-- older score — a Gemini-scored debate would start claiming "via ChatGPT".
+-- The columns sit beside the effort_* snapshot they describe and are
+-- written in the same conditional UPDATE, so they cannot drift from it.
+--
+-- TEXT + inline CHECK rather than a PG enum, matching the provider column
+-- on feature_debate_rounds (000032, line 38): adding a fourth provider
+-- later is an ALTER of the constraint, not a type migration.
+--
+-- Existing projects default to 'gemini', which is exactly what v1 did, so
+-- behaviour is unchanged until an admin opts in.
+
+ALTER TABLE projects
+    ADD COLUMN scorer_provider TEXT NOT NULL DEFAULT 'gemini'
+        CHECK (scorer_provider IN ('claude', 'gemini', 'openai'));
+
+-- Nullable with no default: a debate that has never been scored has no
+-- scorer, and NULL says that honestly. The CHECK admits NULL for the same
+-- reason. effort_scorer_model is deliberately un-constrained — model IDs
+-- change far more often than provider names, and pinning them in a CHECK
+-- would turn every model bump into a migration.
+ALTER TABLE feature_debates
+    ADD COLUMN effort_scorer_provider TEXT
+        CHECK (effort_scorer_provider IS NULL
+               OR effort_scorer_provider IN ('claude', 'gemini', 'openai')),
+    ADD COLUMN effort_scorer_model TEXT;
+
+-- Every score that exists today was produced by GeminiScorer, so stamping
+-- the provider is a statement of historical fact, not a guess. Without it
+-- the effort chip would silently drop its "via Gemini" label for every
+-- pre-existing debate the moment this ships. The model is left NULL: the
+-- exact GEMINI_MODEL in force at scoring time is not recoverable, and
+-- inventing one would be a guess.
+UPDATE feature_debates
+   SET effort_scorer_provider = 'gemini'
+ WHERE effort_scored_at IS NOT NULL;


### PR DESCRIPTION
## Summary

Second implementation PR for #63, per the plan in #115. The adapters from #116 are now wired: `DebateHandler.scorer` (a single instance) becomes `scorers map[string]ai.Scorer`, and which one runs is read **per project** at score time.

**This is the behavior-change PR.** Defaults keep production identical until an admin opts in — but the resolution path is now live.

Refs #63. Next: PR 4 (settings dropdown + effort chip + E2E).

## Migration 000034

Additive, safe to run before the image rolls:

- `projects.scorer_provider` — TEXT + CHECK, default `'gemini'`, which is exactly what v1 hardcoded.
- `feature_debates.effort_scorer_provider` / `_model` — **not redundant with the first.** The effort chip labels a score with the provider that produced it; reading the project's *live* setting instead would retroactively relabel every older score the moment an admin flips the dropdown (a Gemini-scored debate would start claiming "via ChatGPT"). Existing scores are backfilled as gemini-scored — a statement of fact — with the model left NULL because the `GEMINI_MODEL` in force at the time isn't recoverable.

Verified `up → down → up` against the test DB: `34 → 33` (columns gone) `→ 34` (columns back), never dirty. The CHECK genuinely rejects `'llama'`.

## Resolution at both call sites — no silent fallback

Per spec §3.2:

- **Accept path** resolves *inside* the scoring goroutine, so the HTTP response never waits on the lookup.
- **Retry sweep** gets the provider joined into `ClaimStaleEffortScores`' RETURNING via a correlated subquery — **no extra query per claimed row**, and because `projects` isn't locked by the claim, the `FOR UPDATE SKIP LOCKED` semantics that stop two replicas double-billing are untouched.

A project naming an unregistered provider (missing API key) logs a WARNING and writes **no score**, rather than quietly scoring with a different vendor — which would misattribute both the estimate and its cost.

## The startup pricing guard now covers all scorers

It previously checked `cfg.GeminiModel` alone. With per-project selection any of the three can bill, each on its own `SCORER_MODEL_*`, so it iterates the registry. This is precisely what `Scorer.Model()` from #116 was added for.

## The four-scan-site risk, retired rather than paid

Adding a column to `projects` meant four query functions each repeating the column list **and** the scan list — where a mismatch is a *runtime* error, not a compile error. The plan flagged this as this PR's most dangerous item.

Instead of making that fourfold edit, this adopts the `projectColumns` + `scanProject` pattern that `feature_debates` **already uses in the same file**, so the column order now lives in one place. `TestProjectCRUD` passing unchanged is the evidence the refactor is behavior-preserving.

## Tests

- **models:** all four project read paths round-trip `scorer_provider`; `CreateProject` defaults to gemini; the CHECK rejects an unknown provider and leaves the row unchanged; `GetProjectScorerProvider` wraps `pgx.ErrNoRows` for a missing project.
- **handlers:** the sweep picks the project's configured provider (and provably does *not* consult the default); an unregistered provider skips with no fallback and leaves `effort_score` NULL; an empty registry is a no-op that doesn't even burn a retry attempt; the claim returns the joined provider.

Each new assertion was **mutation-verified** — hardcoding gemini in the sweep, recording a constant provider instead of the resolved one, and dropping the subquery from the claim each produced exactly the expected failure, and all reverted clean.

`buildFakeDebateScorers` mirrors `buildFakeDebateRefiners`; without fake scorers the E2E stack couldn't exercise per-project selection at all, since every real scorer needs a billable key.

**Verification:** `go build ./...`, `go vet ./...`, `go vet -tags integration_ai`, `gofmt`, full-repo `golangci-lint` **at CI's exact v2.11.4** (0 issues), and the complete `go test ./internal/... -p 1` suite all pass.

> Note: the `FeatureDebate` struct diff is mostly gofmt realignment — a comment inside a struct splits gofmt's alignment block. Only two fields are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)