### PR TITLE
feat(debate): per-org monthly AI budget with enforcement (#64)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -323,6 +323,7 @@ func main() {
 		r.Patch("/orgs/{orgSlug}/members/{userID}/role", orgH.UpdateMemberRole)
 		r.Post("/orgs/{orgSlug}/settings/business", orgH.UpdateBusinessDetails)
 		r.Post("/orgs/{orgSlug}/settings/margin", orgH.UpdateAIMargin)
+		r.Post("/orgs/{orgSlug}/settings/budget", orgH.UpdateMonthlyBudget)
 		r.Post("/orgs/{orgSlug}/settings/currency", orgH.UpdateCurrency)
 
 		// Projects

--- a/docs/superpowers/plans/2026-08-21-org-monthly-budget.md
+++ b/docs/superpowers/plans/2026-08-21-org-monthly-budget.md
@@ -1,0 +1,341 @@
+# Per-Org Monthly Budget — Implementation Plan (issue #64)
+
+> **For agentic workers:** implement task-by-task, TDD (RED before GREEN). Steps use
+> checkbox syntax. Spec: `docs/superpowers/specs/2026-08-20-org-monthly-budget-design.md`
+> (already survived an adversarial review round with Codex + Mistral Vibe).
+
+**Branch:** `feature/64-org-monthly-budget`
+
+**Step 0 is DONE.** The plan originally opened with "add a membership gate to `OrgSettings`",
+which turned out to be a live cross-tenant leak. It shipped separately as PR #122 / v0.5.1.
+The budget card can therefore be added to a page that is now correctly gated.
+
+**Test env:**
+```bash
+docker compose -f docker-compose.test.yml up -d postgres && docker compose ... up migrate
+go test ./internal/... -p 1 -count=1 -timeout 120s     # -p 1 REQUIRED (shared test DB)
+```
+
+## 1. Approach
+
+One nullable `BIGINT` on `organizations`, a small audit table, one aggregate query over
+`feature_debate_rounds`, and a guard in `CreateRound` after the existing fuses. No new
+services, no cache, no advisory locks — the spec settled that this is a threshold, not a ledger.
+
+**Staff are NOT exempt from the cap.** Spec §5 blocks `CreateRound` with no role qualifier and
+§8 gives staff their own "raise it in organization settings" wording, which only makes sense if
+staff hit the block. So the budget check sits OUTSIDE the `if !auth.IsStaffOrAbove(...)` block
+that wraps the existing fuses. This differs from every other cap in that handler — deliberately.
+
+## 2. Files
+
+**New:** `migrations/000035_org_monthly_budget.{up,down}.sql`;
+`internal/models/queries_budget_test.go`; `internal/handlers/orgs_budget_test.go`;
+`internal/handlers/debate_budget_test.go`.
+
+**Modified:** `internal/models/models.go`, `internal/models/queries.go`,
+`internal/handlers/orgs.go`, `internal/handlers/debate.go`, `cmd/server/main.go`,
+`templates/pages/org_settings.html`, `e2e/tests/12-debate-fake.spec.js`.
+
+## 3. Steps
+
+### Step 1 — migration + model column
+
+```sql
+-- Phase-2 issue #64: per-organization monthly AI debate budget.
+-- Design: docs/superpowers/specs/2026-08-20-org-monthly-budget-design.md
+--
+-- monthly_budget_cents is USD cents, NOT the org's currency_code (spec §2):
+-- provider pricing is quoted in USD and there is no FX anywhere in this
+-- codebase, so rendering a USD-derived figure behind a EUR symbol would be a
+-- false monetary representation. The UI labels it USD explicitly.
+--
+-- NULL = unlimited (the default for every existing org, so this ships
+-- behaviourally inert). 0 is MEANINGFUL: it blocks new debate rounds while
+-- still allowing the post-accept scorer and the retry sweep to finish work
+-- already started (spec §5).
+--
+-- The CHECK matters because enforcement is `spend >= cap -> block`, and a
+-- non-negative spend is always >= a negative cap: a negative value would
+-- permanently block EVERY round for the org, a self-inflicted denial of
+-- service that no UI would explain. (An earlier draft of this plan claimed
+-- the opposite -- that a negative cap would unblock everything. It would
+-- not. Corrected in Debate 2.)
+--
+-- Only that direction is pinned in schema; the USD 1M upper bound lives in
+-- the parser AND the model setter, so a caller bypassing the handler still
+-- cannot persist a value that overflows `cap * microsPerCent`.
+ALTER TABLE organizations
+    ADD COLUMN monthly_budget_cents BIGINT
+        CHECK (monthly_budget_cents IS NULL OR monthly_budget_cents >= 0);
+
+-- Cap changes are audited (spec §8). No existing table fits: ticket_activities
+-- is ticket_id NOT NULL with a closed action CHECK. This is a money control,
+-- so "who raised it, from what, to what, when" must survive container
+-- restarts and log rotation.
+--
+-- changed_by is ON DELETE SET NULL, not CASCADE: deleting a user must not
+-- erase the financial trail, and the row stays meaningful without them.
+CREATE TABLE org_budget_changes (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id     UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    changed_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    old_cents  BIGINT CHECK (old_cents IS NULL OR old_cents >= 0),
+    new_cents  BIGINT CHECK (new_cents IS NULL OR new_cents >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_org_budget_changes_org_created
+    ON org_budget_changes (org_id, created_at DESC);
+```
+
+Down migration carries a LOSSY warning header (dropping the column resets every org to
+unlimited and discards the audit trail; roll the application back instead).
+
+- [ ] `Organization.MonthlyBudgetCents *int64` in `models.go` (fieldalignment is disabled in
+      `.golangci.yml`, so placement is free — put it next to `AIMarginPercent`).
+- [ ] Append `monthly_budget_cents` to `orgColumns` (`queries.go:370`) AND `&o.MonthlyBudgetCents`
+      to `scanOrg` in the matching position. All nine org queries funnel through this pair, so
+      it is a two-line change — but a mismatch is a RUNTIME error, not a compile error.
+
+### Step 2 — `UpdateOrgMonthlyBudget` + audit, atomically
+
+```go
+var ErrOrgNotFound = errors.New("organization not found")
+
+// Sets (non-nil) or clears (nil) the cap, recording old->new in
+// org_budget_changes in the SAME transaction. Atomic on purpose: an
+// unaudited change to a money control is worse than a failed change.
+func (db *DB) UpdateOrgMonthlyBudget(ctx context.Context, orgID, actorUserID string, capCents *int64) error
+```
+Begin → `SELECT monthly_budget_cents ... FOR UPDATE` (ErrNoRows → `ErrOrgNotFound`) → UPDATE →
+INSERT audit → Commit.
+
+**Validate the range HERE too, not only in the parser** (Debate 2, both reviewers): reject
+`*capCents > maxBudgetCents` (100_000_000) with `ErrBudgetOutOfRange`. The handler already
+rejects it, but a future or internal caller bypassing the handler could otherwise persist a
+value that overflows `cap * microsPerCent` at comparison time. The DB CHECK guards the negative
+direction; this guards the positive one.
+
+### Step 3 — spend aggregate + month range
+
+```go
+// Totals raw provider spend for one org's debate rounds in [from, to).
+// Refiner AND scorer cost, all round statuses — a rejected suggestion
+// still cost money.
+//
+// Enforcement source of truth (spec §3), NOT project_costs:
+// IncrementProjectCostCents runs after commit and is explicitly non-fatal,
+// so one failed rollup would permanently undercount and silently lift the
+// cap. These two columns are written inside the round transaction.
+//
+// Returns 0,nil when there are no rounds; callers MUST treat a non-nil
+// error as "unknown", never as zero.
+func (db *DB) SumOrgDebateSpendMicros(ctx context.Context, orgID string, from, to time.Time) (int64, error)
+```
+```sql
+SELECT COALESCE(SUM(COALESCE(r.cost_micros,0) + COALESCE(r.scorer_cost_micros,0)), 0)::BIGINT
+  FROM feature_debate_rounds r
+  JOIN feature_debates d ON d.id = r.debate_id
+ WHERE d.org_id = $1 AND r.created_at >= $2 AND r.created_at < $3
+```
+The inner COALESCEs matter: both columns are nullable, and `NULL + 5` is `NULL`, which would
+drop a whole round from the sum whenever the scorer had not run.
+
+The trailing `::BIGINT` is for type clarity, not a bug fix: `SUM(bigint)` returns `numeric` in
+PostgreSQL, and it was VERIFIED empirically that pgx scans that into `int64` without error. The
+cast documents the intended width and turns a hypothetical overflow into a clean DB error rather
+than a driver conversion surprise. (Debate 2 claimed the uncast query would not work — it does.)
+
+**Assumption, documented rather than enforced:** `cost_micros`/`scorer_cost_micros` are never
+negative — they come from `ComputeCostMicros`, which cannot return a negative. If that ever
+changes, a negative sum would let spend fall below a cap of 0 and unblock rounds.
+
+Half-open range, not `to_char(...) = '2026-08'` — a to_char predicate is not sargable and would
+scan every round. Bucket identity is preserved by DERIVING the range from the same string:
+
+```go
+// Returns [start,end) of the UTC month containing now — the same bucket
+// IncrementProjectCostCents writes via Format("2006-01") (spec §7).
+//
+// No error return: constructing the boundaries directly from now with
+// time.Date(...) in UTC cannot fail, whereas the earlier Format-then-Parse
+// round-trip introduced an impossible error path callers had to handle.
+// MUST use the passed `now`, never time.Now() internally, or the caller's
+// captured instant and the bucket can straddle midnight.
+func currentUTCMonthRange(now time.Time) (start, end time.Time)
+```
+No new index: the planner uses `idx_feature_debates_org_status` + `idx_feature_debate_rounds_debate`.
+Measure with EXPLAIN ANALYZE before adding one.
+
+### Step 4 — money parsing
+
+Do NOT reuse `parseToCents` (`costs.go:320`) — it uses ParseFloat + math.Round, which the spec
+forbids and which silently accepts `1e3`/`NaN`/`Inf` and rounds `25.555`. Changing it would alter
+existing cost-entry behaviour.
+
+```go
+// Decimal USD string -> integer cents, no floating point. Accepts an
+// optional leading '$' and surrounding whitespace; otherwise must match
+// ^\d+(\.\d{1,2})?$
+func parseUSDCents(s string) (int64, error)
+func formatUSDCents(cents int64) string   // fmt.Sprintf("%d.%02d", c/100, c%100)
+//   MUST guard negatives: %02d of a negative remainder renders "0.-5", not
+//   "-0.05". Callers should never pass one, so treat it as a bug-catcher:
+//   clamp to "0.00" or format the absolute value with a leading '-'.
+```
+Distinct sentinels so the handler returns distinct 400s: `errBudgetNotANumber`,
+`errBudgetTooManyDecimals` (3+ decimals REJECTED, never rounded), `errBudgetOutOfRange`
+(> 100_000_000 cents; check the dollar part against 1_000_000 BEFORE multiplying so the guard
+cannot itself overflow). Implementation: `strings.Cut(s,".")`, `ParseInt` each half, right-pad the fraction to 2 digits,
+`dollars*100 + frac`.
+
+**Validate the lexical form BEFORE ParseInt** — `ParseInt` accepts a leading `+` and would let
+`+25` through a grammar that declares it invalid. Check every byte is an ASCII digit (after
+trimming the optional `$` and whitespace, and splitting on at most one `.`) rather than relying
+on ParseInt to reject non-conforming input.
+
+### Step 5 — set handler + route
+
+```go
+// POST /orgs/{orgSlug}/settings/budget
+// NOT staff-only, unlike UpdateAIMargin: the budget is the client's own
+// spend control (spec §6).
+func (h *OrgHandler) UpdateMonthlyBudget(w http.ResponseWriter, r *http.Request)
+```
+1. `GetOrgBySlug` → 404 on ErrNoRows, 500 otherwise (keep DISTINCT; `UpdateAIMargin` currently
+   collapses them — do not copy that).
+2. `h.canManageOrgMembers(r, user, org.ID)` → 403. That helper is already exactly spec §6.
+3. Empty field → `capCents = nil` (unlimited). Else `parseUSDCents` with one message per sentinel.
+4. `UpdateOrgMonthlyBudget` → distinct `ErrOrgNotFound` (404) / generic (500) branches.
+5. `log.Printf` alongside the DB audit row; redirect 303 to settings.
+
+**The org comes from the route slug only** — no `org_id` form field is read. Cross-org
+substitution is covered by a test.
+
+Route in `cmd/server/main.go` inside the auth+CSRF group.
+
+### Step 6 — org settings card
+
+`OrgSettings` adds Go-computed strings (no float in templates, no new FuncMap entries):
+`CanViewBudget`, `BudgetIsUnlimited`, `BudgetCapInput`, `BudgetCapDisplay`,
+`BudgetSpendDisplay` (micros→cents half-up: `(micros+5000)/10000`), `BudgetSpendUnavailable`,
+`BudgetMonth`.
+
+**Capture `now` ONCE** and derive both the aggregate range and `BudgetMonth` from it, so the
+displayed month can never disagree with the figure beside it across a midnight boundary.
+
+An aggregate failure here is NOT fatal to the page — show a dash. Deliberately different from
+the enforcement path: showing "unavailable" is harmless, treating unknown spend as zero at the
+gate is not.
+
+Template: insert BEFORE the `{{if .IsStaff}}` block. Gating is `{{if .CanViewBudget}}` (members
+see it — the margin card is staff-only) with the form itself behind `{{if .CanManage}}`. Reuse
+the margin card's DaisyUI classes verbatim so no new utility classes are introduced. Always
+`$`/USD, never `{{.Org.CurrencyCode}}`. Helper text: *"Applies to AI feature-refinement spend
+only. Leave blank for unlimited. Set to 0 to block new AI suggestions — work already in
+progress still finishes."*
+
+### Step 7 — enforcement in `CreateRound` (the core)
+
+```go
+var (
+    errBudgetExceeded    = errors.New("org monthly budget reached")
+    errBudgetUnavailable = errors.New("org monthly spend could not be determined")
+)
+
+// nil = uncapped or under cap; errBudgetExceeded at/over cap;
+// errBudgetUnavailable when the aggregate could not be read — callers MUST
+// fail closed (spec §3): treating "unknown" as zero turns a transient DB
+// error into unlimited spend.
+func (h *DebateHandler) checkOrgBudget(ctx context.Context, org *models.Organization) error
+```
+Compare in MICROS, no rounding: `spendMicros >= *org.MonthlyBudgetCents * microsPerCent`
+(`const microsPerCent = 10_000`). Max cap 1e8 cents × 1e4 = 1e12 — nowhere near int64 overflow.
+
+Insertion point: AFTER the closing brace of the `if !auth.IsStaffOrAbove(...)` fuse block
+(~line 409) and BEFORE the reservation tx. Guarantees no AI call and no debate-row mutation.
+
+Three distinct branches: nil → continue; `errBudgetExceeded` → 429 + role-appropriate message;
+`errBudgetUnavailable` → 503 + generic infra copy (NOT 429 — "we couldn't verify your budget" is
+not a rate limit and must not tell a client to wait until next month).
+
+`dctx.org` comes from AuthMiddleware, which reloads orgs from the DB on every request — so there
+is no session-cached org. It is NOT, however, a staleness guarantee: an admin can lower the cap
+between that load and this guard, so the request proceeds against the older value. That is one
+more instance of the bounded overshoot the spec already accepts (§4), not a separate defect —
+but the plan should not claim the reload prevents it.
+
+Message selection does ONE `GetOrgMembership` lookup inside the message function only, so the
+hot path pays nothing until the cap actually trips. A lookup error falls back to the CLIENT
+wording (least informative is the safe default).
+
+### Step 8 — E2E + docs
+
+ONE test added to `e2e/tests/12-debate-fake.spec.js` (CI runs only that spec against a fresh DB;
+do not add a new self-registering spec): set the budget to 0, request a suggestion, assert the
+flash appears and no round card is added. Zero is the only workable value — fake rounds cost a
+fraction of a cent and would never trip a realistic nonzero cap.
+
+Verify which role the self-registering E2E user ends up with (first user is auto-promoted to
+superadmin) and assert the matching wording.
+
+## 4. Test plan
+
+**Models:** set/clear round-trip; audit row correctness (first change has `old_cents IS NULL`);
+raw `-1` INSERT must error (proves the CHECK); unknown org → `ErrOrgNotFound` with NO audit row;
+`SumOrgDebateSpendMicros` — empty → 0,nil; sums both columns incl. NULL scorer; excludes other
+orgs; excludes out-of-range rows testing BOTH edges; counts all round statuses.
+
+**Handler (set):** `parseUSDCents` table test (accept `0`,`25`,`25.5`,`25.50`,`$25.00`,` 25.00 `,
+`1000000`; reject ``,`-1`,`25.555`,`1e3`,`abc`,`1,000`,`NaN`,`Inf`,`1000000.01`,`25.`,`.50`);
+role matrix through the real router (member 403, owner 303, admin 303, staff-on-foreign-org 303,
+non-member 403); cross-org substitution; empty clears to NULL; card renders for a member, form
+hidden.
+
+**Handler (enforcement):** cap NULL → created; under cap → created; at/over cap → 429 **and
+`FakeRefiner.CallCount == 0`** and no new round row; cap 0 → CreateRound 429 but StartDebate/
+accept/undo/approve still succeed; role-appropriate wording (note `seedAuthedFeatureTicket`
+makes the user the OWNER, so the client-wording case needs a direct role downgrade);
+rollover (previous-month rounds don't count); scorer cost counts toward the cap.
+
+Added in Debate 2:
+- **cap 0 with spend 0 must BLOCK** (`0 >= 0`). The obvious-looking boundary, and the one an
+  off-by-one in the comparison would flip.
+- **Fail-closed needs a real seam, not a cancelled context.** A cancelled ctx fails auth or the
+  ticket lookup first, so the test would pass without ever reaching the aggregate. Isolate the
+  aggregate failure specifically — e.g. call `checkOrgBudget` directly (it is package-private
+  and the test is in `package handlers`) with a stub/broken pool — and assert 503, zero refiner
+  calls, and no round row.
+- **Audit rows:** assert `changed_by` is the actor, exactly one row per successful update, and
+  **no row at all** when the update fails (proving the transaction is atomic).
+- **Cross-org set:** a non-member of org A attempting to set org B's budget → 403.
+- **Overflow:** a cap at the 100M bound with large seeded costs must still compare correctly and
+  block, not wrap or 503.
+
+**E2E:** assert the settings POST actually persisted `0` (redirect plus the rendered zero) BEFORE
+asserting the suggestion is blocked — otherwise an unrelated pre-existing block satisfies the
+test. Confirm the acting user's role and assert the matching wording branch.
+
+## 5. Risks
+
+- **R2 — Undo erases spend from the aggregate.** `UndoRoundsFromTx` hard-DELETEs rounds, so a
+  user near the cap can undo to reclaim headroom for money already spent. Not a reason to change
+  §3; file as a follow-up.
+- **R3 — Un-priced models record `cost_micros = 0`** (the #108 failure mode), so an org on an
+  un-priced model never trips its cap. The `HasPricing` startup warning already exists; this
+  makes it a money-correctness signal, not just reporting.
+- **R4 — Costs page and budget card will show different numbers** (per-project vs org-wide, with
+  margin vs without). Both correct; the helper text is the mitigation.
+- **R5 — Migration is additive**; `ADD COLUMN ... NULL` with no default is catalog-only on PG 11+.
+  The DOWN is destructive — roll the app back instead.
+- **R6 — GDPR:** `org_budget_changes.changed_by` links a person to an action. `ON DELETE SET NULL`
+  keeps the financial record while removing the identifier on erasure. No new data leaves the EU.
+- **R7 — Overshoot is expected**; no test should assert a hard ceiling.
+- **R8 — Rounding:** comparison in micros with no rounding; only DISPLAY cents are rounded.
+
+## 6. Out of scope
+
+Spec §10, plus: fixing `parseToCents`'s float arithmetic; the undo hole (R2); surfacing the
+budget on the costs page or debate sidebar; any UI for `org_budget_changes`; changes to
+`ClientDailyRoundCap`.

--- a/docs/superpowers/specs/2026-08-20-org-monthly-budget-design.md
+++ b/docs/superpowers/specs/2026-08-20-org-monthly-budget-design.md
@@ -1,0 +1,149 @@
+# Per-Org Monthly Budget with Enforcement — Design Spec (issue #64)
+
+**Status:** agreed after adversarial review by Codex (`codex-cli 0.145.0`) and Mistral Vibe
+(`vibe 2.24.1`). Their must-fix findings are folded in below; §9 records what was rejected
+and why. Phase-2 issue B of `docs/superpowers/specs/2026-04-14-feature-debate-mode-design.md` §8.
+
+## 1. Goal
+
+Give each organization a monthly cap on AI **debate** spend. Once the month's debate spend
+reaches the cap, new debate rounds are refused for that org until the next UTC month. The
+existing per-user daily round fuse (`ClientDailyRoundCap`, clients only) **stays** as defense
+in depth — this supplements it, it does not replace it.
+
+## 2. Money: units, currency, and which number is capped
+
+- **The cap is denominated in USD**, stored as a nullable non-negative `BIGINT` of **USD
+  cents**. Every UI label says USD explicitly.
+- **`organizations.currency_code` is NOT used for the budget.** It is display-only elsewhere
+  (the margin card states "Does not convert amounts"), and rendering a USD-derived figure
+  behind a `€` symbol would be a false monetary representation. No FX, no conversion — the
+  budget card is labelled USD regardless of the org's display currency.
+- **The capped figure is raw provider spend, with no `ai_margin_percent` applied.** Verified:
+  margin is applied at display time only, and only to `ai_usage_entries` (`costs.go:97-99`);
+  debate spend reaches clients un-marked-up inside `infraTotal`. Capping a marked-up number
+  would enforce a figure displayed nowhere.
+
+## 3. Enforcement source of truth — `feature_debate_rounds`, not `project_costs`
+
+`IncrementProjectCostCents` writes `project_costs` **after** the round completes and is
+**explicitly non-fatal** (failures are logged, not returned). Using it to enforce a budget
+would mean a single failed rollup permanently undercounts spend and silently lifts the cap.
+
+Therefore the budget check aggregates the **durable, in-transaction** per-round record:
+`feature_debate_rounds.cost_micros + scorer_cost_micros`, joined to the org via
+`feature_debates.org_id`, filtered to the current UTC month. `project_costs` remains the
+display/rollup path and is unchanged.
+
+**Fail closed.** If the spend aggregate cannot be read, refuse the round. This costs nothing
+in practice: the round insert needs the same database, so a DB outage fails the request
+regardless — but it removes "aggregate errored → treated as zero → unlimited spend".
+
+## 4. Enforcement semantics — a best-effort threshold, not a hard ceiling
+
+Cost is recorded after the provider call, so N concurrent rounds can each pass the check
+before any of their costs land. This is a **threshold that stops new work once observed spend
+reaches the cap**, not a guarantee that spend never exceeds it. Stated plainly so nobody
+implements it believing otherwise.
+
+**Bounded overshoot.** `reserveInFlight` allows at most one in-flight round per debate, so
+worst case is `(concurrently active debates in the org) × (max cost of one refiner + scorer
+round)`. No advisory lock, no cost pre-reservation: the complexity is not justified for a
+control whose purpose is stopping sustained spend, not cent-exact billing.
+
+## 5. What is and is not blocked
+
+| Action | Blocked at cap? | Why |
+|---|---|---|
+| `CreateRound` (new AI round) | **Yes** — 429 | The only place new spend is initiated |
+| `StartDebate` | No | No AI call, costs nothing |
+| Accept / reject / undo / approve | No | No AI call |
+| Post-accept scorer | No | Attaches to an already-created round |
+| Background retry sweep | No | Same; blocking strands debates permanently unscored |
+
+Scorer and sweep spend still **counts** toward the month, so it shrinks headroom for the next
+round — the correct pressure point. Blocking them would leave accepted debates with
+`effort_*` NULL forever to save cents.
+
+Because of this, an explicit cap of `0` means **"block new rounds"**, not "stop all AI spend".
+The UI must use that wording.
+
+## 6. Configuration, roles, and validation
+
+- **Who may set it:** org owner/admin (`auth.CanManageOrg`) **and** staff/superadmin. This
+  deviates from `ai_margin_percent` (staff-only) deliberately: margin is the consultancy's
+  billing knob *about* a client; the budget is the client's own spend control, and the issue
+  says "owners set". Staff/superadmin may set it for **any** org, consistent with the margin
+  precedent.
+- **Who may view it:** any org member sees their own org's cap and current spend (the costs
+  page is already member-visible and already shows debate spend). Staff see all orgs. No new
+  per-provider or per-model granularity is exposed anywhere — aggregate figures only.
+- **The org is always derived from the trusted route/session context**, never from a
+  form field. Cross-org substitution must be covered by a test.
+- **Validation:** cap is nullable (`NULL` = unlimited). When set it must be `>= 0` — enforced
+  by handler validation, a DB `CHECK`, **and** the model-layer setter, so a caller that
+  bypasses the handler still cannot persist an invalid value.
+
+  *Correction (Debate 2):* an earlier draft of this spec claimed a negative cap would
+  "silently unblock everything". That is backwards. Enforcement is
+  `spend >= cap → block`, and a non-negative spend is always `>= a negative cap`, so a
+  negative cap would **permanently block every round** — a self-inflicted denial of
+  service, not a bypass. The constraint is still required; the reason is the opposite of
+  what was written.
+
+  Upper bound `100_000_000` cents (USD 1M) — enforced in the setter as well as the parser,
+  because `cap * microsPerCent` overflows int64 for an unbounded BIGINT;
+  input parsed from a decimal string to integer cents **without floating point**; more than
+  two decimal places is rejected rather than rounded.
+
+## 7. Month boundary
+
+The check uses `time.Now().UTC().Format("2006-01")`, byte-identical to the writer in
+`IncrementProjectCostCents`. Spend is attributed by **cost-write time** (existing behavior);
+the check reads **creation time**. A round created seconds before rollover whose cost lands
+after it is charged to the new month — a one-round wobble, accepted and documented rather
+than engineered away. At rollover the new bucket sums to zero and blocked orgs unblock with
+no intervention.
+
+## 8. Responses and messaging
+
+- HTTP **429**, matching the existing cap responses.
+- **Client wording avoids AI internals**: "Your organization's monthly budget has been
+  reached. It resets at the start of next month." No provider names, no model IDs, no
+  per-round figures.
+- **Owner/admin/staff wording is actionable and names the setting**, since they can change
+  it: "Monthly AI budget reached for this organization — raise it in organization settings
+  to continue."
+- The budget check runs **after** the existing in-flight and daily-fuse guards, so the more
+  specific error wins and no response leaks provider details.
+- **Cap changes are audited** (actor, org, old → new, timestamp). It is a money control; a
+  silent change is indistinguishable from a bug.
+
+## 9. Review findings rejected, with reasons
+
+- **"Showing spend to owners/clients violates the no-AI-internals rule."** Rejected: verified
+  that `costs.go` gates on org *membership*, not role, and debate spend is already inside the
+  `infraTotal` clients see. Aggregate cost is the costs feature's entire purpose; the rule
+  covers provider/model internals. The narrower instinct is honored — no new granularity.
+- **"Introduce a new authoritative per-round cost record."** Rejected as redundant:
+  `feature_debate_rounds.cost_micros` / `scorer_cost_micros` are already written in the round
+  transaction and already durable. §3 adopts the intent by aggregating from them.
+
+## 10. Out of scope
+
+Assistant/chat spend (`ai_usage_entries`); per-project budgets; carryover; proration; FX;
+threshold notifications (email/webhook/Slack); forecasting; changes to the daily fuse or the
+retry sweep; distributed locking or transactional cost reservation.
+
+## 11. Success criteria
+
+1. Org with no cap: behaviorally identical to today; every existing debate test passes.
+2. Cap set, spend below: `CreateRound` succeeds.
+3. Cap set, current-month debate spend >= cap: 429, role-appropriate message, **no AI call**,
+   no debate row mutated.
+4. Cap `0`: new rounds blocked; StartDebate, accept/undo/approve, scorer and sweep still work.
+5. Negative cap rejected by handler and by DB constraint.
+6. Spend aggregate read failure ⇒ round refused (fail closed).
+7. Rollover: a blocked org creates rounds in the next UTC month with no intervention.
+8. Role matrix enforced, including staff-any-org and cross-org substitution.
+9. Aggregation counts scorer cost, not just refiner cost.

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -51,6 +51,68 @@ const (
 	roundStatusRejected = "rejected"
 )
 
+// microsPerCent converts organizations.monthly_budget_cents (USD cents)
+// to the same unit feature_debate_rounds.cost_micros is recorded in, so
+// the comparison in checkOrgBudget never has to round.
+const microsPerCent = 10_000
+
+var (
+	// errBudgetExceeded means the org's current-month debate spend has
+	// reached or passed its cap — CreateRound must refuse the round.
+	errBudgetExceeded = errors.New("org monthly budget reached")
+	// errBudgetUnavailable means the spend aggregate could not be read.
+	// Callers MUST fail closed (spec §3): treating "unknown" as zero
+	// would turn a transient DB error into unlimited spend.
+	errBudgetUnavailable = errors.New("org monthly spend could not be determined")
+)
+
+// checkOrgBudget is the enforcement gate for issue #64. Returns nil when
+// the org is uncapped or under cap; errBudgetExceeded at/over cap;
+// errBudgetUnavailable when the aggregate could not be read.
+//
+// Compares in MICROS with no rounding: only DISPLAY figures (the org
+// settings card) round to cents. The cap is bounded to 100_000_000
+// cents at the model layer, so cap*microsPerCent (max ~1e12) is nowhere
+// near int64 overflow.
+func (h *DebateHandler) checkOrgBudget(ctx context.Context, org *models.Organization) error {
+	if org.MonthlyBudgetCents == nil {
+		return nil
+	}
+
+	from, to := models.CurrentUTCMonthRange(time.Now())
+	spendMicros, err := h.db.SumOrgDebateSpendMicros(ctx, org.ID, from, to)
+	if err != nil {
+		return errBudgetUnavailable
+	}
+
+	if spendMicros >= *org.MonthlyBudgetCents*microsPerCent {
+		return errBudgetExceeded
+	}
+	return nil
+}
+
+// budgetExceededMessage picks role-appropriate copy for a tripped
+// budget cap (spec §8). Does ONE GetOrgMembership lookup, and only when
+// the cap has actually tripped, so the hot (under-cap) path never pays
+// for it. A lookup error falls back to the least-informative CLIENT
+// wording — the safe default when role can't be confirmed.
+func (h *DebateHandler) budgetExceededMessage(ctx context.Context, dctx debateContext) string {
+	const actionable = "Monthly AI budget reached for this organization — raise it in organization settings to continue."
+	const clientSafe = "Your organization's monthly budget has been reached. It resets at the start of next month."
+
+	if auth.IsStaffOrAbove(dctx.user.Role) {
+		return actionable
+	}
+	m, err := h.db.GetOrgMembership(ctx, dctx.user.ID, dctx.org.ID)
+	if err != nil {
+		return clientSafe
+	}
+	if auth.CanManageOrg(m.Role) {
+		return actionable
+	}
+	return clientSafe
+}
+
 // DebateConfig groups the per-deployment tuning knobs for the debate
 // flow. Defaults come from DefaultDebateConfig; production wiring in
 // cmd/server/main.go can override from env or leave defaults in place.
@@ -404,6 +466,29 @@ func (h *DebateHandler) CreateRound(w http.ResponseWriter, r *http.Request) {
 		if dailyCount, dcErr := h.db.CountUserRoundsLast24h(r.Context(), dctx.user.ID); dcErr == nil && dailyCount >= h.cfg.ClientDailyRoundCap {
 			h.renderDebateError(w, r, http.StatusTooManyRequests,
 				"You've reached the daily suggestion limit — try again tomorrow or ask us if you need more.")
+			return
+		}
+	}
+
+	// Org monthly budget (#64). Deliberately OUTSIDE the
+	// !IsStaffOrAbove block above: spec §5 blocks CreateRound with no
+	// role qualifier, and §8 gives staff their own "raise it in
+	// organization settings" wording, which only makes sense if staff
+	// hit the block too. Placed after the existing fuses and before the
+	// reservation tx so a blocked request makes no AI call and mutates
+	// no debate row.
+	if budgetErr := h.checkOrgBudget(r.Context(), dctx.org); budgetErr != nil {
+		switch {
+		case errors.Is(budgetErr, errBudgetExceeded):
+			h.renderDebateError(w, r, http.StatusTooManyRequests,
+				h.budgetExceededMessage(r.Context(), dctx))
+			return
+		case errors.Is(budgetErr, errBudgetUnavailable):
+			// 503, NOT 429: "we couldn't verify your budget" is not a
+			// rate limit and must not tell a client to wait until next
+			// month when the real problem is an infra fault.
+			h.renderDebateError(w, r, http.StatusServiceUnavailable,
+				"We couldn't verify your organization's AI budget — please try again shortly.")
 			return
 		}
 	}

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -66,53 +66,6 @@ var (
 	errBudgetUnavailable = errors.New("org monthly spend could not be determined")
 )
 
-// checkOrgBudget is the enforcement gate for issue #64. Returns nil when
-// the org is uncapped or under cap; errBudgetExceeded at/over cap;
-// errBudgetUnavailable when the aggregate could not be read.
-//
-// Compares in MICROS with no rounding: only DISPLAY figures (the org
-// settings card) round to cents. The cap is bounded to 100_000_000
-// cents at the model layer, so cap*microsPerCent (max ~1e12) is nowhere
-// near int64 overflow.
-func (h *DebateHandler) checkOrgBudget(ctx context.Context, org *models.Organization) error {
-	if org.MonthlyBudgetCents == nil {
-		return nil
-	}
-
-	from, to := models.CurrentUTCMonthRange(time.Now())
-	spendMicros, err := h.db.SumOrgDebateSpendMicros(ctx, org.ID, from, to)
-	if err != nil {
-		return errBudgetUnavailable
-	}
-
-	if spendMicros >= *org.MonthlyBudgetCents*microsPerCent {
-		return errBudgetExceeded
-	}
-	return nil
-}
-
-// budgetExceededMessage picks role-appropriate copy for a tripped
-// budget cap (spec §8). Does ONE GetOrgMembership lookup, and only when
-// the cap has actually tripped, so the hot (under-cap) path never pays
-// for it. A lookup error falls back to the least-informative CLIENT
-// wording — the safe default when role can't be confirmed.
-func (h *DebateHandler) budgetExceededMessage(ctx context.Context, dctx debateContext) string {
-	const actionable = "Monthly AI budget reached for this organization — raise it in organization settings to continue."
-	const clientSafe = "Your organization's monthly budget has been reached. It resets at the start of next month."
-
-	if auth.IsStaffOrAbove(dctx.user.Role) {
-		return actionable
-	}
-	m, err := h.db.GetOrgMembership(ctx, dctx.user.ID, dctx.org.ID)
-	if err != nil {
-		return clientSafe
-	}
-	if auth.CanManageOrg(m.Role) {
-		return actionable
-	}
-	return clientSafe
-}
-
 // DebateConfig groups the per-deployment tuning knobs for the debate
 // flow. Defaults come from DefaultDebateConfig; production wiring in
 // cmd/server/main.go can override from env or leave defaults in place.
@@ -182,6 +135,53 @@ func NewDebateHandler(db *models.DB, engine *render.Engine,
 	refiners map[string]ai.Refiner, scorers map[string]ai.Scorer, cfg DebateConfig,
 ) *DebateHandler {
 	return &DebateHandler{db: db, engine: engine, refiners: refiners, scorers: scorers, cfg: cfg}
+}
+
+// checkOrgBudget is the enforcement gate for issue #64. Returns nil when
+// the org is uncapped or under cap; errBudgetExceeded at/over cap;
+// errBudgetUnavailable when the aggregate could not be read.
+//
+// Compares in MICROS with no rounding: only DISPLAY figures (the org
+// settings card) round to cents. The cap is bounded to 100_000_000
+// cents at the model layer, so cap*microsPerCent (max ~1e12) is nowhere
+// near int64 overflow.
+func (h *DebateHandler) checkOrgBudget(ctx context.Context, org *models.Organization) error {
+	if org.MonthlyBudgetCents == nil {
+		return nil
+	}
+
+	from, to := models.CurrentUTCMonthRange(time.Now())
+	spendMicros, err := h.db.SumOrgDebateSpendMicros(ctx, org.ID, from, to)
+	if err != nil {
+		return errBudgetUnavailable
+	}
+
+	if spendMicros >= *org.MonthlyBudgetCents*microsPerCent {
+		return errBudgetExceeded
+	}
+	return nil
+}
+
+// budgetExceededMessage picks role-appropriate copy for a tripped
+// budget cap (spec §8). Does ONE GetOrgMembership lookup, and only when
+// the cap has actually tripped, so the hot (under-cap) path never pays
+// for it. A lookup error falls back to the least-informative CLIENT
+// wording — the safe default when role can't be confirmed.
+func (h *DebateHandler) budgetExceededMessage(ctx context.Context, dctx debateContext) string {
+	const actionable = "Monthly AI budget reached for this organization — raise it in organization settings to continue."
+	const clientSafe = "Your organization's monthly budget has been reached. It resets at the start of next month."
+
+	if auth.IsStaffOrAbove(dctx.user.Role) {
+		return actionable
+	}
+	m, err := h.db.GetOrgMembership(ctx, dctx.user.ID, dctx.org.ID)
+	if err != nil {
+		return clientSafe
+	}
+	if auth.CanManageOrg(m.Role) {
+		return actionable
+	}
+	return clientSafe
 }
 
 // errScorerNotConfigured means the project names a provider that has no

--- a/internal/handlers/debate_budget_test.go
+++ b/internal/handlers/debate_budget_test.go
@@ -79,11 +79,18 @@ func TestCheckOrgBudget_UnderCapPasses(t *testing.T) {
 	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(10_000)); err != nil {
 		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
 	}
+
+	// Seed REAL spend strictly below the cap. Without this the test only
+	// proves "a nonzero cap permits zero spend", which an implementation
+	// that never reads spend at all would also pass (Debate 3). The point
+	// is that a genuine sum is computed and compared.
+	seedSpendForTicket(t, db, ticket, 4_000*microsPerCentDebate, time.Now().UTC())
+
 	org = loadTicketOrg(t, db, ticket)
 
 	h := NewDebateHandler(db, nil, nil, nil, DefaultDebateConfig())
 	if err := h.checkOrgBudget(context.Background(), org); err != nil {
-		t.Errorf("checkOrgBudget under cap = %v, want nil", err)
+		t.Errorf("checkOrgBudget under cap (4000c spend vs 10000c cap) = %v, want nil", err)
 	}
 }
 
@@ -128,7 +135,13 @@ func TestCheckOrgBudget_AtOrOverCapBlocks(t *testing.T) {
 // TestCheckOrgBudget_OverflowAtMaxBound proves a cap at the 100M-cent
 // bound with large seeded costs still compares correctly and blocks —
 // not wrap, not a false 503 (Debate 2's overflow case).
-func TestCheckOrgBudget_OverflowAtMaxBound(t *testing.T) {
+// TestCheckOrgBudget_AtMaxBoundStillCompares checks the largest cap the
+// system permits still compares correctly. Debate 3 correctly pointed out
+// that this does NOT exercise integer overflow: maxCap*microsPerCent is
+// 1e12, comfortably inside int64. That is the point — the bound exists so
+// overflow is unreachable. TestUpdateOrgMonthlyBudget_RejectsOutOfRange
+// and the DB CHECK are what keep a larger value from ever being stored.
+func TestCheckOrgBudget_AtMaxBoundStillCompares(t *testing.T) {
 	_, db, sessions := setupDebateTestEnv(t)
 	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
 	org := loadTicketOrg(t, db, ticket)
@@ -146,6 +159,24 @@ func TestCheckOrgBudget_OverflowAtMaxBound(t *testing.T) {
 	err := h.checkOrgBudget(context.Background(), org)
 	if !errors.Is(err, errBudgetExceeded) {
 		t.Errorf("checkOrgBudget at max bound with overshoot = %v, want errBudgetExceeded", err)
+	}
+}
+
+// TestOrgMonthlyBudget_DBRejectsOutOfRange proves the storage layer will
+// not accept a cap the enforcement path could not safely multiply. The Go
+// setter already rejects it, so this asserts the CHECK independently —
+// the guard that still holds for a direct SQL write or a data import,
+// which is the only way such a value could realistically appear.
+func TestOrgMonthlyBudget_DBRejectsOutOfRange(t *testing.T) {
+	_, db, sessions := setupDebateTestEnv(t)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+
+	for _, bad := range []int64{-1, 100_000_001} {
+		if _, err := db.Pool.Exec(context.Background(),
+			`UPDATE organizations SET monthly_budget_cents = $1 WHERE id = $2`, bad, org.ID); err == nil {
+			t.Errorf("DB accepted out-of-range cap %d; the CHECK must reject it", bad)
+		}
 	}
 }
 
@@ -370,7 +401,13 @@ func TestCreateRound_Rollover(t *testing.T) {
 	startDebate(t, r, ticket, cookie)
 
 	// All of last month's spend, well past the cap — must NOT count.
-	lastMonth := time.Now().UTC().AddDate(0, -1, 0)
+	// Derive the previous month from THIS month's boundary, never
+	// AddDate(0,-1,0) on today: on the 29th-31st that normalizes forward
+	// and can land back inside the current month (e.g. 31 March -> 3
+	// March), so the "previous month" spend would silently count and the
+	// test would pass for the wrong reason on ~4 days of every month.
+	monthStart, _ := models.CurrentUTCMonthRange(time.Now().UTC())
+	lastMonth := monthStart.AddDate(0, 0, -1)
 	seedSpendForTicket(t, db, ticket, 10_000*microsPerCentDebate, lastMonth)
 
 	rec := postCreateRound(t, r, ticket, cookie)

--- a/internal/handlers/debate_budget_test.go
+++ b/internal/handlers/debate_budget_test.go
@@ -1,0 +1,514 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/madalin/forgedesk/internal/ai"
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/middleware"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/render"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// setupDebateTestEnvWithRefiner is setupDebateTestEnv but also returns
+// the FakeRefiner so budget-enforcement tests can assert CallCount == 0
+// — the only way to prove a blocked round truly made no AI call, rather
+// than just inferring it from the round row being absent.
+func setupDebateTestEnvWithRefiner(t *testing.T) (*chi.Mux, *models.DB, *auth.SessionStore, *ai.FakeRefiner) {
+	t.Helper()
+
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	sessions := auth.NewSessionStore(pool)
+	engine, err := render.NewEngine(testutil.ProjectRoot()+"/templates", nil)
+	if err != nil {
+		t.Fatalf("loading templates: %v", err)
+	}
+
+	refiner := &ai.FakeRefiner{
+		NameVal: "claude", ModelVal: ai.ModelClaudeSonnet46,
+		OutputFunc: func(_ ai.RefineInput) (string, string, error) {
+			return "refactored description from claude", ai.FinishReasonStop, nil
+		},
+	}
+	refiners := map[string]ai.Refiner{"claude": refiner}
+	h := NewDebateHandler(db, engine, refiners, map[string]ai.Scorer{}, DefaultDebateConfig())
+
+	r := chi.NewRouter()
+	r.Use(middleware.Recover)
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.AuthMiddleware(sessions, db))
+		r.Post("/tickets/{ticketID}/debate/start", h.StartDebate)
+		r.Post("/tickets/{ticketID}/debate/rounds", h.CreateRound)
+	})
+	return r, db, sessions, refiner
+}
+
+// ── Unit tests: checkOrgBudget in isolation ─────────────────────────
+
+// TestCheckOrgBudget_NilCapAlwaysPasses proves an org with no cap set
+// behaves identically to today — success criterion 1 in the spec.
+func TestCheckOrgBudget_NilCapAlwaysPasses(t *testing.T) {
+	_, db, sessions := setupDebateTestEnv(t)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+
+	h := NewDebateHandler(db, nil, nil, nil, DefaultDebateConfig())
+	if err := h.checkOrgBudget(context.Background(), org); err != nil {
+		t.Errorf("checkOrgBudget with nil cap = %v, want nil", err)
+	}
+}
+
+// TestCheckOrgBudget_UnderCapPasses proves spend strictly below the cap
+// does not block.
+func TestCheckOrgBudget_UnderCapPasses(t *testing.T) {
+	_, db, sessions := setupDebateTestEnv(t)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(10_000)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	org = loadTicketOrg(t, db, ticket)
+
+	h := NewDebateHandler(db, nil, nil, nil, DefaultDebateConfig())
+	if err := h.checkOrgBudget(context.Background(), org); err != nil {
+		t.Errorf("checkOrgBudget under cap = %v, want nil", err)
+	}
+}
+
+// TestCheckOrgBudget_AtOrOverCapBlocks proves the boundary is >=, not >
+// — the off-by-one a naive implementation would get backwards. Includes
+// the "cap 0, spend 0" edge from Debate 2: 0 >= 0 must block.
+func TestCheckOrgBudget_AtOrOverCapBlocks(t *testing.T) {
+	tests := []struct {
+		name        string
+		capCents    int64
+		spendMicros int64
+	}{
+		{"exactly at cap", 100, 100 * microsPerCentDebate},
+		{"over cap", 100, 150 * microsPerCentDebate},
+		{"cap zero, spend zero", 0, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, sessions := setupDebateTestEnv(t)
+			ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+			org := loadTicketOrg(t, db, ticket)
+
+			if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(tc.capCents)); err != nil {
+				t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+			}
+			org = loadTicketOrg(t, db, ticket)
+
+			if tc.spendMicros > 0 {
+				seedSpendForTicket(t, db, ticket, tc.spendMicros, time.Now().UTC())
+			}
+
+			h := NewDebateHandler(db, nil, nil, nil, DefaultDebateConfig())
+			err := h.checkOrgBudget(context.Background(), org)
+			if !errors.Is(err, errBudgetExceeded) {
+				t.Errorf("checkOrgBudget(cap=%d, spend=%d) = %v, want errBudgetExceeded", tc.capCents, tc.spendMicros, err)
+			}
+		})
+	}
+}
+
+// TestCheckOrgBudget_OverflowAtMaxBound proves a cap at the 100M-cent
+// bound with large seeded costs still compares correctly and blocks —
+// not wrap, not a false 503 (Debate 2's overflow case).
+func TestCheckOrgBudget_OverflowAtMaxBound(t *testing.T) {
+	_, db, sessions := setupDebateTestEnv(t)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+
+	const maxCapCents = 100_000_000
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(maxCapCents)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	org = loadTicketOrg(t, db, ticket)
+
+	// Spend well past the max cap in micros.
+	seedSpendForTicket(t, db, ticket, int64(maxCapCents)*microsPerCentDebate+1, time.Now().UTC())
+
+	h := NewDebateHandler(db, nil, nil, nil, DefaultDebateConfig())
+	err := h.checkOrgBudget(context.Background(), org)
+	if !errors.Is(err, errBudgetExceeded) {
+		t.Errorf("checkOrgBudget at max bound with overshoot = %v, want errBudgetExceeded", err)
+	}
+}
+
+// TestCheckOrgBudget_AggregateFailure_FailsClosed isolates a genuine
+// aggregate-read failure: passing an org with a non-UUID ID makes
+// SumOrgDebateSpendMicros's query itself error (a real Postgres cast
+// failure, not a fabricated one), letting this test exercise the actual
+// fail-closed branch instead of asserting it by inspection. A cancelled
+// context was tried first and rejected — it fails the earlier ticket/
+// auth lookups in a full HTTP round-trip before ever reaching this
+// aggregate, so it can't isolate this specific failure mode (plan step 7).
+func TestCheckOrgBudget_AggregateFailure_FailsClosed(t *testing.T) {
+	_, db, sessions := setupDebateTestEnv(t)
+	ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(100)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	org = loadTicketOrg(t, db, ticket)
+	org.ID = "not-a-valid-uuid"
+
+	h := NewDebateHandler(db, nil, nil, nil, DefaultDebateConfig())
+	err := h.checkOrgBudget(context.Background(), org)
+	if !errors.Is(err, errBudgetUnavailable) {
+		t.Errorf("checkOrgBudget with unreadable aggregate = %v, want errBudgetUnavailable (fail closed)", err)
+	}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+func int64PtrDebate(v int64) *int64 { return &v }
+
+const microsPerCentDebate = 10_000
+
+func loadTicketOrg(t *testing.T, db *models.DB, ticket *models.Ticket) *models.Organization {
+	t.Helper()
+	proj, err := db.GetProjectByID(context.Background(), ticket.ProjectID)
+	if err != nil {
+		t.Fatalf("GetProjectByID: %v", err)
+	}
+	org, err := db.GetOrgByID(context.Background(), proj.OrgID)
+	if err != nil {
+		t.Fatalf("GetOrgByID: %v", err)
+	}
+	return org
+}
+
+// seedSpendForTicket starts (or reuses) an active debate on the ticket
+// and inserts one raw feature_debate_rounds row carrying the given cost,
+// so budget tests can place spend precisely without burning a fake AI
+// round through the full CreateRound flow.
+func seedSpendForTicket(t *testing.T, db *models.DB, ticket *models.Ticket, costMicros int64, createdAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+
+	proj, err := db.GetProjectByID(ctx, ticket.ProjectID)
+	if err != nil {
+		t.Fatalf("GetProjectByID: %v", err)
+	}
+	deb, err := db.GetActiveDebate(ctx, ticket.ID)
+	if err != nil {
+		deb, err = db.StartDebate(ctx, ticket.ID, ticket.ProjectID, proj.OrgID, ticket.CreatedBy)
+		if err != nil {
+			t.Fatalf("StartDebate: %v", err)
+		}
+	}
+
+	var roundNum int
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT COALESCE(MAX(round_number), 0) + 1 FROM feature_debate_rounds WHERE debate_id = $1`,
+		deb.ID).Scan(&roundNum); err != nil {
+		t.Fatalf("computing next round_number: %v", err)
+	}
+
+	if _, err := db.Pool.Exec(ctx,
+		`INSERT INTO feature_debate_rounds (
+			debate_id, round_number, provider, model, triggered_by,
+			input_text, output_text, status, cost_micros, created_at
+		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', 'out', 'accepted', $4, $5)`,
+		deb.ID, roundNum, ticket.CreatedBy, costMicros, createdAt,
+	); err != nil {
+		t.Fatalf("seeding spend round: %v", err)
+	}
+}
+
+// ── HTTP-level enforcement tests: CreateRound ───────────────────────
+
+func startDebate(t *testing.T, r *chi.Mux, ticket *models.Ticket, cookie *http.Cookie) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/debate/start", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("StartDebate: status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func postCreateRound(t *testing.T, r *chi.Mux, ticket *models.Ticket, cookie *http.Cookie) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"provider": {"claude"}, "feedback": {"please improve this feature"}}
+	req := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/debate/rounds", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func countRoundsForTicket(t *testing.T, db *models.DB, ticket *models.Ticket) int {
+	t.Helper()
+	var count int
+	if err := db.Pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM feature_debate_rounds r
+		   JOIN feature_debates d ON d.id = r.debate_id
+		  WHERE d.ticket_id = $1`, ticket.ID).Scan(&count); err != nil {
+		t.Fatalf("counting rounds: %v", err)
+	}
+	return count
+}
+
+// TestCreateRound_NoCapSucceeds pins success criterion 1: an org with
+// no cap behaves identically to today.
+func TestCreateRound_NoCapSucceeds(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	startDebate(t, r, ticket, cookie)
+
+	rec := postCreateRound(t, r, ticket, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CreateRound with no cap: status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	if got := countRoundsForTicket(t, db, ticket); got != 1 {
+		t.Errorf("round count = %d, want 1", got)
+	}
+}
+
+// TestCreateRound_UnderCapSucceeds is success criterion 2.
+func TestCreateRound_UnderCapSucceeds(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(100_00)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	startDebate(t, r, ticket, cookie)
+
+	rec := postCreateRound(t, r, ticket, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CreateRound under cap: status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCreateRound_AtOrOverCapBlocks_NoAICall is success criterion 3: at
+// or over the monthly cap, CreateRound must 429 with NO AI call made
+// (FakeRefiner.CallCount stays 0) and NO round row inserted — the whole
+// point of placing this check before the reservation tx.
+func TestCreateRound_AtOrOverCapBlocks_NoAICall(t *testing.T) {
+	r, db, sessions, refiner := setupDebateTestEnvWithRefiner(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(100)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	startDebate(t, r, ticket, cookie)
+	// Pre-existing spend at exactly the cap.
+	seedSpendForTicket(t, db, ticket, 100*microsPerCentDebate, time.Now().UTC())
+
+	rec := postCreateRound(t, r, ticket, cookie)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("CreateRound at cap: status = %d, want 429, body: %s", rec.Code, rec.Body.String())
+	}
+	if refiner.CallCount != 0 {
+		t.Errorf("FakeRefiner.CallCount = %d, want 0 — a blocked round must never reach the AI call", refiner.CallCount)
+	}
+	// Only the one round seeded via seedSpendForTicket must exist — no
+	// second row from a round that should never have been created.
+	if got := countRoundsForTicket(t, db, ticket); got != 1 {
+		t.Errorf("round count after blocked request = %d, want 1 (only the pre-seeded spend row)", got)
+	}
+}
+
+// TestCreateRound_CapZero_BlocksButOtherActionsStillWork is success
+// criterion 4: cap 0 blocks NEW rounds, but StartDebate itself (already
+// exercised via startDebate above) and — critically — actions that
+// don't spend money must still work. UndoRound/AcceptRound/ApproveDebate
+// need an existing round to act on, which CreateRound is specifically
+// blocked from producing; StartDebate is the one action from spec §5's
+// table this test can exercise without a chicken-and-egg problem, so it
+// re-confirms StartDebate succeeds even once the org is fully capped.
+func TestCreateRound_CapZero_BlocksButOtherActionsStillWork(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(0)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+
+	// StartDebate has no AI call and costs nothing (spec §5) — must
+	// succeed even at cap 0.
+	startDebate(t, r, ticket, cookie)
+
+	rec := postCreateRound(t, r, ticket, cookie)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("CreateRound at cap 0: status = %d, want 429, body: %s", rec.Code, rec.Body.String())
+	}
+	if got := countRoundsForTicket(t, db, ticket); got != 0 {
+		t.Errorf("round count at cap 0 = %d, want 0", got)
+	}
+}
+
+// TestCreateRound_Rollover is success criterion 7: a previous month's
+// spend must not count toward the current month's cap, and a blocked
+// org must unblock at the new month with no intervention.
+func TestCreateRound_Rollover(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(100)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	startDebate(t, r, ticket, cookie)
+
+	// All of last month's spend, well past the cap — must NOT count.
+	lastMonth := time.Now().UTC().AddDate(0, -1, 0)
+	seedSpendForTicket(t, db, ticket, 10_000*microsPerCentDebate, lastMonth)
+
+	rec := postCreateRound(t, r, ticket, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CreateRound with only prior-month spend: status = %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCreateRound_ScorerCostCountsTowardCap is success criterion 9:
+// scorer_cost_micros must count toward the aggregate even though the
+// scorer never creates a round of its own.
+func TestCreateRound_ScorerCostCountsTowardCap(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+	org := loadTicketOrg(t, db, ticket)
+	if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(100)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+	startDebate(t, r, ticket, cookie)
+
+	deb, err := db.GetActiveDebate(context.Background(), ticket.ID)
+	if err != nil {
+		t.Fatalf("GetActiveDebate: %v", err)
+	}
+	// Zero refiner cost, ALL of it scorer cost — this must still trip
+	// the cap, proving the aggregate isn't refiner-cost-only.
+	if _, err := db.Pool.Exec(context.Background(),
+		`INSERT INTO feature_debate_rounds (
+			debate_id, round_number, provider, model, triggered_by,
+			input_text, output_text, status, cost_micros, scorer_cost_micros, created_at
+		) VALUES ($1, 1, 'claude', 'claude-test', $2, 'in', 'out', 'accepted', 0, $3, now())`,
+		deb.ID, ticket.CreatedBy, 100*microsPerCentDebate,
+	); err != nil {
+		t.Fatalf("seeding scorer-cost round: %v", err)
+	}
+
+	rec := postCreateRound(t, r, ticket, cookie)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("CreateRound with scorer-only spend at cap: status = %d, want 429, body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCreateRound_RoleAppropriateWording is success criterion 8 (role
+// wording): a client sees no-AI-internals copy, an owner/admin/staff
+// sees actionable copy naming the setting.
+//
+// seedAuthedFeatureTicket makes its user the org OWNER, so the
+// client-wording case needs a direct role downgrade to 'member' rather
+// than a fresh seed (plan step 7 test-plan note).
+func TestCreateRound_RoleAppropriateWording(t *testing.T) {
+	t.Run("member sees client wording", func(t *testing.T) {
+		r, db, sessions := setupDebateTestEnv(t)
+		ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+		org := loadTicketOrg(t, db, ticket)
+		if _, err := db.Pool.Exec(context.Background(),
+			`UPDATE org_memberships SET role = 'member' WHERE user_id = $1 AND org_id = $2`,
+			ticket.CreatedBy, org.ID); err != nil {
+			t.Fatalf("downgrading role to member: %v", err)
+		}
+		if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(0)); err != nil {
+			t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+		}
+		startDebate(t, r, ticket, cookie)
+
+		rec := postCreateRound(t, r, ticket, cookie)
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("status = %d, want 429", rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, "resets at the start of next month") {
+			t.Errorf("member wording missing client-safe copy, got: %q", body)
+		}
+		if strings.Contains(body, "organization settings") {
+			t.Errorf("member wording must not tell a non-manager to change settings, got: %q", body)
+		}
+	})
+
+	t.Run("owner sees actionable wording", func(t *testing.T) {
+		r, db, sessions := setupDebateTestEnv(t)
+		ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+		org := loadTicketOrg(t, db, ticket)
+		if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(0)); err != nil {
+			t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+		}
+		startDebate(t, r, ticket, cookie)
+
+		rec := postCreateRound(t, r, ticket, cookie)
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("status = %d, want 429", rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, "organization settings") {
+			t.Errorf("owner wording should point at organization settings, got: %q", body)
+		}
+	})
+
+	t.Run("staff sees actionable wording on a foreign org", func(t *testing.T) {
+		r, db, sessions := setupDebateTestEnv(t)
+		ticket, _ := seedAuthedFeatureTicket(t, db, sessions)
+		org := loadTicketOrg(t, db, ticket)
+		if err := db.UpdateOrgMonthlyBudget(context.Background(), org.ID, ticket.CreatedBy, int64PtrDebate(0)); err != nil {
+			t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+		}
+
+		staffHash, _ := auth.HashPassword("TestPassword123!")
+		staffUser, err := db.CreateUser(context.Background(), "staff-wording@example.com", staffHash, "Staff", "staff")
+		if err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		if _, err := db.Pool.Exec(context.Background(),
+			`UPDATE users SET must_setup_2fa = false WHERE id = $1`, staffUser.ID); err != nil {
+			t.Fatalf("clearing must_setup_2fa: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+		token, err := sessions.CreateSession(context.Background(), staffUser.ID, false, req)
+		if err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		sess, err := sessions.GetSession(context.Background(), token)
+		if err != nil {
+			t.Fatalf("GetSession: %v", err)
+		}
+		if err := sessions.MarkTwoFactorVerified(context.Background(), sess.ID); err != nil {
+			t.Fatalf("MarkTwoFactorVerified: %v", err)
+		}
+		if err := sessions.SetSelectedOrg(context.Background(), sess.ID, org.ID); err != nil {
+			t.Fatalf("SetSelectedOrg: %v", err)
+		}
+		staffCookie := &http.Cookie{Name: auth.SessionCookieName, Value: token, HttpOnly: true, Secure: true}
+
+		startDebate(t, r, ticket, staffCookie)
+		rec := postCreateRound(t, r, ticket, staffCookie)
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("status = %d, want 429, body: %s", rec.Code, rec.Body.String())
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, "organization settings") {
+			t.Errorf("staff wording should point at organization settings, got: %q", body)
+		}
+	})
+}

--- a/internal/handlers/debate_budget_test.go
+++ b/internal/handlers/debate_budget_test.go
@@ -480,9 +480,9 @@ func TestCreateRound_RoleAppropriateWording(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CreateUser: %v", err)
 		}
-		if _, err := db.Pool.Exec(context.Background(),
-			`UPDATE users SET must_setup_2fa = false WHERE id = $1`, staffUser.ID); err != nil {
-			t.Fatalf("clearing must_setup_2fa: %v", err)
+		if _, execErr := db.Pool.Exec(context.Background(),
+			`UPDATE users SET must_setup_2fa = false WHERE id = $1`, staffUser.ID); execErr != nil {
+			t.Fatalf("clearing must_setup_2fa: %v", execErr)
 		}
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		token, err := sessions.CreateSession(context.Background(), staffUser.ID, false, req)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -86,6 +86,7 @@ func setupTestRouter(t *testing.T) (*chi.Mux, *models.DB, *auth.SessionStore, *r
 		r.Get("/orgs/{orgSlug}", orgH.OrgPage)
 		r.Get("/orgs/{orgSlug}/settings", orgH.OrgSettings)
 		r.Post("/orgs/{orgSlug}/settings/business", orgH.UpdateBusinessDetails)
+		r.Post("/orgs/{orgSlug}/settings/budget", orgH.UpdateMonthlyBudget)
 		r.Post("/orgs/{orgSlug}/invitations", orgH.InviteMember)
 		r.Delete("/orgs/{orgSlug}/invitations/{invitationID}", inviteH.RevokeInvitation)
 		r.Post("/orgs/{orgSlug}/projects", projH.CreateProject)

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -263,7 +263,14 @@ func (h *OrgHandler) buildBudgetSettingsFields(r *http.Request, org *models.Orga
 	} else {
 		// micros -> cents, half-up: (micros+5000)/10000. microsPerCent is
 		// 10_000, so half a cent is 5_000 micros.
-		spendCents := (spendMicros + 5000) / 10000
+		// Quotient/remainder rather than (micros+5000)/10000: the additive
+		// form overflows int64 for an aggregate near MaxInt64 and would
+		// render a negative amount. Unreachable at real spend, but a
+		// display path should not be the thing that wraps.
+		spendCents := spendMicros / 10000
+		if spendMicros%10000 >= 5000 {
+			spendCents++
+		}
 		fields.BudgetSpendDisplay = "$" + formatUSDCents(spendCents) + " USD"
 	}
 
@@ -606,7 +613,7 @@ func (h *OrgHandler) UpdateMonthlyBudget(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	raw := r.FormValue("monthly_budget_cents")
+	raw := r.FormValue("monthly_budget_usd")
 	var capCents *int64
 	if trimmed := strings.TrimSpace(raw); trimmed != "" {
 		cents, parseErr := parseUSDCents(trimmed)
@@ -794,8 +801,16 @@ func parseUSDCents(s string) (int64, error) {
 // "-0.05" — this guard exists to catch that class of bug rather than
 // display a malformed figure.
 func formatUSDCents(cents int64) string {
+	// Negatives should never reach here — spend and caps are both
+	// non-negative by construction. Handle them anyway because the naive
+	// form renders -5 cents as "0.-5": %02d of a negative remainder keeps
+	// the sign. Formatting the magnitude and prefixing the sign is the
+	// only version that cannot emit garbage.
+	sign := ""
+	abs := cents
 	if cents < 0 {
-		return "-" + formatUSDCents(-cents)
+		sign = "-"
+		abs = -cents
 	}
-	return fmt.Sprintf("%d.%02d", cents/100, cents%100)
+	return fmt.Sprintf("%s%d.%02d", sign, abs/100, abs%100)
 }

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -181,6 +181,12 @@ func (h *OrgHandler) OrgSettings(w http.ResponseWriter, r *http.Request) {
 
 	invitations, _ := h.db.ListOrgInvitations(r.Context(), org.ID)
 
+	// Capture `now` ONCE and derive both the aggregate range and the
+	// displayed month label from it, so the two can never disagree
+	// across a midnight boundary between computing one and the other.
+	now := time.Now()
+	budgetFields := h.buildBudgetSettingsFields(r, org, now)
+
 	_ = h.engine.Render(w, r, "org_settings.html", render.PageData{
 		Title:       org.Name + " Settings",
 		User:        user,
@@ -188,15 +194,91 @@ func (h *OrgHandler) OrgSettings(w http.ResponseWriter, r *http.Request) {
 		Orgs:        middleware.GetOrgs(r),
 		Projects:    middleware.GetProjects(r),
 		CurrentPath: r.URL.Path,
-		Data: map[string]any{
+		Data: mergeMap(map[string]any{
 			"Members":       members,
 			"Invitations":   invitations,
 			"CanManage":     canManage,
 			"IsStaff":       auth.IsStaffOrAbove(user.Role),
 			"CurrentUserID": user.ID,
 			"OrgSlug":       org.Slug,
-		},
+		}, budgetFields),
 	})
+}
+
+// mergeMap combines two string-keyed maps into one new map (b's keys win
+// on conflict, though none are expected to overlap here). Kept tiny and
+// local rather than pulling in a generic "maps" helper package for a
+// single call site.
+func mergeMap(a, b map[string]any) map[string]any {
+	out := make(map[string]any, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+
+// budgetSettingsFields carries every Go-computed value the budget card
+// template needs. All money is pre-formatted as strings here so the
+// template never does float arithmetic or a new FuncMap entry (spec §6
+// forbids float on a money control).
+type budgetSettingsFields struct {
+	CanViewBudget          bool
+	BudgetIsUnlimited      bool
+	BudgetCapInput         string // value= for the <input>, empty when unlimited
+	BudgetCapDisplay       string // human "Unlimited" or "$X.XX"
+	BudgetSpendDisplay     string // "$X.XX" or "" when unavailable
+	BudgetSpendUnavailable bool
+	BudgetMonth            string // e.g. "August 2026"
+}
+
+// buildBudgetSettingsFields computes the budget card's display data.
+// Any org member (or staff) who reached OrgSettings at all may VIEW this
+// — the costs page is already member-visible and already shows debate
+// spend inside infraTotal, so this exposes no new granularity (spec §6).
+//
+// An aggregate failure here is NOT fatal to the page (unlike the
+// enforcement path in checkOrgBudget, which fails closed) — showing a
+// dash for spend is harmless; treating unknown spend as zero at the
+// enforcement gate is not. These two paths deliberately diverge.
+func (h *OrgHandler) buildBudgetSettingsFields(r *http.Request, org *models.Organization, now time.Time) map[string]any {
+	from, to := models.CurrentUTCMonthRange(now)
+
+	fields := budgetSettingsFields{
+		CanViewBudget: true,
+		BudgetMonth:   now.UTC().Format("January 2006"),
+	}
+
+	if org.MonthlyBudgetCents == nil {
+		fields.BudgetIsUnlimited = true
+		fields.BudgetCapDisplay = "Unlimited"
+	} else {
+		fields.BudgetCapInput = formatUSDCents(*org.MonthlyBudgetCents)
+		fields.BudgetCapDisplay = "$" + formatUSDCents(*org.MonthlyBudgetCents) + " USD"
+	}
+
+	spendMicros, err := h.db.SumOrgDebateSpendMicros(r.Context(), org.ID, from, to)
+	if err != nil {
+		log.Printf("org settings: summing debate spend for org %s: %v", org.ID, err)
+		fields.BudgetSpendUnavailable = true
+	} else {
+		// micros -> cents, half-up: (micros+5000)/10000. microsPerCent is
+		// 10_000, so half a cent is 5_000 micros.
+		spendCents := (spendMicros + 5000) / 10000
+		fields.BudgetSpendDisplay = "$" + formatUSDCents(spendCents) + " USD"
+	}
+
+	return map[string]any{
+		"CanViewBudget":          fields.CanViewBudget,
+		"BudgetIsUnlimited":      fields.BudgetIsUnlimited,
+		"BudgetCapInput":         fields.BudgetCapInput,
+		"BudgetCapDisplay":       fields.BudgetCapDisplay,
+		"BudgetSpendDisplay":     fields.BudgetSpendDisplay,
+		"BudgetSpendUnavailable": fields.BudgetSpendUnavailable,
+		"BudgetMonth":            fields.BudgetMonth,
+	}
 }
 
 // canManageOrgMembers checks if the current user has permission to manage members of the given org.

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"regexp"
 	"slices"
@@ -207,16 +208,12 @@ func (h *OrgHandler) OrgSettings(w http.ResponseWriter, r *http.Request) {
 
 // mergeMap combines two string-keyed maps into one new map (b's keys win
 // on conflict, though none are expected to overlap here). Kept tiny and
-// local rather than pulling in a generic "maps" helper package for a
-// single call site.
+// local rather than pulling in a third-party helper for a single call
+// site; stdlib maps.Copy does the actual copying.
 func mergeMap(a, b map[string]any) map[string]any {
 	out := make(map[string]any, len(a)+len(b))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		out[k] = v
-	}
+	maps.Copy(out, a)
+	maps.Copy(out, b)
 	return out
 }
 
@@ -718,7 +715,7 @@ const maxBudgetCentsInput = maxBudgetDollars * 100
 // like ',' or 'e' as a unit — it stops at the first invalid rune, which
 // would silently truncate rather than reject.
 func isAllASCIIDigits(s string) bool {
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		if s[i] < '0' || s[i] > '9' {
 			return false
 		}

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/madalin/forgedesk/internal/auth"
 	"github.com/madalin/forgedesk/internal/mail"
 	"github.com/madalin/forgedesk/internal/middleware"
@@ -488,6 +490,79 @@ func (h *OrgHandler) UpdateBusinessDetails(w http.ResponseWriter, r *http.Reques
 	); err != nil {
 		log.Printf("updating business details: %v", err)
 		http.Error(w, "Failed to update business details", http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/orgs/"+slug+"/settings", http.StatusSeeOther)
+}
+
+// UpdateMonthlyBudget sets or clears an org's monthly AI debate budget
+// cap (spec §6, plan step 5). NOT staff-only, unlike UpdateAIMargin: the
+// budget is the client's own spend control, so org owner/admin may set
+// it for their own org. Staff/superadmin may set it for ANY org,
+// consistent with the margin precedent.
+//
+// The org is derived from the route slug ONLY — no org_id form field is
+// read, so there is nothing for a cross-org request to substitute.
+func (h *OrgHandler) UpdateMonthlyBudget(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	slug := r.PathValue("orgSlug")
+
+	// Distinct 404 (unknown slug) vs 500 (real DB failure) — UpdateAIMargin
+	// collapses these into one branch; that is a known gap, not the
+	// pattern to copy (plan step 5).
+	org, err := h.db.GetOrgBySlug(r.Context(), slug)
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "Organization not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Printf("looking up org %q for budget update: %v", slug, err)
+		http.Error(w, "Failed to load organization", http.StatusInternalServerError)
+		return
+	}
+
+	if !h.canManageOrgMembers(r, user, org.ID) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	raw := r.FormValue("monthly_budget_cents")
+	var capCents *int64
+	if trimmed := strings.TrimSpace(raw); trimmed != "" {
+		cents, parseErr := parseUSDCents(trimmed)
+		switch {
+		case errors.Is(parseErr, errBudgetTooManyDecimals):
+			http.Error(w, errBudgetTooManyDecimals.Error(), http.StatusBadRequest)
+			return
+		case errors.Is(parseErr, errBudgetOutOfRange):
+			http.Error(w, errBudgetOutOfRange.Error(), http.StatusBadRequest)
+			return
+		case parseErr != nil:
+			http.Error(w, errBudgetNotANumber.Error(), http.StatusBadRequest)
+			return
+		}
+		capCents = &cents
+	}
+	// Empty field (raw == "" after trim) leaves capCents nil — "leave
+	// blank for unlimited" per the helper text in the settings card.
+
+	switch err := h.db.UpdateOrgMonthlyBudget(r.Context(), org.ID, user.ID, capCents); {
+	case err == nil:
+		capDesc := "unlimited"
+		if capCents != nil {
+			capDesc = strconv.FormatInt(*capCents, 10) + " cents"
+		}
+		log.Printf("org %s monthly budget updated by user %s: %s", org.ID, user.ID, capDesc)
+	case errors.Is(err, models.ErrOrgNotFound):
+		// The org existed at the GetOrgBySlug above but was deleted
+		// before this write reached it — genuinely rare, but distinct
+		// from the parse-validation 400s above and from a generic 500.
+		http.Error(w, "Organization not found", http.StatusNotFound)
+		return
+	default:
+		log.Printf("updating monthly budget for org %s: %v", org.ID, err)
+		http.Error(w, "Failed to update budget", http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"regexp"
@@ -527,4 +528,120 @@ func (h *OrgHandler) UpdateCurrency(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, "/orgs/"+slug+"/settings", http.StatusSeeOther)
+}
+
+// Distinct sentinels so the set-budget handler can return distinct 400s
+// per failure mode, matching this repo's convention of never collapsing
+// DB-error / not-found / validation-failure into a single branch.
+var (
+	errBudgetNotANumber      = errors.New("that doesn't look like a dollar amount — use a plain number like 25 or 25.50")
+	errBudgetTooManyDecimals = errors.New("use at most two decimal places")
+	errBudgetOutOfRange      = errors.New("amount is too large — the maximum is $1,000,000")
+)
+
+// maxBudgetDollars mirrors models.maxBudgetCents (100_000_000 cents =
+// USD 1,000,000), expressed as whole dollars. Checked BEFORE multiplying
+// by 100 (spec §6): a caller supplying a huge but syntactically valid
+// dollar figure must be rejected by comparison, not by letting
+// dollars*100 run first and hoping it doesn't overflow.
+const maxBudgetDollars = 1_000_000
+
+// maxBudgetCentsInput is the cents-side twin of maxBudgetDollars, used
+// for the final range check after the fractional part is folded in
+// (e.g. "1000000.01" passes the whole-dollar check but must still be
+// rejected). Duplicated from models.maxBudgetCents rather than
+// exported/shared — it is a parsing-layer constant, not a persistence
+// one, and the two are independently pinned by tests on both sides.
+const maxBudgetCentsInput = maxBudgetDollars * 100
+
+// isAllASCIIDigits reports whether every byte in s is '0'-'9'. Used to
+// validate the lexical grammar BEFORE handing substrings to ParseInt:
+// ParseInt alone would accept a leading '+' (letting "+25" through a
+// grammar that declares it invalid) and doesn't reject non-digit bytes
+// like ',' or 'e' as a unit — it stops at the first invalid rune, which
+// would silently truncate rather than reject.
+func isAllASCIIDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseUSDCents converts a decimal USD string to integer cents without
+// any floating point (spec §6 forbids float arithmetic on a money
+// control — ParseFloat+Round, as costs.go's parseToCents uses, silently
+// accepts scientific notation ("1e3") and NaN/Inf, and rounds instead of
+// rejecting a third decimal place). Accepts an optional leading '$' and
+// surrounding whitespace; otherwise the trimmed string must match
+// ^\d+(\.\d{1,2})?$.
+func parseUSDCents(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "$")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, errBudgetNotANumber
+	}
+
+	dollarsStr, fracStr, hasDot := strings.Cut(s, ".")
+	if dollarsStr == "" || !isAllASCIIDigits(dollarsStr) {
+		return 0, errBudgetNotANumber
+	}
+	if hasDot {
+		if fracStr == "" || !isAllASCIIDigits(fracStr) {
+			return 0, errBudgetNotANumber
+		}
+		if len(fracStr) > 2 {
+			return 0, errBudgetTooManyDecimals
+		}
+	}
+
+	dollars, err := strconv.ParseInt(dollarsStr, 10, 64)
+	if err != nil {
+		// Only reachable for a dollar string ParseInt itself can't hold
+		// (e.g. more digits than fit in int64) — isAllASCIIDigits already
+		// rejected every other malformed shape.
+		return 0, errBudgetNotANumber
+	}
+	if dollars > maxBudgetDollars {
+		return 0, errBudgetOutOfRange
+	}
+
+	// Right-pad the fraction to exactly 2 digits ("5" -> "50") so e.g.
+	// "25.5" and "25.50" both parse to 2550 cents.
+	frac := fracStr
+	for len(frac) < 2 {
+		frac += "0"
+	}
+	var fracCents int64
+	if frac != "" {
+		fracCents, err = strconv.ParseInt(frac, 10, 64)
+		if err != nil {
+			return 0, errBudgetNotANumber
+		}
+	}
+
+	// dollars <= maxBudgetDollars here, so dollars*100 cannot overflow;
+	// fracCents is at most 99. The final bound check below still catches
+	// e.g. "1000000.01", which passed the whole-dollar check above but
+	// pushes the total over the cap once the cents are folded in.
+	cents := dollars*100 + fracCents
+	if cents > maxBudgetCentsInput {
+		return 0, errBudgetOutOfRange
+	}
+	return cents, nil
+}
+
+// formatUSDCents renders integer cents as a plain decimal string for
+// display/pre-fill ("2550" -> "25.50"). Callers should never pass a
+// negative value (the setter and DB CHECK both reject them before
+// persistence), but %02d of a negative remainder renders "0.-5", not
+// "-0.05" — this guard exists to catch that class of bug rather than
+// display a malformed figure.
+func formatUSDCents(cents int64) string {
+	if cents < 0 {
+		return "-" + formatUSDCents(-cents)
+	}
+	return fmt.Sprintf("%d.%02d", cents/100, cents%100)
 }

--- a/internal/handlers/orgs_budget_test.go
+++ b/internal/handlers/orgs_budget_test.go
@@ -91,6 +91,8 @@ func TestFormatUSDCents(t *testing.T) {
 	}
 }
 
+func int64Ptr(v int64) *int64 { return &v }
+
 // seedBudgetTestOrg creates an org and returns its slug/ID plus a
 // membership-role setter so each role-matrix case can attach a fresh
 // user at the exact role under test without cross-contaminating others.
@@ -272,5 +274,122 @@ func TestUpdateMonthlyBudget_UnknownOrg(t *testing.T) {
 	rec := postBudget(t, r, cookie, "no-such-org-at-all", "10.00")
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("unknown org slug: status = %d, want 404", rec.Code)
+	}
+}
+
+// TestOrgSettingsPage_BudgetCard_MemberSeesReadOnly proves the budget
+// card is visible to a plain member (spec §6 — "any org member sees
+// their own org's cap and current spend") but the SET form is not,
+// unlike the staff-only margin card which a member never sees any part
+// of.
+func TestOrgSettingsPage_BudgetCard_MemberSeesReadOnly(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa6@test.com", "superadmin")
+	org := seedBudgetTestOrg(t, db, "Card Member Org", "card-member-org")
+
+	cookie := createAuthenticatedUser(t, db, sessions, "card-member@test.com", "client")
+	var userID string
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'card-member@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up user: %v", err)
+	}
+	if err := db.AddOrgMember(ctx, userID, org.ID, "member"); err != nil {
+		t.Fatalf("AddOrgMember: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/"+org.Slug+"/settings", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET org settings: got %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Monthly AI Budget") {
+		t.Error("member should see the budget card")
+	}
+	if strings.Contains(body, `name="monthly_budget_cents"`) {
+		t.Error("member should NOT see the budget-setting form (read-only view only)")
+	}
+	if !strings.Contains(body, "Unlimited") {
+		t.Error("a fresh org has no cap set, so the card should read as unlimited")
+	}
+}
+
+// TestOrgSettingsPage_BudgetCard_OwnerSeesForm proves an owner (who CAN
+// manage the org) sees the actual input form, not just the read-only
+// figures.
+func TestOrgSettingsPage_BudgetCard_OwnerSeesForm(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa7@test.com", "superadmin")
+	org := seedBudgetTestOrg(t, db, "Card Owner Org", "card-owner-org")
+
+	cookie := createAuthenticatedUser(t, db, sessions, "card-owner@test.com", "client")
+	var userID string
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'card-owner@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up user: %v", err)
+	}
+	if err := db.AddOrgMember(ctx, userID, org.ID, "owner"); err != nil {
+		t.Fatalf("AddOrgMember: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/"+org.Slug+"/settings", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET org settings: got %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `name="monthly_budget_cents"`) {
+		t.Error("owner should see the budget-setting form")
+	}
+	if !strings.Contains(body, "USD") {
+		t.Error("budget card must label the figure USD explicitly, never the org's display currency")
+	}
+}
+
+// TestOrgSettingsPage_BudgetCard_ShowsSetCapAndSpend proves a set cap
+// renders as a dollar figure (not raw cents) and the card shows a
+// current-spend figure derived in Go, not a template float.
+func TestOrgSettingsPage_BudgetCard_ShowsSetCapAndSpend(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa8@test.com", "superadmin")
+	org := seedBudgetTestOrg(t, db, "Card Cap Org", "card-cap-org")
+
+	cookie := createAuthenticatedUser(t, db, sessions, "card-cap-owner@test.com", "client")
+	var userID string
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'card-cap-owner@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up user: %v", err)
+	}
+	if err := db.AddOrgMember(ctx, userID, org.ID, "owner"); err != nil {
+		t.Fatalf("AddOrgMember: %v", err)
+	}
+	if err := db.UpdateOrgMonthlyBudget(ctx, org.ID, userID, int64Ptr(12345)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/"+org.Slug+"/settings", http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET org settings: got %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "123.45") {
+		t.Errorf("expected cap 12345 cents to render as 123.45, body:\n%s", body)
+	}
+	// No rounds exist yet, so spend should render as 0.00, not "unavailable".
+	if !strings.Contains(body, "0.00") {
+		t.Error("expected zero current-month spend to render as 0.00")
 	}
 }

--- a/internal/handlers/orgs_budget_test.go
+++ b/internal/handlers/orgs_budget_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestParseUSDCents covers the accept/reject grammar from the plan's
+// test matrix. parseUSDCents deliberately does NOT reuse costs.go's
+// parseToCents: that helper uses ParseFloat + math.Round, which silently
+// accepts scientific notation / NaN / Inf and rounds instead of
+// rejecting extra decimal places — wrong for a money control per spec §6.
+func TestParseUSDCents(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr error
+	}{
+		{"zero", "0", 0, nil},
+		{"whole dollars", "25", 2500, nil},
+		{"one decimal", "25.5", 2550, nil},
+		{"two decimals", "25.50", 2550, nil},
+		{"leading dollar sign", "$25.00", 2500, nil},
+		{"surrounding whitespace", " 25.00 ", 2500, nil},
+		{"at the max bound", "1000000", 100_000_000, nil},
+
+		{"empty string", "", 0, errBudgetNotANumber},
+		{"negative", "-1", 0, errBudgetNotANumber},
+		{"three decimals rejected not rounded", "25.555", 0, errBudgetTooManyDecimals},
+		{"scientific notation rejected", "1e3", 0, errBudgetNotANumber},
+		{"non-numeric", "abc", 0, errBudgetNotANumber},
+		{"thousands separator rejected", "1,000", 0, errBudgetNotANumber},
+		{"NaN literal rejected", "NaN", 0, errBudgetNotANumber},
+		{"Inf literal rejected", "Inf", 0, errBudgetNotANumber},
+		{"over the max bound", "1000000.01", 0, errBudgetOutOfRange},
+		{"trailing dot with no digits", "25.", 0, errBudgetNotANumber},
+		{"leading dot with no whole part", ".50", 0, errBudgetNotANumber},
+		{"leading plus rejected", "+25", 0, errBudgetNotANumber},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseUSDCents(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("parseUSDCents(%q) err = %v, want %v", tc.input, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseUSDCents(%q) unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseUSDCents(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatUSDCents(t *testing.T) {
+	tests := []struct {
+		cents int64
+		want  string
+	}{
+		{0, "0.00"},
+		{5, "0.05"},
+		{2500, "25.00"},
+		{2550, "25.50"},
+		{100_000_000, "1000000.00"},
+		// Negative input should never happen (callers only ever format a
+		// validated non-negative cap), but %02d of a negative remainder
+		// renders "0.-5" rather than "-0.05" if unguarded — this is a
+		// bug-catcher, not an expected code path.
+		{-5, "-0.05"},
+	}
+	for _, tc := range tests {
+		got := formatUSDCents(tc.cents)
+		if got != tc.want {
+			t.Errorf("formatUSDCents(%d) = %q, want %q", tc.cents, got, tc.want)
+		}
+	}
+}

--- a/internal/handlers/orgs_budget_test.go
+++ b/internal/handlers/orgs_budget_test.go
@@ -107,7 +107,7 @@ func seedBudgetTestOrg(t *testing.T, db *models.DB, name, slug string) *models.O
 
 func postBudget(t *testing.T, r *chi.Mux, cookie *http.Cookie, slug, amount string) *httptest.ResponseRecorder {
 	t.Helper()
-	form := url.Values{"monthly_budget_cents": {amount}}
+	form := url.Values{"monthly_budget_usd": {amount}}
 	req := httptest.NewRequest(http.MethodPost, "/orgs/"+slug+"/settings/budget", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if cookie != nil {
@@ -313,7 +313,7 @@ func TestOrgSettingsPage_BudgetCard_MemberSeesReadOnly(t *testing.T) {
 	if !strings.Contains(body, "Monthly AI Budget") {
 		t.Error("member should see the budget card")
 	}
-	if strings.Contains(body, `name="monthly_budget_cents"`) {
+	if strings.Contains(body, `name="monthly_budget_usd"`) {
 		t.Error("member should NOT see the budget-setting form (read-only view only)")
 	}
 	if !strings.Contains(body, "Unlimited") {
@@ -349,7 +349,7 @@ func TestOrgSettingsPage_BudgetCard_OwnerSeesForm(t *testing.T) {
 		t.Fatalf("GET org settings: got %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, `name="monthly_budget_cents"`) {
+	if !strings.Contains(body, `name="monthly_budget_usd"`) {
 		t.Error("owner should see the budget-setting form")
 	}
 	if !strings.Contains(body, "USD") {

--- a/internal/handlers/orgs_budget_test.go
+++ b/internal/handlers/orgs_budget_test.go
@@ -1,8 +1,17 @@
 package handlers
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/madalin/forgedesk/internal/models"
 )
 
 // TestParseUSDCents covers the accept/reject grammar from the plan's
@@ -79,5 +88,189 @@ func TestFormatUSDCents(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("formatUSDCents(%d) = %q, want %q", tc.cents, got, tc.want)
 		}
+	}
+}
+
+// seedBudgetTestOrg creates an org and returns its slug/ID plus a
+// membership-role setter so each role-matrix case can attach a fresh
+// user at the exact role under test without cross-contaminating others.
+func seedBudgetTestOrg(t *testing.T, db *models.DB, name, slug string) *models.Organization {
+	t.Helper()
+	org, err := db.CreateOrg(context.Background(), name, slug)
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	return org
+}
+
+func postBudget(t *testing.T, r *chi.Mux, cookie *http.Cookie, slug, amount string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"monthly_budget_cents": {amount}}
+	req := httptest.NewRequest(http.MethodPost, "/orgs/"+slug+"/settings/budget", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestUpdateMonthlyBudget_RoleMatrix exercises every role this endpoint
+// treats differently, through the real router (not a direct handler
+// call) so routing/middleware wiring is also under test. Unlike
+// UpdateAIMargin, this endpoint is NOT staff-only (spec §6) — it is the
+// client's own spend control.
+func TestUpdateMonthlyBudget_RoleMatrix(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	// First registered user is auto-promoted to superadmin — burn that
+	// slot on a throwaway account so later role assertions are exact.
+	createAuthenticatedUser(t, db, sessions, "first-sa@test.com", "superadmin")
+
+	org := seedBudgetTestOrg(t, db, "Role Matrix Org", "role-matrix-org")
+
+	tests := []struct {
+		name       string
+		email      string
+		platform   string // platform (global) role
+		orgRole    string // "" = not a member at all
+		wantStatus int
+	}{
+		{"member cannot set", "member@test.com", "client", "member", http.StatusForbidden},
+		{"owner can set", "owner@test.com", "client", "owner", http.StatusSeeOther},
+		{"admin can set", "admin@test.com", "client", "admin", http.StatusSeeOther},
+		{"staff on foreign org can set", "staff@test.com", "staff", "", http.StatusSeeOther},
+		{"non-member cannot set", "outsider@test.com", "client", "", http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cookie := createAuthenticatedUser(t, db, sessions, tc.email, tc.platform)
+			if tc.orgRole != "" {
+				var userID string
+				if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = $1`, tc.email).Scan(&userID); err != nil {
+					t.Fatalf("look up user: %v", err)
+				}
+				if err := db.AddOrgMember(ctx, userID, org.ID, tc.orgRole); err != nil {
+					t.Fatalf("AddOrgMember: %v", err)
+				}
+			}
+
+			rec := postBudget(t, r, cookie, org.Slug, "10.00")
+			if rec.Code != tc.wantStatus {
+				t.Errorf("%s: status = %d, want %d (body: %s)", tc.name, rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestUpdateMonthlyBudget_CrossOrgSubstitution proves the org is derived
+// ONLY from the trusted route slug: a member of org A must not be able
+// to set org B's budget by any means (there is no org_id form field to
+// even attempt this with, but the test pins the outcome regardless).
+func TestUpdateMonthlyBudget_CrossOrgSubstitution(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa2@test.com", "superadmin")
+
+	orgA := seedBudgetTestOrg(t, db, "Org A", "cross-org-a")
+	orgB := seedBudgetTestOrg(t, db, "Org B", "cross-org-b")
+
+	cookie := createAuthenticatedUser(t, db, sessions, "member-a@test.com", "client")
+	var userID string
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'member-a@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up user: %v", err)
+	}
+	if err := db.AddOrgMember(ctx, userID, orgA.ID, "owner"); err != nil {
+		t.Fatalf("AddOrgMember: %v", err)
+	}
+
+	rec := postBudget(t, r, cookie, orgB.Slug, "10.00")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("member of org A posting to org B's budget: status = %d, want 403", rec.Code)
+	}
+
+	orgBAfter, err := db.GetOrgByID(ctx, orgB.ID)
+	if err != nil {
+		t.Fatalf("GetOrgByID: %v", err)
+	}
+	if orgBAfter.MonthlyBudgetCents != nil {
+		t.Errorf("org B's budget was set to %v despite the 403 — cross-tenant write succeeded", orgBAfter.MonthlyBudgetCents)
+	}
+}
+
+// TestUpdateMonthlyBudget_EmptyClears proves an empty field maps to
+// NULL (unlimited), not to a parse error or a stored 0.
+func TestUpdateMonthlyBudget_EmptyClears(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa3@test.com", "superadmin")
+	org := seedBudgetTestOrg(t, db, "Empty Clears Org", "empty-clears-org")
+
+	cookie := createAuthenticatedUser(t, db, sessions, "owner-clear@test.com", "client")
+	var userID string
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'owner-clear@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up user: %v", err)
+	}
+	if err := db.AddOrgMember(ctx, userID, org.ID, "owner"); err != nil {
+		t.Fatalf("AddOrgMember: %v", err)
+	}
+
+	// Set first, so clearing is a real transition rather than a no-op.
+	if rec := postBudget(t, r, cookie, org.Slug, "50.00"); rec.Code != http.StatusSeeOther {
+		t.Fatalf("initial set: status = %d, want 303", rec.Code)
+	}
+	if rec := postBudget(t, r, cookie, org.Slug, ""); rec.Code != http.StatusSeeOther {
+		t.Fatalf("clear: status = %d, want 303, body: %s", rec.Code, rec.Body.String())
+	}
+
+	org2, err := db.GetOrgByID(ctx, org.ID)
+	if err != nil {
+		t.Fatalf("GetOrgByID: %v", err)
+	}
+	if org2.MonthlyBudgetCents != nil {
+		t.Errorf("MonthlyBudgetCents after empty submit = %v, want nil", org2.MonthlyBudgetCents)
+	}
+}
+
+// TestUpdateMonthlyBudget_InvalidAmountRejected proves a malformed
+// amount is a 400, not silently coerced or a 500.
+func TestUpdateMonthlyBudget_InvalidAmountRejected(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa4@test.com", "superadmin")
+	org := seedBudgetTestOrg(t, db, "Invalid Amount Org", "invalid-amount-org")
+
+	cookie := createAuthenticatedUser(t, db, sessions, "owner-invalid@test.com", "client")
+	var userID string
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'owner-invalid@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up user: %v", err)
+	}
+	if err := db.AddOrgMember(ctx, userID, org.ID, "owner"); err != nil {
+		t.Fatalf("AddOrgMember: %v", err)
+	}
+
+	rec := postBudget(t, r, cookie, org.Slug, "not-a-number")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid amount: status = %d, want 400", rec.Code)
+	}
+}
+
+// TestUpdateMonthlyBudget_UnknownOrg404sDistinctFromDBError pins that
+// UpdateAIMargin's known bug (collapsing not-found and infra-error into
+// one branch) is NOT copied here (plan step 5).
+func TestUpdateMonthlyBudget_UnknownOrg(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+
+	cookie := createAuthenticatedUser(t, db, sessions, "first-sa5@test.com", "superadmin")
+
+	rec := postBudget(t, r, cookie, "no-such-org-at-all", "10.00")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown org slug: status = %d, want 404", rec.Code)
 	}
 }

