### PR TITLE
fix(security): gate org settings on membership — cross-tenant roster leak

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -782,14 +782,28 @@ func TestOrgSettingsPage_NonMemberForbidden(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusForbidden {
-		t.Errorf("non-member GET org settings: got %d, want 403", rec.Code)
+	// 404, not 403: authorizeOrgAccess deliberately collapses "not your
+	// org" into "no such org" so probing cannot enumerate organizations.
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("non-member GET org settings: got %d, want 404", rec.Code)
 	}
 	body := rec.Body.String()
 	for _, leaked := range []string{"insider@victim.test", "Victim Insider"} {
 		if strings.Contains(body, leaked) {
 			t.Errorf("response leaked %q across tenants", leaked)
 		}
+	}
+
+	// The response for a real-but-forbidden org must be indistinguishable
+	// from one for an org that does not exist — otherwise the status code
+	// itself confirms which slugs are real.
+	missReq := httptest.NewRequest(http.MethodGet, "/orgs/no-such-org-at-all/settings", http.NoBody)
+	missReq.AddCookie(outsider)
+	missRec := httptest.NewRecorder()
+	r.ServeHTTP(missRec, missReq)
+	if missRec.Code != rec.Code {
+		t.Errorf("org enumeration: existing-but-forbidden org returned %d but nonexistent org returned %d — these must match",
+			rec.Code, missRec.Code)
 	}
 }
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -737,3 +737,94 @@ func TestOrgSettingsPage(t *testing.T) {
 		t.Error("should contain Members section")
 	}
 }
+
+// A non-member must not be able to read another organization's settings.
+// Before the fix, OrgSettings resolved the org by slug and rendered it
+// unconditionally: the only GetOrgMembership call was used to compute a
+// canManage flag for showing forms, and its error was swallowed — so a
+// non-member simply got canManage=false and the page still rendered,
+// leaking the victim org's name and its full member roster (each member's
+// name, email address, platform role and org role) across tenants.
+//
+// The business-details card and pending invitations happen to be hidden by
+// template guards ({{if or .IsStaff .CanManage}}), so they did NOT leak —
+// but that is the template coincidentally covering for a missing handler
+// gate, not access control. Assert on the roster, which did.
+func TestOrgSettingsPage_NonMemberForbidden(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	// Victim org, with data worth leaking.
+	victim, err := db.CreateOrg(ctx, "Victim Org", "victim-org")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	// A member whose identity must not cross the tenant boundary.
+	hash, _ := auth.HashPassword("TestPassword123!")
+	insider, err := db.CreateUser(ctx, "insider@victim.test", hash, "Victim Insider", "client")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx,
+		`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1, $2, 'owner')`,
+		insider.ID, victim.ID); err != nil {
+		t.Fatalf("seed victim membership: %v", err)
+	}
+
+	// An authenticated CLIENT who belongs to no org at all. The first
+	// registered user is auto-promoted to superadmin, so create a throwaway
+	// first before the one under test.
+	createAuthenticatedUser(t, db, sessions, "first-superadmin@test.com", "superadmin")
+	outsider := createAuthenticatedUser(t, db, sessions, "outsider@test.com", "client")
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/victim-org/settings", http.NoBody)
+	req.AddCookie(outsider)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-member GET org settings: got %d, want 403", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, leaked := range []string{"insider@victim.test", "Victim Insider"} {
+		if strings.Contains(body, leaked) {
+			t.Errorf("response leaked %q across tenants", leaked)
+		}
+	}
+}
+
+// Members of the org must still get in — the fix must not lock out the
+// people the page is for.
+func TestOrgSettingsPage_MemberAllowed(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa@test.com", "superadmin")
+	memberCookie := createAuthenticatedUser(t, db, sessions, "member@test.com", "client")
+
+	var userID string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT id FROM users WHERE email = 'member@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up member: %v", err)
+	}
+	org, err := db.CreateOrg(ctx, "Member Org", "member-org")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	// Plain 'member' — the weakest membership, so this pins that the fix
+	// gates on membership existing, not on management rights.
+	if _, err := db.Pool.Exec(ctx,
+		`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1, $2, 'member')`,
+		userID, org.ID); err != nil {
+		t.Fatalf("add membership: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/member-org/settings", http.NoBody)
+	req.AddCookie(memberCookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("member GET org settings: got %d, want 200", rec.Code)
+	}
+}

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -8,8 +8,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-
-	"github.com/jackc/pgx/v5"
 	"time"
 
 	"github.com/madalin/forgedesk/internal/auth"
