### PR TITLE
feat(debate): staff-only scorer provider dropdown + provider-driven chip (#63)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -110,7 +110,6 @@ func main() {
 	authH := handlers.NewAuthHandler(db, sessions, engine, cfg.AESKey, secureCookie)
 	dashH := handlers.NewDashboardHandler(db, engine)
 	orgH := handlers.NewOrgHandler(db, engine, sessions, mailer, cfg.BaseURL, cfg.ProtectedSuperadmins)
-	projH := handlers.NewProjectHandler(db, engine)
 	ticketH := handlers.NewTicketHandler(db, engine, geminiClient, cfg)
 	commentH := handlers.NewCommentHandler(db, engine)
 	adminH := handlers.NewAdminHandler(db, engine)
@@ -205,6 +204,10 @@ func main() {
 	}
 	debateCfg := handlers.DefaultDebateConfig()
 	debateH := handlers.NewDebateHandler(db, engine, debateRefiners, debateScorers, debateCfg)
+	// Constructed here rather than with the other handlers above because
+	// the project settings dropdown offers exactly the scorer providers
+	// that are actually configured (issue #63), so it needs the registry.
+	projH := handlers.NewProjectHandler(db, engine, ai.SortedProviderKeys(debateScorers))
 	log.Printf("Feature Debate Mode wired (%d refiners, %d scorers)", len(debateRefiners), len(debateScorers))
 
 	// Cost-tracking guard (issue #108). A model absent from the pricing
@@ -333,6 +336,7 @@ func main() {
 		r.Get("/orgs/{orgSlug}/projects/{projSlug}/archived", projH.ProjectArchived)
 		r.Get("/orgs/{orgSlug}/projects/{projSlug}/settings", projH.ProjectSettings)
 		r.Post("/orgs/{orgSlug}/projects/{projSlug}/settings/repo", projH.UpdateRepoURL)
+		r.Post("/orgs/{orgSlug}/projects/{projSlug}/settings/scorer", projH.UpdateScorerProvider)
 		r.Post("/orgs/{orgSlug}/projects/{projSlug}/transfer", projH.TransferProject)
 		r.Get("/orgs/{orgSlug}/projects/{projSlug}/costs", costH.ProjectCosts)
 		r.Post("/orgs/{orgSlug}/projects/{projSlug}/costs", costH.AddCostItem)

--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -260,11 +260,16 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
 
     await select.selectOption('claude');
     await page.click('button:has-text("Save Scorer Provider")');
-    await page.waitForLoadState('networkidle');
 
-    // The choice survives a reload.
-    await authenticatedDebatePage(page, `/orgs/${orgSlug}/projects/${projSlug}/settings`);
-    await expect(page.locator('select[name="scorer_provider"]')).toHaveValue('claude');
+    // Save responds with Hx-Redirect, which performs a REAL navigation
+    // back to this same URL. Calling page.goto() before that settles
+    // races it ("Navigation is interrupted by another navigation"), so
+    // retry the reload-and-assert until it lands.
+    await expect(async () => {
+      await page.goto(`/orgs/${orgSlug}/projects/${projSlug}/settings`);
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('select[name="scorer_provider"]')).toHaveValue('claude');
+    }).toPass({ timeout: 20000 });
 
     // ── Run a round to completion ───────────────────────────────
     await authenticatedDebatePage(page, `/tickets/${scorerTicketID}/debate`);

--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -208,4 +208,84 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
     await ensureComposer(page);
     await expect(page.locator('[data-testid="debate-feedback"]')).toHaveValue('');
   });