--- a/internal/handlers/orgs_budget_test.go
+++ b/internal/handlers/orgs_budget_test.go
@@ -149,7 +149,10 @@ func TestUpdateMonthlyBudget_RoleMatrix(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cookie := createAuthenticatedUser(t, db, sessions, tc.email, tc.platform)
+			// createAuthenticatedUser is a shared test helper that creates
+			// its own background context; threading the table-test ctx
+			// through it would change a signature used by ~40 other tests.
+			cookie := createAuthenticatedUser(t, db, sessions, tc.email, tc.platform) //nolint:contextcheck // shared helper manages its own ctx
 			if tc.orgRole != "" {
 				var userID string
 				if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = $1`, tc.email).Scan(&userID); err != nil {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -35,6 +35,9 @@ type Organization struct {
 	ContactEmails      string    `db:"contact_emails"`
 	Slug               string    `db:"slug"`
 	AIMarginPercent    int       `db:"ai_margin_percent"`
+	// MonthlyBudgetCents is USD cents; nil = unlimited. See migration
+	// 000035 and docs/superpowers/specs/2026-08-20-org-monthly-budget-design.md.
+	MonthlyBudgetCents *int64 `db:"monthly_budget_cents"`
 }
 
 type OrgMembership struct {

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -822,7 +822,7 @@ func (db *DB) UpdateOrgCurrency(ctx context.Context, orgID, currencyCode string)
 var ErrOrgNotFound = errors.New("organization not found")
 
 // ErrBudgetOutOfRange is returned by UpdateOrgMonthlyBudget when capCents
-// exceeds maxBudgetCents. The handler's parser already rejects this, but
+// is negative or exceeds maxBudgetCents. The handler's parser already rejects this, but
 // a future or internal caller that bypasses the handler must not be able
 // to persist a value that overflows cap*microsPerCent at comparison time
 // (spec §6). The DB CHECK only guards the negative direction.
@@ -841,7 +841,10 @@ const maxBudgetCents = 100_000_000
 // not survive either — a silent, unrecorded budget change is exactly
 // the failure mode spec §8 exists to prevent.
 func (db *DB) UpdateOrgMonthlyBudget(ctx context.Context, orgID, actorUserID string, capCents *int64) error {
-	if capCents != nil && *capCents > maxBudgetCents {
+	// Both directions, and with a distinct sentinel: a negative cap would
+	// otherwise reach the DB and come back as an opaque constraint
+	// violation, which the handler cannot tell apart from an infra fault.
+	if capCents != nil && (*capCents < 0 || *capCents > maxBudgetCents) {
 		return ErrBudgetOutOfRange
 	}
 

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -815,6 +815,76 @@ func (db *DB) UpdateOrgCurrency(ctx context.Context, orgID, currencyCode string)
 	return nil
 }
 
+// ErrOrgNotFound is returned by UpdateOrgMonthlyBudget when the org row
+// doesn't exist (or was deleted between the caller's lookup and this
+// call) — distinct from a generic DB failure so the handler can 404
+// instead of 500.
+var ErrOrgNotFound = errors.New("organization not found")
+
+// ErrBudgetOutOfRange is returned by UpdateOrgMonthlyBudget when capCents
+// exceeds maxBudgetCents. The handler's parser already rejects this, but
+// a future or internal caller that bypasses the handler must not be able
+// to persist a value that overflows cap*microsPerCent at comparison time
+// (spec §6). The DB CHECK only guards the negative direction.
+var ErrBudgetOutOfRange = errors.New("monthly budget out of range")
+
+// maxBudgetCents is USD 1,000,000 in cents. Chosen so maxBudgetCents *
+// microsPerCent (10_000) is nowhere near int64 overflow (1e12 vs ~9.2e18).
+const maxBudgetCents = 100_000_000
+
+// UpdateOrgMonthlyBudget sets (non-nil) or clears (nil) an org's monthly
+// AI debate budget cap, recording the old->new transition in
+// org_budget_changes in the SAME transaction.
+//
+// Atomic on purpose: an unaudited change to a money control is worse
+// than a failed change. If the audit INSERT fails, the cap UPDATE must
+// not survive either — a silent, unrecorded budget change is exactly
+// the failure mode spec §8 exists to prevent.
+func (db *DB) UpdateOrgMonthlyBudget(ctx context.Context, orgID, actorUserID string, capCents *int64) error {
+	if capCents != nil && *capCents > maxBudgetCents {
+		return ErrBudgetOutOfRange
+	}
+
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning update org monthly budget transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// FOR UPDATE: takes a row lock so a concurrent update can't read the
+	// same pre-image, both producing an audit row that claims to be "the"
+	// transition from the same old value.
+	var oldCents *int64
+	err = tx.QueryRow(ctx,
+		`SELECT monthly_budget_cents FROM organizations WHERE id = $1 FOR UPDATE`,
+		orgID,
+	).Scan(&oldCents)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrOrgNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("locking org for budget update: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE organizations SET monthly_budget_cents = $1, updated_at = now() WHERE id = $2`,
+		capCents, orgID); err != nil {
+		return fmt.Errorf("updating org monthly budget: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO org_budget_changes (org_id, changed_by, old_cents, new_cents)
+		 VALUES ($1, $2, $3, $4)`,
+		orgID, actorUserID, oldCents, capCents); err != nil {
+		return fmt.Errorf("inserting org budget change audit row: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing update org monthly budget transaction: %w", err)
+	}
+	return nil
+}
+
 // ── Projects ──────────────────────────────────────────────────────
 
 // projectColumns lists the column order used by every project SELECT /

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -913,7 +913,7 @@ func (db *DB) SumOrgDebateSpendMicros(ctx context.Context, orgID string, from, t
 	return sum, nil
 }
 
-// currentUTCMonthRange returns [start,end) of the UTC month containing
+// CurrentUTCMonthRange returns [start,end) of the UTC month containing
 // now — the same bucket IncrementProjectCostCents writes via
 // Format("2006-01") (spec §7).
 //
@@ -925,7 +925,7 @@ func (db *DB) SumOrgDebateSpendMicros(ctx context.Context, orgID string, from, t
 // Callers MUST pass `now` explicitly and never substitute time.Now()
 // internally, or the caller's captured instant and this function's
 // bucket can straddle midnight and disagree.
-func currentUTCMonthRange(now time.Time) (start, end time.Time) {
+func CurrentUTCMonthRange(now time.Time) (start, end time.Time) {
 	y, m, _ := now.UTC().Date()
 	start = time.Date(y, m, 1, 0, 0, 0, 0, time.UTC)
 	end = start.AddDate(0, 1, 0)

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -885,6 +885,53 @@ func (db *DB) UpdateOrgMonthlyBudget(ctx context.Context, orgID, actorUserID str
 	return nil
 }
 
+// SumOrgDebateSpendMicros totals raw provider spend for one org's debate
+// rounds in [from, to). Refiner AND scorer cost, all round statuses — a
+// rejected suggestion still cost money.
+//
+// Enforcement source of truth (spec §3), NOT project_costs:
+// IncrementProjectCostCents runs after commit and is explicitly
+// non-fatal, so one failed rollup would permanently undercount and
+// silently lift the cap. cost_micros/scorer_cost_micros are written
+// inside the round transaction itself.
+//
+// Returns 0,nil when there are no rounds; callers MUST treat a non-nil
+// error as "unknown", never as zero — see checkOrgBudget's fail-closed
+// contract in internal/handlers/debate.go.
+func (db *DB) SumOrgDebateSpendMicros(ctx context.Context, orgID string, from, to time.Time) (int64, error) {
+	var sum int64
+	err := db.Pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(COALESCE(r.cost_micros,0) + COALESCE(r.scorer_cost_micros,0)), 0)::BIGINT
+		   FROM feature_debate_rounds r
+		   JOIN feature_debates d ON d.id = r.debate_id
+		  WHERE d.org_id = $1 AND r.created_at >= $2 AND r.created_at < $3`,
+		orgID, from, to,
+	).Scan(&sum)
+	if err != nil {
+		return 0, fmt.Errorf("summing org debate spend: %w", err)
+	}
+	return sum, nil
+}
+
+// currentUTCMonthRange returns [start,end) of the UTC month containing
+// now — the same bucket IncrementProjectCostCents writes via
+// Format("2006-01") (spec §7).
+//
+// No error return: constructing the boundaries directly from now with
+// time.Date(...) in UTC cannot fail, whereas a Format-then-Parse
+// round-trip would introduce an impossible error path callers had to
+// handle for no benefit.
+//
+// Callers MUST pass `now` explicitly and never substitute time.Now()
+// internally, or the caller's captured instant and this function's
+// bucket can straddle midnight and disagree.
+func currentUTCMonthRange(now time.Time) (start, end time.Time) {
+	y, m, _ := now.UTC().Date()
+	start = time.Date(y, m, 1, 0, 0, 0, 0, time.UTC)
+	end = start.AddDate(0, 1, 0)
+	return start, end
+}
+
 // ── Projects ──────────────────────────────────────────────────────
 
 // projectColumns lists the column order used by every project SELECT /

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -371,7 +371,7 @@ const orgColumns = `id, name, slug, ai_margin_percent, currency_code,
 	business_name, vat_number, registration_number,
 	address_street, address_extra, postal_code, city, country,
 	contact_phones, contact_emails,
-	created_at, updated_at`
+	created_at, updated_at, monthly_budget_cents`
 
 // prefixColumns adds a table alias prefix to each column in a comma-separated list.
 // e.g. prefixColumns("o", "id, name") → "o.id, o.name"
@@ -390,7 +390,7 @@ func scanOrg(scanner interface{ Scan(dest ...any) error }, o *Organization) erro
 		&o.BusinessName, &o.VATNumber, &o.RegistrationNumber,
 		&o.AddressStreet, &o.AddressExtra, &o.PostalCode, &o.City, &o.Country,
 		&o.ContactPhones, &o.ContactEmails,
-		&o.CreatedAt, &o.UpdatedAt,
+		&o.CreatedAt, &o.UpdatedAt, &o.MonthlyBudgetCents,
 	)
 }
 

--- a/internal/models/queries_budget_test.go
+++ b/internal/models/queries_budget_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -200,5 +201,146 @@ func TestOrgMonthlyBudgetCents_NegativeCheckConstraint(t *testing.T) {
 		`UPDATE organizations SET monthly_budget_cents = -1 WHERE id = $1`, orgID)
 	if err == nil {
 		t.Fatal("raw UPDATE with monthly_budget_cents = -1 succeeded, want CHECK constraint violation")
+	}
+}
+
+// seedRoundAt inserts a raw feature_debate_rounds row with an explicit
+// created_at and cost figures, bypassing InsertDebateRoundTx entirely so
+// the aggregate tests can place rounds precisely on either side of the
+// month boundary — something no public API lets a caller do (rounds are
+// always created "now").
+func seedRoundAt(t *testing.T, db *DB, debateID, triggeredBy string, roundNum int,
+	costMicros, scorerCostMicros *int64, status string, createdAt time.Time,
+) {
+	t.Helper()
+	if _, err := db.Pool.Exec(context.Background(),
+		`INSERT INTO feature_debate_rounds (
+			debate_id, round_number, provider, model, triggered_by,
+			input_text, output_text, status, cost_micros, scorer_cost_micros, created_at
+		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', 'out', $4, $5, $6, $7)`,
+		debateID, roundNum, triggeredBy, status, costMicros, scorerCostMicros, createdAt,
+	); err != nil {
+		t.Fatalf("seedRoundAt: %v", err)
+	}
+}
+
+func TestSumOrgDebateSpendMicros_NoRounds(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, _, _, _ := seedFeatureTicket(t, db, "desc")
+	now := time.Now().UTC()
+	from, to := currentUTCMonthRange(now)
+
+	sum, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros: %v", err)
+	}
+	if sum != 0 {
+		t.Fatalf("sum = %d, want 0 for an org with no rounds at all", sum)
+	}
+}
+
+// TestSumOrgDebateSpendMicros_SumsAndFilters is the main aggregate test:
+// sums both cost columns including a NULL scorer cost, excludes another
+// org's spend, excludes rounds outside [from,to) on BOTH edges, and
+// counts every round status (a rejected suggestion still cost money).
+func TestSumOrgDebateSpendMicros_SumsAndFilters(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "desc")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	// seedFeatureTicket keys its user's email off t.Name() alone, so a
+	// second call within the same test would collide on the unique
+	// email constraint — seed the "other org" fixture by hand instead.
+	otherUser, err := db.CreateUser(ctx, t.Name()+"-other@example.com",
+		"$argon2id$v=19$m=65536,t=3,p=4$dGVzdHNhbHQ$dGVzdGhhc2g", "Other Org User", "client")
+	if err != nil {
+		t.Fatalf("CreateUser (other org): %v", err)
+	}
+	otherOrg, err := db.CreateOrgWithOwnerTx(ctx, otherUser.ID, "Other Org "+t.Name(), "other-org-"+t.Name(), OrgRoleOwner)
+	if err != nil {
+		t.Fatalf("CreateOrgWithOwnerTx (other org): %v", err)
+	}
+	otherProj, err := db.CreateProject(ctx, otherOrg.ID, "Other Project", "other-proj-"+t.Name())
+	if err != nil {
+		t.Fatalf("CreateProject (other org): %v", err)
+	}
+	otherTicket := &Ticket{
+		ProjectID: otherProj.ID, Type: "feature", Title: "Other feature",
+		DescriptionMarkdown: "other desc", Status: "backlog", Priority: "medium",
+		CreatedBy: otherUser.ID,
+	}
+	if err := db.CreateTicket(ctx, otherTicket); err != nil {
+		t.Fatalf("CreateTicket (other org): %v", err)
+	}
+	otherDeb, err := db.StartDebate(ctx, otherTicket.ID, otherProj.ID, otherOrg.ID, otherUser.ID)
+	if err != nil {
+		t.Fatalf("StartDebate (other org): %v", err)
+	}
+
+	now := time.Now().UTC()
+	from, to := currentUTCMonthRange(now)
+	inRange := from.Add(time.Hour)
+	beforeRange := from.Add(-time.Second) // excluded: at/before the lower edge minus epsilon
+	atOrAfterEnd := to                    // excluded: half-open upper bound, exactly "to"
+
+	// In range, refiner cost only (scorer NULL) — NULL + cost must not
+	// drop the round from the sum.
+	seedRoundAt(t, db, deb.ID, userID, 1, int64Ptr(1_000_000), nil, "accepted", inRange)
+	// In range, both refiner and scorer cost, rejected status — status
+	// must not gate inclusion.
+	seedRoundAt(t, db, deb.ID, userID, 2, int64Ptr(500_000), int64Ptr(250_000), "rejected", inRange)
+	// In range, in_review status.
+	seedRoundAt(t, db, deb.ID, userID, 3, int64Ptr(100_000), nil, "in_review", inRange)
+
+	// Out of range: previous month (lower edge excluded).
+	seedRoundAt(t, db, deb.ID, userID, 4, int64Ptr(9_999_999), nil, "accepted", beforeRange)
+	// Out of range: next month (upper edge excluded, half-open).
+	seedRoundAt(t, db, deb.ID, userID, 5, int64Ptr(9_999_999), nil, "accepted", atOrAfterEnd)
+
+	// Different org entirely: must not leak into this org's sum.
+	seedRoundAt(t, db, otherDeb.ID, otherUser.ID, 1, int64Ptr(9_999_999), nil, "accepted", inRange)
+
+	sum, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros: %v", err)
+	}
+	want := int64(1_000_000 + 500_000 + 250_000 + 100_000)
+	if sum != want {
+		t.Fatalf("sum = %d, want %d", sum, want)
+	}
+}
+
+func TestCurrentUTCMonthRange_HalfOpenAndUsesPassedNow(t *testing.T) {
+	// A fixed instant, not time.Now() — the function must derive its
+	// boundaries from the passed `now`, never read the wall clock
+	// itself, or the caller's captured instant and the bucket could
+	// straddle midnight independently.
+	now := time.Date(2026, 8, 21, 15, 4, 5, 0, time.UTC)
+	from, to := currentUTCMonthRange(now)
+
+	wantFrom := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	wantTo := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	if !from.Equal(wantFrom) {
+		t.Errorf("from = %v, want %v", from, wantFrom)
+	}
+	if !to.Equal(wantTo) {
+		t.Errorf("to = %v, want %v", to, wantTo)
+	}
+
+	// December must roll over the year, not overflow month=13.
+	dec := time.Date(2026, 12, 15, 0, 0, 0, 0, time.UTC)
+	_, decTo := currentUTCMonthRange(dec)
+	wantDecTo := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !decTo.Equal(wantDecTo) {
+		t.Errorf("December to = %v, want %v", decTo, wantDecTo)
 	}
 }

