### PR TITLE
fix(security): close org-existence oracle on OrgPage (#127)

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -843,3 +843,79 @@ func TestOrgSettingsPage_MemberAllowed(t *testing.T) {
 		t.Errorf("member GET org settings: got %d, want 200", rec.Code)
 	}
 }
+
+// A non-member must not be able to tell whether an org exists. OrgPage
+// was correctly gated on membership, but answered 403 for a real org and
+// 404 for a missing one — so the status code alone confirmed which slugs
+// were real. Slugs are slugify(name), so that turns a guessing game into
+// an enumeration of the client list (issue #127).
+func TestOrgPage_NonMemberCannotDistinguishExistence(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	if _, err := db.CreateOrg(ctx, "Real Org", "real-org"); err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+
+	// First registered user is auto-promoted to superadmin, so burn one
+	// before creating the client under test.
+	createAuthenticatedUser(t, db, sessions, "first-sa-orgpage@test.com", "superadmin")
+	outsider := createAuthenticatedUser(t, db, sessions, "outsider-orgpage@test.com", "client")
+
+	get := func(slug string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/orgs/"+slug, http.NoBody)
+		req.AddCookie(outsider)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec
+	}
+
+	existing := get("real-org")
+	missing := get("no-such-org-anywhere")
+
+	if existing.Code != http.StatusNotFound {
+		t.Errorf("non-member GET existing org: got %d, want 404", existing.Code)
+	}
+	if existing.Code != missing.Code {
+		t.Errorf("enumeration oracle: existing-but-forbidden org returned %d, nonexistent returned %d — these must match",
+			existing.Code, missing.Code)
+	}
+	if strings.Contains(existing.Body.String(), "Real Org") {
+		t.Error("response leaked the org name to a non-member")
+	}
+}
+
+// The gate must not lock out the people the page is for.
+func TestOrgPage_MemberStillAllowed(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	createAuthenticatedUser(t, db, sessions, "first-sa-orgpage2@test.com", "superadmin")
+	memberCookie := createAuthenticatedUser(t, db, sessions, "member-orgpage@test.com", "client")
+
+	var userID string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT id FROM users WHERE email = 'member-orgpage@test.com'`).Scan(&userID); err != nil {
+		t.Fatalf("look up member: %v", err)
+	}
+	org, err := db.CreateOrg(ctx, "Member Org Page", "member-org-page")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	// Weakest membership on purpose: the gate checks membership exists,
+	// not management rights.
+	if _, err := db.Pool.Exec(ctx,
+		`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1, $2, 'member')`,
+		userID, org.ID); err != nil {
+		t.Fatalf("add membership: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/member-org-page", http.NoBody)
+	req.AddCookie(memberCookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("member GET org page: got %d, want 200", rec.Code)
+	}
+}

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -54,17 +54,33 @@ func (h *OrgHandler) OrgPage(w http.ResponseWriter, r *http.Request) {
 
 	org, err := h.db.GetOrgBySlug(r.Context(), slug)
 	if err != nil {
-		h.engine.RenderError(w, http.StatusNotFound, "Organization not found")
+		if errors.Is(err, pgx.ErrNoRows) {
+			h.engine.RenderError(w, http.StatusNotFound, "Organization not found")
+			return
+		}
+		// A lookup failure is infrastructure, not a missing org. Reporting
+		// it as 404 hides real outages behind a routine-looking response.
+		log.Printf("org page: looking up org %q: %v", slug, err)
+		h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
 		return
 	}
 
-	// Check access
-	if !auth.IsStaffOrAbove(user.Role) {
-		_, err := h.db.GetOrgMembership(r.Context(), user.ID, org.ID)
-		if err != nil {
-			h.engine.RenderError(w, http.StatusForbidden, "Access denied")
+	// Access gate. Uses authorizeOrgAccess rather than an inline
+	// membership check so this page inherits the documented convention:
+	// "not a member" and "no such org" BOTH surface as 404 (issue #127).
+	// Answering 403 here for a real org and 404 for a missing one made the
+	// status code an existence oracle — and since slugs are slugify(name),
+	// that turns guessing into enumerating the client list.
+	if authErr := authorizeOrgAccess(r.Context(), h.db, user, org.ID); authErr != nil {
+		if errors.Is(authErr, errCrossTenant) {
+			h.engine.RenderError(w, http.StatusNotFound, "Organization not found")
 			return
 		}
+		// Distinct from the cross-tenant case on purpose: a database fault
+		// must never be reported as an authorization decision (issue #128).
+		log.Printf("org page authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
+		return
 	}
 
 	projects := middleware.GetProjects(r)


### PR DESCRIPTION
## Problem

`OrgPage` was **correctly gated** on membership — no org content leaked. But it distinguished two cases in its response:

| Case | Before |
|---|---|
| Org does not exist | 404 |
| Org exists, you are not a member | **403** |

So the status code confirmed which slugs were real. Since slugs are `slugify(org name)`, that turns guessing into **enumerating the client list** — no content needed.

This is the sibling the #122 security review flagged and I deliberately left out of that hotfix to keep it minimal.

## Fix

Replaced the inline membership check with `authorizeOrgAccess`, which exists for precisely this and states the reason in its own doc comment:

> …so an attacker probing for valid IDs cannot distinguish "does not exist" from "belongs to another tenant".

Already the convention in `comments.go`, `tickets.go`, `reactions.go`, and adopted by `OrgSettings` in #122. `OrgPage` was the last straggler on the old pattern — worth closing, because a lone holdout is how a pattern spreads back.

## Also, on the same lines

Two collapsed error conditions split apart (the shape tracked in **#128**):

- `GetOrgBySlug` failing for *any* reason returned 404 — a DB outage looked like a missing org.
- The authz lookup failing returned a permission denial rather than an infra error.

Both now log and return 500. A database fault should be visible as infrastructure, not hidden behind a routine-looking response.

## Tests

- **The property directly:** a real-but-forbidden org and a nonexistent one must return the **same** status.
- A plain `member` (weakest membership) still gets 200 — nobody legitimate locked out.
- **Mutation-verified twice:** restoring the 403 reproduces the oracle; deleting the gate outright leaks the org name. Both failed as expected, then reverted clean.

## Verification

`go build`, `go vet`, full `go test ./internal/... -p 1`, and lint via the new `bash scripts/lint.sh` — which dogfooded #120 immediately and caught a `revive` finding (a test variable named `real`, shadowing the builtin) that my old local linter would have missed.

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)