### PR TITLE
deploy: pin server & orchestrator images to v0.5.1

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.5.0
+          image: registry.k3s.vlah.sh/smartpm:v0.5.1
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.5.0
+          image: registry.k3s.vlah.sh/smartpm:v0.5.1
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for the **v0.5.1 security hotfix, already deployed to production**.

`imagePullPolicy: IfNotPresent` means the image tag is the only thing pinning the version. Leaving these at v0.5.0 would let a routine `kubectl apply` silently roll production back to the **vulnerable** build — worth merging promptly for that reason.

## Deploy record

`v0.5.1` (tag → `6d934df`, digest `sha256:20dfe071…`) — the org-settings membership gate, PR #122.

| Step | Result |
|------|--------|
| Migration | **none** — schema stays at 34 |
| Rollout | server ×2 + orchestrator, **0 restarts** |
| Digest check | all 3 running pods report `sha256:20dfe071…`, identical to the image built from `6d934df` |
| Smoke | `/login` 200 (0.24s), `/health` 200, no errors in logs |
| Route check | unauthenticated `GET /orgs/x/settings` → 303 to `/login` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)