### PR TITLE
deploy: pin server & orchestrator images to v0.6.0

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.5.1
+          image: registry.k3s.vlah.sh/smartpm:v0.6.0
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.5.1
+          image: registry.k3s.vlah.sh/smartpm:v0.6.0
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for the **v0.6.0 deploy, already applied to production**. `imagePullPolicy: IfNotPresent` makes the tag the only version pin, so stale manifests would let a routine `kubectl apply` roll production backwards.

`v0.6.0` (tag → `f2efe30`, digest `sha256:65d37f60…`) — per-org monthly AI budget, #64.

| Step | Result |
|------|--------|
| Migration 000035 | 34 → **35**, `dirty=false`, 520ms, applied **before** the rollout |
| Post-migration state | all 3 orgs `NULL` = unlimited; `org_budget_changes` present |
| CHECK verified live | prod rejected both `-1` and `100000001` |
| Rollout | server ×2 + orchestrator, **0 restarts** |
| Digest check | all 3 pods report `sha256:65d37f60…`, identical to the built image |
| Smoke | `/login` 200 (0.25s), `/health` 200, no errors in logs |

**Client-visible behaviour is unchanged** until an admin sets a cap — every existing org defaults to unlimited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)