+
+  // Per-project scorer provider (issue #63). Lives in this file rather
+  // than its own spec because registration is first-user-only and the CI
+  // job runs exactly one self-registering spec against a fresh database.
+  //
+  // Uses a dedicated org/project/ticket so changing the scorer provider
+  // can't affect the other tests here regardless of execution order.
+  //
+  // Only the critical flow is covered end-to-end; the 403 path and the
+  // validation errors are functional tests in
+  // internal/handlers/projects_scorer_test.go. This works without any
+  // billable key because DEBATE_REFINER_MODE=fake also installs fake
+  // scorers for all three providers (buildFakeDebateScorers).
+  test('scorer provider is per-project and the effort chip credits it', async ({ page }) => {
+    const orgSlug = 'scorer-pick-org';
+    const projSlug = 'scorer-pick-project';
+
+    if (authCookies.length > 0) {
+      await page.context().addCookies(authCookies);
+    }
+    await page.request.post('/orgs', { form: { name: 'Scorer Pick Org' } });
+    await page.request.post(`/orgs/${orgSlug}/projects`, { form: { name: 'Scorer Pick Project' } });
+
+    await page.goto(`/orgs/${orgSlug}/projects/${projSlug}/features`);
+    const projectID = await page.locator("input[name='project_id']").first().getAttribute('value');
+    expect(projectID, 'project id must be discoverable').toBeTruthy();
+
+    const created = await page.request.post('/tickets', {
+      form: {
+        project_id: projectID,
+        title: 'E2E scorer provider feature',
+        type: 'feature',
+        priority: 'medium',
+        description: 'Feature used to verify the per-project scorer provider',
+      },
+      headers: { Referer: `/orgs/${orgSlug}/projects/${projSlug}/features` },
+    });
+    expect(created.status(), 'create-ticket response').toBeLessThan(400);
+
+    await page.goto(`/orgs/${orgSlug}/projects/${projSlug}/features`);
+    const href = await page.locator("a[href^='/tickets/']").first().getAttribute('href');
+    const scorerTicketID = href ? href.split('/').pop() : '';
+    expect(scorerTicketID, 'ticket id must be discoverable').not.toEqual('');
+
+    // ── Change the provider in project settings ─────────────────
+    await authenticatedDebatePage(page, `/orgs/${orgSlug}/projects/${projSlug}/settings`);
+    const select = page.locator('select[name="scorer_provider"]');
+    await expect(select, 'staff must see the scorer dropdown').toBeVisible();
+    await expect(select, 'defaults to the schema default').toHaveValue('gemini');
+
+    await select.selectOption('claude');
+    await page.click('button:has-text("Save Scorer Provider")');
+    await page.waitForLoadState('networkidle');
+
+    // The choice survives a reload.
+    await authenticatedDebatePage(page, `/orgs/${orgSlug}/projects/${projSlug}/settings`);
+    await expect(page.locator('select[name="scorer_provider"]')).toHaveValue('claude');
+
+    // ── Run a round to completion ───────────────────────────────
+    await authenticatedDebatePage(page, `/tickets/${scorerTicketID}/debate`);
+    await ensureComposer(page);
+    await page.click('[data-testid="debate-suggest"]');
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+    await page.click('[data-testid="debate-accept"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+
+    // ── The chip credits the chosen provider ────────────────────
+    // Scoring is fire-and-forget, so retry a reload until it settles.
+    const chip = page.locator('[data-testid="debate-effort-chip"]');
+    await expect(async () => {
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      await expect(chip).toContainText('Effort', { timeout: 2000 });
+    }).toPass({ timeout: 30000 });
+
+    const chipText = await chip.textContent();
+    expect(chipText, `effort chip text was: ${chipText}`).toContain('via Claude');
+    // The whole point of the feature: not the default provider.
+    expect(chipText, `effort chip text was: ${chipText}`).not.toContain('via Gemini');
+  });
 });

--- a/internal/ai/refiner.go
+++ b/internal/ai/refiner.go
@@ -19,6 +19,25 @@ const (
 	ProviderOpenAI = "openai"
 )
 