@@ -141,31 +139,35 @@ func (h *OrgHandler) OrgSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Access gate. This MUST come before any org data is loaded: without
-	// it any authenticated user could read any org's settings by guessing
-	// a slug (slugs are slugify(name), so they are guessable), exposing
-	// the member roster across tenants.
+	// Access gate. MUST come before any org data is loaded: without it any
+	// authenticated user could read any org's settings by guessing a slug
+	// (slugs are slugify(name), so they are guessable), exposing the member
+	// roster across tenants.
 	//
-	// The membership lookup below does double duty — it decides both
-	// "may this user be here at all" and "may they manage". Those are
-	// different questions, and answering only the second was the bug:
-	// a non-member simply got canManage=false and the page still rendered.
-	canManage := auth.IsStaffOrAbove(user.Role)
-	if !canManage {
-		m, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID)
-		switch {
-		case errors.Is(memErr, pgx.ErrNoRows):
-			// Not a member of this org.
-			h.engine.RenderError(w, http.StatusForbidden, "Access denied")
-			return
-		case memErr != nil:
-			// Infrastructure failure — distinct from "not a member" so a
-			// database problem is never reported as an authorization one.
-			log.Printf("org settings: membership lookup for user %s org %s: %v", user.ID, org.ID, memErr)
-			h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
+	// Uses the shared authorizeOrgAccess helper rather than an inline
+	// membership check so this page inherits the documented convention:
+	// "not a member" and "no such org" both surface as 404, so probing
+	// cannot distinguish an org that exists from one that does not.
+	if authErr := authorizeOrgAccess(r.Context(), h.db, user, org.ID); authErr != nil {
+		if errors.Is(authErr, errCrossTenant) {
+			h.engine.RenderError(w, http.StatusNotFound, "Organization not found")
 			return
 		}
-		canManage = auth.CanManageOrg(m.Role)
+		// Real infrastructure failure — never report a DB fault as an
+		// authorization decision.
+		log.Printf("org settings authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
+		return
+	}
+
+	// Separate question from "may they be here": may they EDIT. The bug
+	// this fix closes was answering only this one and letting the page
+	// render regardless.
+	canManage := auth.IsStaffOrAbove(user.Role)
+	if !canManage {
+		if m, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID); memErr == nil {
+			canManage = auth.CanManageOrg(m.Role)
+		}
 	}
 
 	members, err := h.db.ListOrgMembers(r.Context(), org.ID)

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/jackc/pgx/v5"
 	"time"
 
 	"github.com/madalin/forgedesk/internal/auth"
@@ -139,17 +141,37 @@ func (h *OrgHandler) OrgSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Access gate. This MUST come before any org data is loaded: without
+	// it any authenticated user could read any org's settings by guessing
+	// a slug (slugs are slugify(name), so they are guessable), exposing
+	// the member roster across tenants.
+	//
+	// The membership lookup below does double duty — it decides both
+	// "may this user be here at all" and "may they manage". Those are
+	// different questions, and answering only the second was the bug:
+	// a non-member simply got canManage=false and the page still rendered.
+	canManage := auth.IsStaffOrAbove(user.Role)
+	if !canManage {
+		m, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID)
+		switch {
+		case errors.Is(memErr, pgx.ErrNoRows):
+			// Not a member of this org.
+			h.engine.RenderError(w, http.StatusForbidden, "Access denied")
+			return
+		case memErr != nil:
+			// Infrastructure failure — distinct from "not a member" so a
+			// database problem is never reported as an authorization one.
+			log.Printf("org settings: membership lookup for user %s org %s: %v", user.ID, org.ID, memErr)
+			h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
+			return
+		}
+		canManage = auth.CanManageOrg(m.Role)
+	}
+
 	members, err := h.db.ListOrgMembers(r.Context(), org.ID)
 	if err != nil {
 		h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load members")
 		return
-	}
-
-	canManage := auth.IsStaffOrAbove(user.Role)
-	if !canManage {
-		if m, err := h.db.GetOrgMembership(r.Context(), user.ID, org.ID); err == nil {
-			canManage = auth.CanManageOrg(m.Role)
-		}
 	}
 
 	invitations, _ := h.db.ListOrgInvitations(r.Context(), org.ID)