--- a/internal/models/queries_budget_test.go
+++ b/internal/models/queries_budget_test.go
@@ -231,7 +231,7 @@ func TestSumOrgDebateSpendMicros_NoRounds(t *testing.T) {
 
 	orgID, _, _, _ := seedFeatureTicket(t, db, "desc")
 	now := time.Now().UTC()
-	from, to := currentUTCMonthRange(now)
+	from, to := CurrentUTCMonthRange(now)
 
 	sum, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
 	if err != nil {
@@ -287,7 +287,7 @@ func TestSumOrgDebateSpendMicros_SumsAndFilters(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	from, to := currentUTCMonthRange(now)
+	from, to := CurrentUTCMonthRange(now)
 	inRange := from.Add(time.Hour)
 	beforeRange := from.Add(-time.Second) // excluded: at/before the lower edge minus epsilon
 	atOrAfterEnd := to                    // excluded: half-open upper bound, exactly "to"
@@ -325,7 +325,7 @@ func TestCurrentUTCMonthRange_HalfOpenAndUsesPassedNow(t *testing.T) {
 	// itself, or the caller's captured instant and the bucket could
 	// straddle midnight independently.
 	now := time.Date(2026, 8, 21, 15, 4, 5, 0, time.UTC)
-	from, to := currentUTCMonthRange(now)
+	from, to := CurrentUTCMonthRange(now)
 
 	wantFrom := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	wantTo := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
@@ -338,7 +338,7 @@ func TestCurrentUTCMonthRange_HalfOpenAndUsesPassedNow(t *testing.T) {
 
 	// December must roll over the year, not overflow month=13.
 	dec := time.Date(2026, 12, 15, 0, 0, 0, 0, time.UTC)
-	_, decTo := currentUTCMonthRange(dec)
+	_, decTo := CurrentUTCMonthRange(dec)
 	wantDecTo := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
 	if !decTo.Equal(wantDecTo) {
 		t.Errorf("December to = %v, want %v", decTo, wantDecTo)

--- a/internal/models/queries_budget_test.go
+++ b/internal/models/queries_budget_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// TestOrgMonthlyBudgetColumn_DefaultsNil proves the new column round-trips
+// through the shared orgColumns/scanOrg pair used by all nine org queries.
+// A mismatched column order is a RUNTIME error (wrong field gets the wrong
+// value), not a compile error — this is the cheapest possible tripwire for
+// that class of bug (plan step 1).
+func TestOrgMonthlyBudgetColumn_DefaultsNil(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	org, err := db.CreateOrg(ctx, "Budget Org", "budget-org")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	if org.MonthlyBudgetCents != nil {
+		t.Fatalf("MonthlyBudgetCents on create = %v, want nil (unlimited by default)", org.MonthlyBudgetCents)
+	}
+
+	// Round-trip through GetOrgBySlug to prove the scan (not just the
+	// struct default) picks up the column in the right position.
+	fetched, err := db.GetOrgBySlug(ctx, "budget-org")
+	if err != nil {
+		t.Fatalf("GetOrgBySlug: %v", err)
+	}
+	if fetched.MonthlyBudgetCents != nil {
+		t.Fatalf("MonthlyBudgetCents after fetch = %v, want nil", fetched.MonthlyBudgetCents)
+	}
+}

--- a/internal/models/queries_budget_test.go
+++ b/internal/models/queries_budget_test.go
@@ -82,10 +82,10 @@ func TestUpdateOrgMonthlyBudget_SetAndClear(t *testing.T) {
 
 	var oldCents, newCents *int64
 	var changedBy *string
-	if err := pool.QueryRow(ctx,
+	if scanErr := pool.QueryRow(ctx,
 		`SELECT old_cents, new_cents, changed_by FROM org_budget_changes WHERE org_id = $1`,
-		orgID).Scan(&oldCents, &newCents, &changedBy); err != nil {
-		t.Fatalf("querying audit row: %v", err)
+		orgID).Scan(&oldCents, &newCents, &changedBy); scanErr != nil {
+		t.Fatalf("querying audit row: %v", scanErr)
 	}
 	if oldCents != nil {
 		t.Fatalf("first change old_cents = %v, want nil", oldCents)
@@ -98,8 +98,8 @@ func TestUpdateOrgMonthlyBudget_SetAndClear(t *testing.T) {
 	}
 
 	// Clear back to unlimited.
-	if err := db.UpdateOrgMonthlyBudget(ctx, orgID, userID, nil); err != nil {
-		t.Fatalf("UpdateOrgMonthlyBudget(clear): %v", err)
+	if clearErr := db.UpdateOrgMonthlyBudget(ctx, orgID, userID, nil); clearErr != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget(clear): %v", clearErr)
 	}
 	org2, err := db.GetOrgByID(ctx, orgID)
 	if err != nil {
@@ -229,7 +229,9 @@ func TestSumOrgDebateSpendMicros_NoRounds(t *testing.T) {
 	db := NewDB(pool)
 	ctx := context.Background()
 
-	orgID, _, _, _ := seedFeatureTicket(t, db, "desc")
+	// Only the org matters here — the project/ticket/user the helper also
+	// creates are irrelevant to an org-scoped spend aggregate.
+	orgID, _, _, _ := seedFeatureTicket(t, db, "desc") //nolint:dogsled // helper returns 4 values; only orgID is relevant
 	now := time.Now().UTC()
 	from, to := CurrentUTCMonthRange(now)
 
@@ -278,8 +280,8 @@ func TestSumOrgDebateSpendMicros_SumsAndFilters(t *testing.T) {
 		DescriptionMarkdown: "other desc", Status: "backlog", Priority: "medium",
 		CreatedBy: otherUser.ID,
 	}
-	if err := db.CreateTicket(ctx, otherTicket); err != nil {
-		t.Fatalf("CreateTicket (other org): %v", err)
+	if ctErr := db.CreateTicket(ctx, otherTicket); ctErr != nil {
+		t.Fatalf("CreateTicket (other org): %v", ctErr)
 	}
 	otherDeb, err := db.StartDebate(ctx, otherTicket.ID, otherProj.ID, otherOrg.ID, otherUser.ID)
 	if err != nil {

--- a/internal/models/queries_budget_test.go
+++ b/internal/models/queries_budget_test.go
@@ -2,10 +2,15 @@ package models
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/madalin/forgedesk/internal/testutil"
 )
+
+func int64Ptr(v int64) *int64 { return &v }
 
 // TestOrgMonthlyBudgetColumn_DefaultsNil proves the new column round-trips
 // through the shared orgColumns/scanOrg pair used by all nine org queries.
@@ -33,5 +38,167 @@ func TestOrgMonthlyBudgetColumn_DefaultsNil(t *testing.T) {
 	}
 	if fetched.MonthlyBudgetCents != nil {
 		t.Fatalf("MonthlyBudgetCents after fetch = %v, want nil", fetched.MonthlyBudgetCents)
+	}
+}
+
+// seedBudgetOrgWithUser creates one org + one owning user, the minimal
+// fixture every UpdateOrgMonthlyBudget test needs.
+func seedBudgetOrgWithUser(t *testing.T, db *DB) (orgID, userID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	user, err := db.CreateUser(ctx, t.Name()+"@example.com", "$argon2id$fakehash", "Budget Test User", "client")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	org, err := db.CreateOrgWithOwnerTx(ctx, user.ID, "Org "+t.Name(), "org-"+t.Name(), OrgRoleOwner)
+	if err != nil {
+		t.Fatalf("CreateOrgWithOwnerTx: %v", err)
+	}
+	return org.ID, user.ID
+}
+
+// TestUpdateOrgMonthlyBudget_SetAndClear covers the round-trip and the
+// audit row's first-change shape (old_cents IS NULL — proves the SELECT
+// ... FOR UPDATE inside the tx reads the pre-image, not a stale default).
+func TestUpdateOrgMonthlyBudget_SetAndClear(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID := seedBudgetOrgWithUser(t, db)
+
+	if err := db.UpdateOrgMonthlyBudget(ctx, orgID, userID, int64Ptr(5000)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget(set): %v", err)
+	}
+	org, err := db.GetOrgByID(ctx, orgID)
+	if err != nil {
+		t.Fatalf("GetOrgByID: %v", err)
+	}
+	if org.MonthlyBudgetCents == nil || *org.MonthlyBudgetCents != 5000 {
+		t.Fatalf("MonthlyBudgetCents = %v, want 5000", org.MonthlyBudgetCents)
+	}
+
+	var oldCents, newCents *int64
+	var changedBy *string
+	if err := pool.QueryRow(ctx,
+		`SELECT old_cents, new_cents, changed_by FROM org_budget_changes WHERE org_id = $1`,
+		orgID).Scan(&oldCents, &newCents, &changedBy); err != nil {
+		t.Fatalf("querying audit row: %v", err)
+	}
+	if oldCents != nil {
+		t.Fatalf("first change old_cents = %v, want nil", oldCents)
+	}
+	if newCents == nil || *newCents != 5000 {
+		t.Fatalf("first change new_cents = %v, want 5000", newCents)
+	}
+	if changedBy == nil || *changedBy != userID {
+		t.Fatalf("changed_by = %v, want %s", changedBy, userID)
+	}
+
+	// Clear back to unlimited.
+	if err := db.UpdateOrgMonthlyBudget(ctx, orgID, userID, nil); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget(clear): %v", err)
+	}
+	org2, err := db.GetOrgByID(ctx, orgID)
+	if err != nil {
+		t.Fatalf("GetOrgByID after clear: %v", err)
+	}
+	if org2.MonthlyBudgetCents != nil {
+		t.Fatalf("MonthlyBudgetCents after clear = %v, want nil", org2.MonthlyBudgetCents)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM org_budget_changes WHERE org_id = $1`, orgID).Scan(&count); err != nil {
+		t.Fatalf("counting audit rows: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("audit row count = %d, want 2 (one per successful update)", count)
+	}
+
+	// Second change's old_cents must reflect the prior value, not NULL again.
+	var secondOld *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT old_cents FROM org_budget_changes WHERE org_id = $1 ORDER BY created_at DESC LIMIT 1`,
+		orgID).Scan(&secondOld); err != nil {
+		t.Fatalf("querying second audit row: %v", err)
+	}
+	if secondOld == nil || *secondOld != 5000 {
+		t.Fatalf("second change old_cents = %v, want 5000", secondOld)
+	}
+}
+
+// TestUpdateOrgMonthlyBudget_UnknownOrg proves the FOR UPDATE SELECT's
+// ErrNoRows maps to ErrOrgNotFound AND that no audit row leaks out of a
+// rolled-back transaction — the whole point of doing this atomically.
+func TestUpdateOrgMonthlyBudget_UnknownOrg(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	_, userID := seedBudgetOrgWithUser(t, db)
+	bogusOrgID := uuid.NewString()
+
+	err := db.UpdateOrgMonthlyBudget(ctx, bogusOrgID, userID, int64Ptr(100))
+	if !errors.Is(err, ErrOrgNotFound) {
+		t.Fatalf("UpdateOrgMonthlyBudget(unknown org) err = %v, want ErrOrgNotFound", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM org_budget_changes WHERE org_id = $1`, bogusOrgID).Scan(&count); err != nil {
+		t.Fatalf("counting audit rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("audit rows for unknown org = %d, want 0 (failed update must not leave a trail)", count)
+	}
+}
+
+// TestUpdateOrgMonthlyBudget_OutOfRange proves the model-layer setter
+// rejects the same upper bound the handler does (spec §6 — "enforced in
+// the setter as well as the parser", so a caller bypassing the handler
+// still cannot persist a value that overflows cap*microsPerCent).
+func TestUpdateOrgMonthlyBudget_OutOfRange(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID := seedBudgetOrgWithUser(t, db)
+
+	err := db.UpdateOrgMonthlyBudget(ctx, orgID, userID, int64Ptr(100_000_001))
+	if !errors.Is(err, ErrBudgetOutOfRange) {
+		t.Fatalf("UpdateOrgMonthlyBudget(over max) err = %v, want ErrBudgetOutOfRange", err)
+	}
+
+	// The bound itself must be accepted (off-by-one check on the guard).
+	if err := db.UpdateOrgMonthlyBudget(ctx, orgID, userID, int64Ptr(100_000_000)); err != nil {
+		t.Fatalf("UpdateOrgMonthlyBudget(at max) unexpected error: %v", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM org_budget_changes WHERE org_id = $1`, orgID).Scan(&count); err != nil {
+		t.Fatalf("counting audit rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit rows = %d, want 1 (only the successful at-max update)", count)
+	}
+}
+
+// TestOrgMonthlyBudgetCents_NegativeCheckConstraint proves the DB CHECK
+// blocks a negative value even if some future caller bypasses both the
+// handler parser and UpdateOrgMonthlyBudget's own range guard entirely.
+func TestOrgMonthlyBudgetCents_NegativeCheckConstraint(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, _ := seedBudgetOrgWithUser(t, db)
+
+	_, err := pool.Exec(ctx,
+		`UPDATE organizations SET monthly_budget_cents = -1 WHERE id = $1`, orgID)
+	if err == nil {
+		t.Fatal("raw UPDATE with monthly_budget_cents = -1 succeeded, want CHECK constraint violation")
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -60,6 +60,10 @@ func SetupTestDB(t *testing.T) *pgxpool.Pool {
 		"projects",
 		"invitations",
 		"org_memberships",
+		// References organizations; must go before it even though the FK
+		// is ON DELETE CASCADE, to match this list's "children first"
+		// convention (#64).
+		"org_budget_changes",
 		"organizations",
 		"webauthn_credentials",
 		"sessions",

--- a/migrations/000035_org_monthly_budget.down.sql
+++ b/migrations/000035_org_monthly_budget.down.sql
@@ -1,0 +1,7 @@
+-- LOSSY: dropping monthly_budget_cents resets EVERY org to unlimited, and
+-- dropping org_budget_changes discards the entire audit trail of who
+-- raised/lowered a money control and when. There is no way to reconstruct
+-- either after this runs. If you need to roll back a bad deploy, roll back
+-- the application binary instead of running this migration down.
+DROP TABLE IF EXISTS org_budget_changes;
+ALTER TABLE organizations DROP COLUMN IF EXISTS monthly_budget_cents;

--- a/migrations/000035_org_monthly_budget.up.sql
+++ b/migrations/000035_org_monthly_budget.up.sql
@@ -18,12 +18,17 @@
 -- the opposite -- that a negative cap would unblock everything. It would
 -- not. Corrected in Debate 2.)
 --
--- Only that direction is pinned in schema; the USD 1M upper bound lives in
--- the parser AND the model setter, so a caller bypassing the handler still
--- cannot persist a value that overflows `cap * microsPerCent`.
+-- BOTH directions are pinned in schema, not just the negative one. The Go
+-- setter and the HTTP parser also bound the value, but neither guards a
+-- direct SQL write or a data import: enforcement computes
+-- `cap * microsPerCent` (x10,000), so a stored cap above ~9.2e14 overflows
+-- int64 to a negative, and `spend >= negative` is always true — the org
+-- would be silently blocked forever with no way to see why. 100000000
+-- cents is USD 1M; x10,000 = 1e12, far inside int64.
 ALTER TABLE organizations
     ADD COLUMN monthly_budget_cents BIGINT
-        CHECK (monthly_budget_cents IS NULL OR monthly_budget_cents >= 0);
+        CHECK (monthly_budget_cents IS NULL
+               OR (monthly_budget_cents >= 0 AND monthly_budget_cents <= 100000000));
 
 -- Cap changes are audited (spec §8). No existing table fits: ticket_activities
 -- is ticket_id NOT NULL with a closed action CHECK. This is a money control,

--- a/migrations/000035_org_monthly_budget.up.sql
+++ b/migrations/000035_org_monthly_budget.up.sql
@@ -1,0 +1,45 @@
+-- Phase-2 issue #64: per-organization monthly AI debate budget.
+-- Design: docs/superpowers/specs/2026-08-20-org-monthly-budget-design.md
+--
+-- monthly_budget_cents is USD cents, NOT the org's currency_code (spec §2):
+-- provider pricing is quoted in USD and there is no FX anywhere in this
+-- codebase, so rendering a USD-derived figure behind a EUR symbol would be a
+-- false monetary representation. The UI labels it USD explicitly.
+--
+-- NULL = unlimited (the default for every existing org, so this ships
+-- behaviourally inert). 0 is MEANINGFUL: it blocks new debate rounds while
+-- still allowing the post-accept scorer and the retry sweep to finish work
+-- already started (spec §5).
+--
+-- The CHECK matters because enforcement is `spend >= cap -> block`, and a
+-- non-negative spend is always >= a negative cap: a negative value would
+-- permanently block EVERY round for the org, a self-inflicted denial of
+-- service that no UI would explain. (An earlier draft of this plan claimed
+-- the opposite -- that a negative cap would unblock everything. It would
+-- not. Corrected in Debate 2.)
+--
+-- Only that direction is pinned in schema; the USD 1M upper bound lives in
+-- the parser AND the model setter, so a caller bypassing the handler still
+-- cannot persist a value that overflows `cap * microsPerCent`.
+ALTER TABLE organizations
+    ADD COLUMN monthly_budget_cents BIGINT
+        CHECK (monthly_budget_cents IS NULL OR monthly_budget_cents >= 0);
+
+-- Cap changes are audited (spec §8). No existing table fits: ticket_activities
+-- is ticket_id NOT NULL with a closed action CHECK. This is a money control,
+-- so "who raised it, from what, to what, when" must survive container
+-- restarts and log rotation.
+--
+-- changed_by is ON DELETE SET NULL, not CASCADE: deleting a user must not
+-- erase the financial trail, and the row stays meaningful without them.
+CREATE TABLE org_budget_changes (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id     UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    changed_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    old_cents  BIGINT CHECK (old_cents IS NULL OR old_cents >= 0),
+    new_cents  BIGINT CHECK (new_cents IS NULL OR new_cents >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_org_budget_changes_org_created
+    ON org_budget_changes (org_id, created_at DESC);

--- a/templates/pages/org_settings.html
+++ b/templates/pages/org_settings.html
@@ -180,7 +180,7 @@
                   class="flex items-center gap-3">
                 {{csrfField}}
                 <span class="text-sm text-base-content/70">$</span>
-                <input type="text" name="monthly_budget_cents"
+                <input type="text" name="monthly_budget_usd"
                        value="{{.BudgetCapInput}}"
                        placeholder="Unlimited"
                        class="input input-bordered input-sm w-32">

--- a/templates/pages/org_settings.html
+++ b/templates/pages/org_settings.html
@@ -152,6 +152,46 @@
     </div>
     {{end}}
 
+    {{if .CanViewBudget}}
+    <div class="card bg-base-100 border border-base-300 shadow-sm">
+        <div class="card-body p-6 gap-3">
+            <div>
+                <h2 class="text-lg font-semibold">Monthly AI Budget</h2>
+                <p class="text-sm text-base-content/60 mt-1">
+                    Applies to AI feature-refinement spend only. Leave blank for unlimited.
+                    Set to 0 to block new AI suggestions — work already in progress still finishes.
+                </p>
+            </div>
+
+            <div class="text-sm text-base-content/70">
+                <p>Current cap: <span class="font-medium">{{.BudgetCapDisplay}}</span></p>
+                <p>
+                    {{.BudgetMonth}} spend:
+                    {{if .BudgetSpendUnavailable}}
+                        <span class="font-medium">unavailable</span>
+                    {{else}}
+                        <span class="font-medium">{{.BudgetSpendDisplay}}</span>
+                    {{end}}
+                </p>
+            </div>
+
+            {{if .CanManage}}
+            <form method="POST" action="/orgs/{{.OrgSlug}}/settings/budget"
+                  class="flex items-center gap-3">
+                {{csrfField}}
+                <span class="text-sm text-base-content/70">$</span>
+                <input type="text" name="monthly_budget_cents"
+                       value="{{.BudgetCapInput}}"
+                       placeholder="Unlimited"
+                       class="input input-bordered input-sm w-32">
+                <span class="text-sm text-base-content/70">USD</span>
+                <button type="submit" class="btn btn-primary btn-sm">Save</button>
+            </form>
+            {{end}}
+        </div>
+    </div>
+    {{end}}
+
     {{if .IsStaff}}
     <div class="card bg-base-100 border border-base-300 shadow-sm">
         <div class="card-body p-6 gap-3">


### PR DESCRIPTION
## Summary

Per-organization monthly USD cap on AI debate spend. When the month's spend reaches the cap, new debate rounds are refused. The existing per-user daily fuse stays as defense in depth.

**Closes #64.** Spec and plan are in the branch (`docs/superpowers/specs/2026-08-20-...`, `docs/superpowers/plans/2026-08-21-...`), each hardened by an adversarial review round with Codex and Mistral Vibe before any code was written, and the diff reviewed by both again afterwards.

## The decision that matters most

**Enforcement reads `feature_debate_rounds.cost_micros + scorer_cost_micros`, not the `project_costs` rollup.** That rollup is written post-commit and is explicitly non-fatal, so a single failed write would permanently undercount an org's spend and silently lift its cap forever. The per-round columns are written inside the round transaction. Debate 1 caught this; it would have been a slow, invisible failure.

## Design (all settled in review)

| | |
|---|---|
| Unit | USD cents, labelled USD. No FX — `currency_code` is display-only by existing design |
| Figure capped | Raw provider spend, no margin (verified: margin only ever applies to `ai_usage_entries`) |
| `NULL` cap | Unlimited — every existing org is unaffected |
| `0` cap | Blocks **new rounds**; work already accepted still finishes |
| Blocked | `CreateRound` only — **not** the post-accept scorer or the retry sweep, which would strand debates permanently unscored to save cents |
| Semantics | A best-effort threshold with bounded overshoot, not a hard ceiling — costs land after the provider call. Stated plainly so nobody implements against the wrong promise |
| Aggregate unreadable | **Fail closed** — refuse the round |
| Who sets it | Owner/admin + staff (staff for any org); any member may view |
| Staff | **Not exempt.** The other caps are abuse fuses; this is a financial control and a staff round spends the org's real money |

Cap changes are audited (actor, org, old → new) in the same transaction as the update.

## What the three debates changed

**Debate 1 (spec)** — the `project_costs` hole above; USD labelling (a USD figure behind a `€` symbol is a false monetary representation); and renaming "hard block" to what it actually is.

**Debate 2 (plan)** — caught an error in *my own* reasoning. Both the spec and the migration comment claimed a negative cap would "silently unblock everything." It's the opposite: `spend >= cap → block`, and a non-negative spend is always `>=` a negative cap, so it would block **every** round permanently. The constraint was right, the stated reason inverted. Corrected in place, visibly.

**Debate 3 (diff)** — the DB CHECK now bounds both directions (the Go layer bounded it, but nothing guarded a direct SQL write, and an oversized cap overflows `cap * 10_000` into a permanent block); the form field was named `monthly_budget_cents` while being parsed as **dollars**, so a caller posting `100` would have set `$100`; and two tests were repaired that would have passed while hiding a break — one seeded no spend at all, and one derived "last month" with `AddDate(0,-1,0)`, which normalizes forward on the 29th–31st and lands back in the current month.

## Rejected, with evidence

- **"`SUM(BIGINT)` won't scan into int64"** — it returns `numeric`, but pgx scans it fine; verified against the test DB. Kept a `::BIGINT` cast for type clarity only.
- **"`for i := range len(s)` is a compilation error" (graded DO NOT SHIP)** — range-over-int is legal since Go 1.22; this repo is on 1.25. Compiled and ran it to confirm. The line exists because `golangci-lint`'s `intrange` asked for it.
- **"Showing spend to owners leaks AI internals"** (Debate 1) — `costs.go` gates on membership, not role, and debate spend already appears in the totals clients see.

## Testing

~1,250 lines of tests. Models: round-trip, audit correctness (including *no* audit row when the update fails), DB CHECK rejection in both directions, aggregate correctness across NULL scorer costs, other orgs, both range edges and all round statuses. Handlers: full role matrix incl. cross-org substitution, the `parseUSDCents` accept/reject table, cap-0-spend-0 must block, no-AI-call on block (`FakeRefiner.CallCount == 0`), rollover, and scorer cost counting toward the cap.

Migration 000035 verified round-tripping (`35 → 34 → 35`, never dirty). Mutation-verified: the `>=` boundary, and that a spend-ignoring implementation is caught.

**Known gap, stated rather than hidden:** fail-closed is proven at unit level with a genuine aggregate error, not through the full HTTP stack — every query shares one pool, so isolating an aggregate-only failure end-to-end needs a test seam not worth adding here.

`go build`, `go vet`, `gofmt`, full `go test ./internal/... -p 1`, and `golangci-lint` at CI's pinned **v2.11.4** all pass.

## Deploy note

Migration 000035 is **additive** — run it before the image rolls, like 000034. Behaviour is inert until an admin sets a cap: every existing org gets `NULL` = unlimited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)