### PR TITLE
deploy: pin server & orchestrator images to v0.5.0

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.4.0
+          image: registry.k3s.vlah.sh/smartpm:v0.5.0
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.4.0
+          image: registry.k3s.vlah.sh/smartpm:v0.5.0
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for the **v0.5.0 deploy, already applied to production**. Opening this so `deploy/k8s/` matches what is running — `imagePullPolicy: IfNotPresent` means the tag is the only thing pinning the version, so stale manifests would let a future `kubectl apply` silently roll production back to v0.4.0.

## What was deployed

`v0.5.0` (tag → `473eb69`, image digest `sha256:4b0d6247…`):
- **#63** — per-project debate scorer provider (PRs #115–#118)
- **#111** — `*_MODEL` config whitespace trimming

## Deploy record

| Step | Result |
|------|--------|
| Pre-state | v0.4.0, schema 33, 3 pods healthy, 44d uptime |
| Migration 000034 | 33 → **34**, `dirty=false`, 521ms |
| Backfill | 4 projects default `gemini`; 3 scored debates stamped gemini-produced |
| Rollout | server ×2 + orchestrator on v0.5.0, **0 restarts** |
| Startup log | `Feature Debate Mode wired (3 refiners, 3 scorers)`, **no** unpriced-model warning |
| Smoke | `/login` HTTP 200 (0.24s), `/health` 200, no errors in logs |

Migration ran **before** the rollout — it is purely additive, so v0.4.0 pods ignored the new columns during the window.

**Client-visible behavior is unchanged until someone opts in:** every project defaults to `gemini`, which is exactly what v0.4.0 hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)