### PR DESCRIPTION
## The vulnerability

`GET /orgs/{orgSlug}/settings` performed **no access check**. It resolved the org by slug and rendered the page for any authenticated user. The only `GetOrgMembership` call was used to compute a `canManage` boolean for showing/hiding forms — and its error was swallowed (`if err == nil`), so a non-member simply got `canManage=false` and **the page still rendered**.

**Live on v0.5.0.** Any logged-in user could read any organization's settings by knowing or guessing a slug — and slugs are `slugify(name)`, so they're guessable.

### Confirmed exposure (measured, not assumed)

I probed the actual 200 response before fixing:

| Data | Leaked? |
|---|---|
| Org name | **Yes** |
| Full member roster — each member's name, email, platform role, org role | **Yes** |
| VAT number, registration number, address, contact details | No — behind `{{if or .IsStaff .CanManage}}` |
| Pending invitations | No — behind `{{if .CanManage}}` |

The business fields were saved by **template** conditionals written to hide an edit form. That's defense by coincidence: move those fields outside the conditional in any future refactor and the leak widens, because nothing in the handler ever said "this user may not be here."

Cross-tenant disclosure of names + email addresses is personal data under GDPR.

## The fix

Access gate before **any** org data loads, using the existing `authorizeOrgAccess` helper from `internal/handlers/authz.go` — already the convention in `comments.go`, `tickets.go`, `reactions.go`.

The first cut hand-rolled the check and returned 403. Security review correctly flagged that as an **org-enumeration oracle**: 403 for a real org vs 404 for a missing one tells an attacker which slugs exist. The helper's doc comment states exactly this, and collapsing both to 404 is why it exists. Second commit switches to it.

Costs one extra membership lookup for non-staff (the `canManage` flag still needs the role) — irrelevant on a settings page, and worth reusing audited code over bespoke security logic.

## Sweep

Checked **every** handler resolving an org by slug — `OrgPage`, `InviteMember`, `RemoveMember`, `UpdateMemberRole`, `UpdateAIMargin`, `UpdateBusinessDetails`, `UpdateCurrency`, all three in `costs.go`, projects' `getOrgAndProject`, `CreateProject`, `RevokeInvitation`, `ResendInvitation`. All gate correctly, by membership or staff-only. **`OrgSettings` was the only gap.** Independently re-verified by the reviewer.

## Tests

- Non-member → **404**, and the body contains neither the member's name nor email.
- **Enumeration**: a real-but-forbidden org and a nonexistent one return the *same* status — the property the helper guarantees.
- A plain `member` (weakest membership) still gets **200** — the fix locks out nobody legitimate.
- **Mutation-verified**: deleting the gate reproduces the original leak exactly (200 + name + email). The reviewer independently reproduced it against `main` too.

`go build`, `go vet`, `gofmt`, full `go test ./internal/... -p 1`, and `golangci-lint` at CI's pinned v2.11.4 (0 issues) all pass.

## Follow-ups (not blocking, pre-existing)

1. **`OrgPage` has the same enumeration shape** — 403 vs 404 distinguishes existence. Same class, different handler.
2. **Inline membership checks elsewhere treat *any* DB error as 403** (`canManageOrgMembers`, `canManageOrg`, `costs.go`, `projects.go`). Fail-closed and not a security bug, but a Postgres blip gets misreported as an authorization denial. Migrating them to `authorizeOrgAccess` would fix both at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)