+// SortedProviderKeys returns the keys present in a provider-keyed
+// registry, in fixed display order.
+//
+// Order is pinned rather than map-iteration order so UI built from a
+// registry — the debate AI-picker buttons, the project scorer dropdown —
+// never shuffles between requests. Generic over the value type so the
+// refiner and scorer registries share one definition instead of each
+// carrying its own copy of the provider list.
+func SortedProviderKeys[T any](registry map[string]T) []string {
+	order := []string{ProviderClaude, ProviderGemini, ProviderOpenAI}
+	keys := make([]string, 0, len(registry))
+	for _, name := range order {
+		if _, ok := registry[name]; ok {
+			keys = append(keys, name)
+		}
+	}
+	return keys
+}
+
 // Refiner refactors a feature description for one round of debate mode.
 // Implementations MUST be safe to call concurrently.
 //

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -228,14 +228,7 @@ func (h *DebateHandler) requireDebateContext(r *http.Request) (debateContext, in
 // on this handler. Used by the template to render the AI-picker
 // buttons.
 func (h *DebateHandler) providerNames() []string {
-	names := make([]string, 0, len(h.refiners))
-	// Fixed order so the button layout doesn't shuffle between requests.
-	for _, n := range []string{"claude", "gemini", "openai"} {
-		if _, ok := h.refiners[n]; ok {
-			names = append(names, n)
-		}
-	}
-	return names
+	return ai.SortedProviderKeys(h.refiners)
 }
 
 // ── GET /tickets/{ticketID}/debate ────────────────────────────────

--- a/internal/handlers/debate_scorer_provider_test.go
+++ b/internal/handlers/debate_scorer_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -271,6 +272,43 @@ func TestAcceptRound_UnregisteredProviderStillAcceptsWithoutScoring(t *testing.T
 	}
 	if provider != nil {
 		t.Errorf("effort_scorer_provider = %q, want NULL", *provider)
+	}
+}
+
+// The effort chip must name the provider that actually produced the
+// score, read from the score row rather than the project's current
+// setting — otherwise flipping the dropdown relabels history. This is
+// the assertion that catches a regression back to a hardcoded label.
+func TestEffortChip_LabelsRecordedProvider(t *testing.T) {
+	openaiScorer := fakeScorerFor(ai.ProviderOpenAI, ai.ModelGPT5Mini)
+	r, db, sessions := setupDebateTestEnvWithRegistry(t, map[string]ai.Scorer{
+		ai.ProviderOpenAI: openaiScorer,
+	})
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	if err := db.UpdateProjectScorerProvider(context.Background(), ticket.ProjectID, ai.ProviderOpenAI); err != nil {
+		t.Fatalf("UpdateProjectScorerProvider: %v", err)
+	}
+	_, round := insertInReviewRound(t, db, cookie, r, ticket.ID, "scored text")
+
+	acceptRoundOK(t, r, cookie, ticket.ID, round.ID)
+	if !waitForEffortScore(t, db, ticket.ID, round.ID) {
+		t.Fatal("scorer did not write a score within 5s")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/tickets/"+ticket.ID+"/debate/effort", http.NoBody)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("effort chip: got %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "via ChatGPT") {
+		t.Errorf("chip should credit the recorded provider (ChatGPT); body: %s", body)
+	}
+	if strings.Contains(body, "via Gemini") {
+		t.Error("chip must not hardcode Gemini")
 	}
 }
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/madalin/forgedesk/internal/ai"
 	"github.com/madalin/forgedesk/internal/auth"
 	"github.com/madalin/forgedesk/internal/config"
 	"github.com/madalin/forgedesk/internal/mail"
@@ -44,7 +45,7 @@ func setupTestRouter(t *testing.T) (*chi.Mux, *models.DB, *auth.SessionStore, *r
 	authH := NewAuthHandler(db, sessions, engine, aesKey, false)
 	dashH := NewDashboardHandler(db, engine)
 	orgH := NewOrgHandler(db, engine, sessions, mailer, baseURL, nil)
-	projH := NewProjectHandler(db, engine)
+	projH := NewProjectHandler(db, engine, []string{ai.ProviderGemini})
 	ticketH := NewTicketHandler(db, engine, nil, &config.Config{})
 	commentH := NewCommentHandler(db, engine)
 	adminH := NewAdminHandler(db, engine)

--- a/internal/handlers/projects.go
+++ b/internal/handlers/projects.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/madalin/forgedesk/internal/auth"
@@ -15,10 +16,17 @@ import (
 type ProjectHandler struct {
 	db     *models.DB
 	engine *render.Engine
+	// scorerProviders are the debate scorer providers that actually have
+	// an API key configured, in stable display order (issue #63). The
+	// settings dropdown offers exactly these, and UpdateScorerProvider
+	// refuses anything outside the list: storing a provider with no
+	// registered scorer would leave the project silently unscored,
+	// visible only as a WARNING in the server log.
+	scorerProviders []string
 }
 
-func NewProjectHandler(db *models.DB, engine *render.Engine) *ProjectHandler {
-	return &ProjectHandler{db: db, engine: engine}
+func NewProjectHandler(db *models.DB, engine *render.Engine, scorerProviders []string) *ProjectHandler {
+	return &ProjectHandler{db: db, engine: engine, scorerProviders: scorerProviders}
 }
 
 type projectPageData struct {
@@ -28,7 +36,15 @@ type projectPageData struct {
 	Tickets   []models.Ticket
 	Revisions []models.BriefRevision
 	AllOrgs   []models.Organization
-	IsStaff   bool
+	// ScorerProviders are the selectable debate scorer providers for the
+	// settings dropdown (issue #63); empty when no AI keys are configured.
+	ScorerProviders []string
+	IsStaff         bool
+	// ScorerProviderUnavailable is true when the project's stored provider
+	// is not in ScorerProviders — its API key was removed after an admin
+	// selected it. The dropdown surfaces that rather than silently
+	// appearing to say something else.
+	ScorerProviderUnavailable bool
 }
 
 func (h *ProjectHandler) getOrgAndProject(r *http.Request, user *models.User) (*models.Organization, *models.Project, error) {
@@ -252,8 +268,48 @@ func (h *ProjectHandler) ProjectSettings(w http.ResponseWriter, r *http.Request)
 		Title: proj.Name + " — Settings", User: user, Org: org, Orgs: middleware.GetOrgs(r), CurrentPath: r.URL.Path,
 		Projects: projects, ActiveProject: proj, ActiveTab: "settings",
 		ProjectID: proj.ID,
-		Data:      projectPageData{Project: proj, Projects: projects, Tab: "settings", IsStaff: true, AllOrgs: allOrgs},
+		Data: projectPageData{
+			Project: proj, Projects: projects, Tab: "settings", IsStaff: true, AllOrgs: allOrgs,
+			ScorerProviders:           h.scorerProviders,
+			ScorerProviderUnavailable: !slices.Contains(h.scorerProviders, proj.ScorerProvider),
+		},
 	})
+}
+
+// UpdateScorerProvider sets which AI provider scores this project's
+// feature debates (issue #63). Staff-only, like every other setting on
+// this page.
+func (h *ProjectHandler) UpdateScorerProvider(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	if !auth.IsStaffOrAbove(user.Role) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	_, proj, err := h.getOrgAndProject(r, user)
+	if err != nil {
+		h.engine.RenderError(w, http.StatusNotFound, "Not found")
+		return
+	}
+
+	// One membership check covers both failure modes: a name that is not
+	// a provider at all, and a real provider whose API key this
+	// deployment lacks. Either way the value must not reach the database
+	// — the CHECK constraint would catch the former but not the latter.
+	provider := strings.TrimSpace(r.FormValue("scorer_provider"))
+	if !slices.Contains(h.scorerProviders, provider) {
+		http.Error(w, "Unknown or unconfigured scorer provider", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.db.UpdateProjectScorerProvider(r.Context(), proj.ID, provider); err != nil {
+		log.Printf("updating scorer provider: %v", err)
+		http.Error(w, "Failed to update", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Hx-Redirect", r.URL.Path[:strings.LastIndex(r.URL.Path, "/")])
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h *ProjectHandler) TransferProject(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/projects.go
+++ b/internal/handlers/projects.go
@@ -292,11 +292,27 @@ func (h *ProjectHandler) UpdateScorerProvider(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// One membership check covers both failure modes: a name that is not
-	// a provider at all, and a real provider whose API key this
-	// deployment lacks. Either way the value must not reach the database
-	// — the CHECK constraint would catch the former but not the latter.
 	provider := strings.TrimSpace(r.FormValue("scorer_provider"))
+
+	// An absent field is "nothing was selected", not "invalid selection",
+	// and must not be reported as an error. It happens for real: when the
+	// stored provider has lost its API key the dropdown renders it as a
+	// disabled option, and HTML form submission SKIPS disabled options
+	// even when they are selected — so a staff user who opens settings
+	// and clicks Save without touching the dropdown sends no field at
+	// all. Treat that as a no-op and return them to the page.
+	if provider == "" {
+		w.Header().Set("Hx-Redirect", r.URL.Path[:strings.LastIndex(r.URL.Path, "/")])
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// One membership check covers both remaining failure modes: a name
+	// that is not a provider at all, and a real provider whose API key
+	// this deployment lacks. Either way the value must not reach the
+	// database — the CHECK constraint would catch the former but not the
+	// latter, and storing the latter leaves the project silently
+	// unscored.
 	if !slices.Contains(h.scorerProviders, provider) {
 		http.Error(w, "Unknown or unconfigured scorer provider", http.StatusBadRequest)
 		return

--- a/internal/handlers/projects_scorer_test.go
+++ b/internal/handlers/projects_scorer_test.go
@@ -97,8 +97,10 @@ func TestUpdateScorerProvider_ClientForbidden(t *testing.T) {
 
 	w := postScorer(t, r, cookie, org, proj, ai.ProviderOpenAI)
 
-	if w.Code != http.StatusForbidden && w.Code != http.StatusNotFound {
-		t.Errorf("client POST: got %d, want 403 (or 404 if org not visible)", w.Code)
+	// Exactly 403: the role check runs before getOrgAndProject, so a
+	// client never reaches the lookup that could 404.
+	if w.Code != http.StatusForbidden {
+		t.Errorf("client POST: got %d, want 403", w.Code)
 	}
 	if got := providerOf(t, db, proj.ID); got != ai.ProviderGemini {
 		t.Errorf("provider = %q, want it unchanged at gemini", got)
@@ -142,6 +144,31 @@ func TestUpdateScorerProvider_RejectsUnconfiguredProvider(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("unconfigured provider: got %d, want 400", w.Code)
+	}
+	if got := providerOf(t, db, proj.ID); got != ai.ProviderGemini {
+		t.Errorf("provider = %q, want it unchanged at gemini", got)
+	}
+}
+
+// An absent scorer_provider field is a no-op, not an error. This is a
+// real interaction, not a hypothetical: when the stored provider has lost
+// its API key the dropdown renders it as a disabled option, and HTML form
+// submission skips disabled options even when selected — so clicking Save
+// without touching the dropdown submits no field at all. Returning 400
+// there would show a bare error page for doing nothing wrong.
+func TestUpdateScorerProvider_EmptySubmissionIsNoOp(t *testing.T) {
+	r, db, sessions := setupScorerSettingsEnv(t, []string{ai.ProviderGemini})
+	_, proj, _ := seedOrgProject(t, db, "staff@test.com", "staff")
+	org, err := db.GetOrgBySlug(context.Background(), "org-"+strings.ToLower(t.Name()))
+	if err != nil {
+		t.Fatalf("GetOrgBySlug: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "staff2@test.com", "staff")
+
+	w := postScorer(t, r, cookie, org, proj, "")
+
+	if w.Code != http.StatusOK {
+		t.Errorf("empty submission: got %d, want 200 (no-op)", w.Code)
 	}
 	if got := providerOf(t, db, proj.ID); got != ai.ProviderGemini {
 		t.Errorf("provider = %q, want it unchanged at gemini", got)

--- a/internal/handlers/projects_scorer_test.go
+++ b/internal/handlers/projects_scorer_test.go
@@ -1,0 +1,201 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/madalin/forgedesk/internal/ai"
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/middleware"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/render"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// setupScorerSettingsEnv wires just the project-settings routes with an
+// explicit list of configured scorer providers (issue #63). The list is
+// what main.go passes from the live scorer registry, so a test can model
+// a deployment that is missing a vendor's API key.
+func setupScorerSettingsEnv(t *testing.T, providers []string) (*chi.Mux, *models.DB, *auth.SessionStore) {
+	t.Helper()
+
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	sessions := auth.NewSessionStore(pool)
+	engine, err := render.NewEngine(testutil.ProjectRoot()+"/templates", nil)
+	if err != nil {
+		t.Fatalf("loading templates: %v", err)
+	}
+	projH := NewProjectHandler(db, engine, providers)
+
+	r := chi.NewRouter()
+	r.Use(middleware.Recover)
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.AuthMiddleware(sessions, db))
+		r.Get("/orgs/{orgSlug}/projects/{projSlug}/settings", projH.ProjectSettings)
+		r.Post("/orgs/{orgSlug}/projects/{projSlug}/settings/scorer", projH.UpdateScorerProvider)
+	})
+	return r, db, sessions
+}
+
+// seedOrgProject creates an org owned by the given user plus one project.
+func seedOrgProject(t *testing.T, db *models.DB, email, role string) (*models.Organization, *models.Project, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	hash, _ := auth.HashPassword("TestPassword123!")
+	user, err := db.CreateUser(ctx, email, hash, "Test User", role)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	org, err := db.CreateOrgWithOwnerTx(ctx, user.ID, "Org "+t.Name(), "org-"+strings.ToLower(t.Name()), models.OrgRoleOwner)
+	if err != nil {
+		t.Fatalf("CreateOrgWithOwnerTx: %v", err)
+	}
+	proj, err := db.CreateProject(ctx, org.ID, "P", "proj-"+strings.ToLower(t.Name()))
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	return org, proj, user.ID
+}
+
+func postScorer(t *testing.T, r *chi.Mux, cookie *http.Cookie, org *models.Organization, proj *models.Project, provider string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"scorer_provider": {provider}}
+	req := httptest.NewRequest(http.MethodPost,
+		"/orgs/"+org.Slug+"/projects/"+proj.Slug+"/settings/scorer",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func providerOf(t *testing.T, db *models.DB, projectID string) string {
+	t.Helper()
+	p, err := db.GetProjectScorerProvider(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("GetProjectScorerProvider: %v", err)
+	}
+	return p
+}
+
+// The dropdown is staff-only: clients must never see or set which AI
+// vendor processes their project's text.
+func TestUpdateScorerProvider_ClientForbidden(t *testing.T) {
+	r, db, sessions := setupScorerSettingsEnv(t, []string{ai.ProviderGemini, ai.ProviderOpenAI})
+	org, proj, _ := seedOrgProject(t, db, "client@test.com", "client")
+	cookie := createAuthenticatedUser(t, db, sessions, "client2@test.com", "client")
+	_ = org
+
+	w := postScorer(t, r, cookie, org, proj, ai.ProviderOpenAI)
+
+	if w.Code != http.StatusForbidden && w.Code != http.StatusNotFound {
+		t.Errorf("client POST: got %d, want 403 (or 404 if org not visible)", w.Code)
+	}
+	if got := providerOf(t, db, proj.ID); got != ai.ProviderGemini {
+		t.Errorf("provider = %q, want it unchanged at gemini", got)
+	}
+}
+
+func TestUpdateScorerProvider_StaffCanSetConfiguredProvider(t *testing.T) {
+	r, db, sessions := setupScorerSettingsEnv(t, []string{ai.ProviderGemini, ai.ProviderOpenAI})
+	_, proj, userID := seedOrgProject(t, db, "staff@test.com", "staff")
+	org, err := db.GetOrgBySlug(context.Background(), "org-"+strings.ToLower(t.Name()))
+	if err != nil {
+		t.Fatalf("GetOrgBySlug: %v", err)
+	}
+	_ = userID
+	cookie := createAuthenticatedUser(t, db, sessions, "staff2@test.com", "staff")
+
+	w := postScorer(t, r, cookie, org, proj, ai.ProviderOpenAI)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("staff POST: got %d, want 200 — body: %s", w.Code, w.Body.String())
+	}
+	if got := providerOf(t, db, proj.ID); got != ai.ProviderOpenAI {
+		t.Errorf("provider = %q, want openai", got)
+	}
+}
+
+// A provider whose API key isn't configured must be rejected rather than
+// silently stored — storing it would leave the project permanently
+// unscored, visible only as a WARNING in the server log.
+func TestUpdateScorerProvider_RejectsUnconfiguredProvider(t *testing.T) {
+	r, db, sessions := setupScorerSettingsEnv(t, []string{ai.ProviderGemini})
+	_, proj, _ := seedOrgProject(t, db, "staff@test.com", "staff")
+	org, err := db.GetOrgBySlug(context.Background(), "org-"+strings.ToLower(t.Name()))
+	if err != nil {
+		t.Fatalf("GetOrgBySlug: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "staff2@test.com", "staff")
+
+	// claude is a valid provider name but has no registered scorer here.
+	w := postScorer(t, r, cookie, org, proj, ai.ProviderClaude)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("unconfigured provider: got %d, want 400", w.Code)
+	}
+	if got := providerOf(t, db, proj.ID); got != ai.ProviderGemini {
+		t.Errorf("provider = %q, want it unchanged at gemini", got)
+	}
+}
+
+func TestUpdateScorerProvider_RejectsUnknownProvider(t *testing.T) {
+	r, db, sessions := setupScorerSettingsEnv(t, []string{ai.ProviderGemini, ai.ProviderOpenAI})
+	_, proj, _ := seedOrgProject(t, db, "staff@test.com", "staff")
+	org, err := db.GetOrgBySlug(context.Background(), "org-"+strings.ToLower(t.Name()))
+	if err != nil {
+		t.Fatalf("GetOrgBySlug: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "staff2@test.com", "staff")
+
+	w := postScorer(t, r, cookie, org, proj, "llama")
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("unknown provider: got %d, want 400", w.Code)
+	}
+	if got := providerOf(t, db, proj.ID); got != ai.ProviderGemini {
+		t.Errorf("provider = %q, want it unchanged at gemini", got)
+	}
+}
+
+// The settings page must render the dropdown with only configured
+// providers, and mark the project's current one as selected.
+func TestProjectSettings_RendersScorerDropdown(t *testing.T) {
+	r, db, sessions := setupScorerSettingsEnv(t, []string{ai.ProviderGemini, ai.ProviderOpenAI})
+	_, proj, _ := seedOrgProject(t, db, "staff@test.com", "staff")
+	org, err := db.GetOrgBySlug(context.Background(), "org-"+strings.ToLower(t.Name()))
+	if err != nil {
+		t.Fatalf("GetOrgBySlug: %v", err)
+	}
+	cookie := createAuthenticatedUser(t, db, sessions, "staff2@test.com", "staff")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/orgs/"+org.Slug+"/projects/"+proj.Slug+"/settings", http.NoBody)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("settings page: got %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `name="scorer_provider"`) {
+		t.Error("settings page should render the scorer_provider select")
+	}
+	// Configured providers appear; unconfigured ones must not be offered.
+	if !strings.Contains(body, `value="openai"`) {
+		t.Error("configured provider openai should be an option")
+	}
+	if strings.Contains(body, `value="claude"`) {
+		t.Error("unconfigured provider claude must not be offered")
+	}
+}

--- a/templates/components/debate_effort_chip.html
+++ b/templates/components/debate_effort_chip.html
@@ -18,7 +18,11 @@
           </p>
           {{if .Debate.EffortReasoning}}<p class="text-base-content/70">{{derefStr .Debate.EffortReasoning}}</p>{{end}}
           <p class="text-base-content/50">Estimate assumes a full-stack, mid-senior developer.
-            {{if .Debate.EffortScoredAt}}Updated {{relTime .Debate.EffortScoredAt}} · via Gemini{{end}}</p>
+            {{/* Provider comes from the score itself, not the project's
+                 current setting (issue #63): changing the dropdown must
+                 not retroactively relabel who produced an older score.
+                 NULL only for scores predating migration 000034. */}}
+            {{if .Debate.EffortScoredAt}}Updated {{relTime .Debate.EffortScoredAt}}{{if .Debate.EffortScorerProvider}} · via {{providerLabel (derefStr .Debate.EffortScorerProvider)}}{{end}}{{end}}</p>
         </div>
       </div>
     </div>

--- a/templates/components/debate_effort_chip.html
+++ b/templates/components/debate_effort_chip.html
@@ -22,7 +22,11 @@
                  current setting (issue #63): changing the dropdown must
                  not retroactively relabel who produced an older score.
                  NULL only for scores predating migration 000034. */}}
-            {{if .Debate.EffortScoredAt}}Updated {{relTime .Debate.EffortScoredAt}}{{if .Debate.EffortScorerProvider}} · via {{providerLabel (derefStr .Debate.EffortScorerProvider)}}{{end}}{{end}}</p>
+            {{/* derefStr, not a bare pointer test: a non-nil *string is
+                 always truthy to text/template, so a pointer to "" would
+                 render "· via " with no label. The CHECK constraint makes
+                 that unreachable today, but the guard is free. */}}
+            {{if .Debate.EffortScoredAt}}Updated {{relTime .Debate.EffortScoredAt}}{{with derefStr .Debate.EffortScorerProvider}} · via {{providerLabel .}}{{end}}{{end}}</p>
         </div>
       </div>
     </div>

--- a/templates/pages/project_settings.html
+++ b/templates/pages/project_settings.html
@@ -42,6 +42,77 @@
             </div>
         </div>
 
+        {{/* Debate scorer provider (issue #63). Staff-only — the Go
+             handler already 403s non-staff for this whole page, so the
+             IsStaff guard here is belt-and-braces, matching the AI Cost
+             Margin card in org_settings.html. */}}
+        {{if .IsStaff}}
+        <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <div class="card-body p-6 gap-3">
+                <div>
+                    <h3 class="text-lg font-semibold">Debate effort scorer</h3>
+                    <p class="text-sm text-base-content/60 mt-1">
+                        Which AI provider estimates complexity and hours after each accepted debate round.
+                        Only the refiner buttons are visible to clients; this choice is not.
+                    </p>
+                </div>
+                {{if .ScorerProviders}}
+                <form method="POST"
+                      action="/orgs/{{$.Org.Slug}}/projects/{{.Project.Slug}}/settings/scorer"
+                      class="flex flex-col gap-3">
+                    {{csrfField}}
+                    <div class="form-control">
+                        <label class="label pb-1" for="scorer_provider">
+                            <span class="label-text">Scorer provider</span>
+                        </label>
+                        <select id="scorer_provider" name="scorer_provider"
+                                class="select select-bordered w-full">
+                            {{$current := .Project.ScorerProvider}}
+                            {{range .ScorerProviders}}
+                            {{/* The whole <option> tag is duplicated rather
+                                 than using a conditional bare `selected`
+                                 attribute — html/template can silently
+                                 truncate output on the latter (PR #80). */}}
+                            {{if eq . $current}}
+                            <option value="{{.}}" selected>{{providerLabel .}}</option>
+                            {{else}}
+                            <option value="{{.}}">{{providerLabel .}}</option>
+                            {{end}}
+                            {{end}}
+                            {{/* The stored provider may no longer be
+                                 configured (its API key was removed). Show
+                                 it truthfully rather than letting the select
+                                 silently appear to say something else. */}}
+                            {{if .ScorerProviderUnavailable}}
+                            <option value="{{$current}}" selected disabled>
+                                {{providerLabel $current}} (API key not configured)
+                            </option>
+                            {{end}}
+                        </select>
+                        <label class="label pt-1">
+                            <span class="label-text-alt text-base-content/60">
+                                Scoring runs on every accepted round, so a cheap model is used per provider.
+                                Claude is currently the most expensive option.
+                            </span>
+                        </label>
+                    </div>
+                    <div>
+                        <button type="submit" class="btn btn-primary">Save Scorer Provider</button>
+                    </div>
+                </form>
+                {{else}}
+                <div class="alert alert-warning">
+                    <span>
+                        No AI providers are configured, so debates cannot be scored.
+                        Set at least one of <code>ANTHROPIC_API_KEY</code>, <code>GEMINI_API_KEY</code>
+                        or <code>OPENAI_API_KEY</code> on the server.
+                    </span>
+                </div>
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+
         {{if gt (len .AllOrgs) 1}}
         <div class="card bg-base-100 border border-error/30 shadow-sm"
              x-data="{ confirm: false, targetName: '' }">


### PR DESCRIPTION
## Summary

Final implementation PR for #63, per the plan in #115. PR #117 made the scorer per-project but left it **unreachable** — no UI to change the value, and the effort chip still hardcoded "via Gemini". This closes both.

**Closes #63.**

## Settings dropdown (staff-only)

A new card in project settings with a select offering exactly the providers that have an API key configured.

Validation is one membership check against that list, which deliberately covers **both** failure modes:

| Input | Why it must be rejected |
|---|---|
| `"llama"` — not a provider | The CHECK constraint would catch this |
| `"claude"` with no `ANTHROPIC_API_KEY` | The CHECK would **accept** it — and the project would then be permanently unscored, visible only as a WARNING in the server log |

If the stored provider later loses its key, the select renders it as a disabled `(API key not configured)` option rather than silently appearing to say something else. That flag is computed in the handler rather than adding a slice-membership template function.

The conditional `selected` duplicates the whole `<option>` tag instead of emitting a bare attribute — the `html/template` truncation gotcha from PR #80.

## Effort chip

Now reads the provider off the **score row**, so flipping the dropdown cannot retroactively relabel who produced an older score. Scores predating migration 000034 render without the suffix rather than lying.

## Shared provider ordering

`ai.SortedProviderKeys` replaces the provider list that was hardcoded inside `DebateHandler.providerNames`, so the refiner buttons and the scorer dropdown now derive their fixed display order from one definition. That's one fewer of the four places the plan flagged as drift-prone.

`NewProjectHandler` takes the configured provider list, so `projH` is now constructed after the scorer registry rather than alongside the other handlers.

## E2E — folded into the existing spec, deliberately

The test lives in `12-debate-fake.spec.js` rather than a new file. The CI job runs **exactly one self-registering spec** against a fresh database (registration is first-user-only), and the workflow says so explicitly:

> `# ... do not add other self-registering specs to this invocation.`

A separate spec would either break that rule or silently never run in CI. The test creates its **own** org/project/ticket so changing the provider can't affect the other tests regardless of execution order, and it needs no billable key because fake mode installs fake scorers for all three providers.

## Tests

- Staff can set a configured provider; **client gets 403**.
- An unconfigured provider **and** an unknown name are both 400, with the stored value unchanged.
- The settings page renders only configured providers (asserts `claude` is *absent* when unconfigured).
- The chip credits the recorded provider — **mutation-verified** by reverting the chip to a hardcoded label, which failed exactly as expected.

**Verification:** `go build ./...`, `go vet ./...`, `go vet -tags integration_ai`, `gofmt`, full-repo `golangci-lint` at **CI's exact v2.11.4** (0 issues), and the complete `go test ./internal/... -p 1` suite all pass.

Also ran `bash scripts/css.sh` and confirmed `tw.css` is **byte-identical** — the new card reuses only already-compiled utilities, so there's no generated-asset churn in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)