### PR TITLE
fix(handlers): stop reporting DB failures as 403 Forbidden (#128)

### DIFF
--- a/internal/handlers/assistant.go
+++ b/internal/handlers/assistant.go
@@ -96,6 +96,11 @@ func (h *AssistantHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 
 	// Verify user has access to the project
 	if err := h.checkProjectAccess(r.Context(), user, projectID); err != nil {
+		if !errors.Is(err, errCrossTenant) {
+			log.Printf("assistant project authz for user %s project %s: %v", user.ID, projectID, err)
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -361,15 +366,10 @@ func (h *AssistantHandler) checkProjectAccess(ctx context.Context, user *models.
 	if user.Role == roleSuperadmin || user.Role == roleStaff {
 		return nil
 	}
-	proj, err := h.db.GetProjectByID(ctx, projectID)
-	if err != nil {
-		return fmt.Errorf("project not found")
-	}
-	_, err = h.db.GetOrgMembership(ctx, user.ID, proj.OrgID)
-	if err != nil {
-		return fmt.Errorf("no access to project")
-	}
-	return nil
+	// Delegates to the shared gate so a database fault propagates as
+	// itself instead of being flattened into "no access" and rendered as
+	// 403 Forbidden (#128). errCrossTenant still means a genuine denial.
+	return authorizeProjectAccess(ctx, h.db, user, projectID)
 }
 
 // DeleteConversation deletes a conversation (staff/superadmin only).
@@ -945,13 +945,21 @@ func (e *toolExecutor) checkProjectAccess(ctx context.Context, projectID string)
 	if e.user.Role == roleSuperadmin || e.user.Role == roleStaff {
 		return nil
 	}
+	// Same gate as the handler path (#128): an infrastructure failure must
+	// not reach the model as "you don't have access", which would make the
+	// assistant confidently tell a user they lack permissions they have.
 	proj, err := e.db.GetProjectByID(ctx, projectID)
 	if err != nil {
-		return fmt.Errorf("project not found")
+		if isRowMiss(err) {
+			return errCrossTenant
+		}
+		return err
 	}
-	_, err = e.db.GetOrgMembership(ctx, e.userID, proj.OrgID)
-	if err != nil {
-		return fmt.Errorf("you don't have access to this project")
+	if _, memErr := e.db.GetOrgMembership(ctx, e.userID, proj.OrgID); memErr != nil {
+		if isRowMiss(memErr) {
+			return errCrossTenant
+		}
+		return memErr
 	}
 	return nil
 }

--- a/internal/handlers/authz.go
+++ b/internal/handlers/authz.go
@@ -48,6 +48,37 @@ func authorizeOrgAccess(ctx context.Context, db *models.DB, user *models.User, o
 	return nil
 }
 
+// authorizeOrgManage reports whether the user may MANAGE the given org —
+// invite and remove members, change roles, edit org settings — as opposed
+// to merely reading it (authorizeOrgAccess).
+//
+// The (bool, error) shape is the point. Its two predecessors,
+// OrgHandler.canManageOrgMembers and the byte-identical package function
+// canManageOrg in invitations.go, returned a bare bool and mapped ANY
+// error from the membership lookup to false. Callers then rendered that
+// as 403 Forbidden, so a transient database failure was reported to the
+// user as a permission denial and never surfaced as an infrastructure
+// fault in the logs (issue #128).
+//
+// Now: (false, nil) means a genuine denial, and a non-nil error means the
+// question could not be answered — callers must render 5xx and log it,
+// never 403. Staff and superadmin short-circuit to true without a query,
+// matching every other gate in this package.
+func authorizeOrgManage(ctx context.Context, db *models.DB, user *models.User, orgID string) (bool, error) {
+	if auth.IsStaffOrAbove(user.Role) {
+		return true, nil
+	}
+	m, err := db.GetOrgMembership(ctx, user.ID, orgID)
+	if err != nil {
+		if isRowMiss(err) {
+			// Not a member at all — a real answer, not a failure.
+			return false, nil
+		}
+		return false, err
+	}
+	return auth.CanManageOrg(m.Role), nil
+}
+
 // authorizeProjectAccess loads the project and verifies the user is
 // authorized to act on its owning org. Used by write handlers that take a
 // project_id from the request body (e.g. CreateTicket).

--- a/internal/handlers/authz_manage_test.go
+++ b/internal/handlers/authz_manage_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// authorizeOrgManage must distinguish "this user may not manage" from
+// "we could not find out". The predecessors (canManageOrgMembers and
+// canManageOrg, byte-identical duplicates) returned a bare bool and
+// collapsed both into false, so a Postgres blip surfaced to users as
+// 403 Forbidden and never reached the logs as an infra fault (#128).
+func TestAuthorizeOrgManage(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := models.NewDB(pool)
+	ctx := context.Background()
+
+	org, err := db.CreateOrg(ctx, "Manage Org", "manage-org")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+
+	hash, _ := auth.HashPassword("TestPassword123!")
+	mk := func(email, platformRole, orgRole string) *models.User {
+		t.Helper()
+		u, uErr := db.CreateUser(ctx, email, hash, "U", platformRole)
+		if uErr != nil {
+			t.Fatalf("CreateUser: %v", uErr)
+		}
+		if orgRole != "" {
+			if _, exErr := db.Pool.Exec(ctx,
+				`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1,$2,$3)`,
+				u.ID, org.ID, orgRole); exErr != nil {
+				t.Fatalf("add membership: %v", exErr)
+			}
+		}
+		return u
+	}
+
+	owner := mk("owner-mg@test.com", "client", "owner")
+	member := mk("member-mg@test.com", "client", "member")
+	outsider := mk("outsider-mg@test.com", "client", "")
+	staff := mk("staff-mg@test.com", "staff", "")
+
+	cases := []struct {
+		name    string
+		user    *models.User
+		wantOK  bool
+		wantErr bool
+	}{
+		{"owner may manage", owner, true, false},
+		{"plain member may not", member, false, false},
+		{"non-member may not", outsider, false, false},
+		{"staff may manage any org", staff, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, mgErr := authorizeOrgManage(ctx, db, tc.user, org.ID)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if (mgErr != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr %v", mgErr, tc.wantErr)
+			}
+		})
+	}
+
+	// The point of the change: an infrastructure failure must come back as
+	// an ERROR, not as a silent false that the caller renders as 403.
+	t.Run("db failure returns an error, not a bare false", func(t *testing.T) {
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+
+		ok, mgErr := authorizeOrgManage(cancelled, db, owner, org.ID)
+		if ok {
+			t.Error("ok = true on a failed lookup, want false")
+		}
+		if mgErr == nil {
+			t.Fatal("err = nil on a failed lookup — the caller cannot tell this from a genuine denial")
+		}
+		if errors.Is(mgErr, errCrossTenant) {
+			t.Error("a DB failure must not be reported as cross-tenant denial")
+		}
+	})
+}

--- a/internal/handlers/costs.go
+++ b/internal/handlers/costs.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"log"
 	"math"
 	"net/http"
@@ -66,11 +67,15 @@ func (h *CostHandler) ProjectCosts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !auth.IsStaffOrAbove(user.Role) {
-		if _, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID); memErr != nil {
-			h.engine.RenderError(w, http.StatusForbidden, "Access denied")
+	if authErr := authorizeOrgAccess(r.Context(), h.db, user, org.ID); authErr != nil {
+		if errors.Is(authErr, errCrossTenant) {
+			h.engine.RenderError(w, http.StatusNotFound, "Organization not found")
 			return
 		}
+		// A lookup failure is infrastructure, never an access decision (#128).
+		log.Printf("costs authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
+		return
 	}
 
 	proj, err := h.db.GetProject(r.Context(), org.ID, projSlug)
@@ -136,11 +141,15 @@ func (h *CostHandler) OrgCosts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !auth.IsStaffOrAbove(user.Role) {
-		if _, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID); memErr != nil {
-			h.engine.RenderError(w, http.StatusForbidden, "Access denied")
+	if authErr := authorizeOrgAccess(r.Context(), h.db, user, org.ID); authErr != nil {
+		if errors.Is(authErr, errCrossTenant) {
+			h.engine.RenderError(w, http.StatusNotFound, "Organization not found")
 			return
 		}
+		// A lookup failure is infrastructure, never an access decision (#128).
+		log.Printf("costs authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		h.engine.RenderError(w, http.StatusInternalServerError, "Failed to load organization")
+		return
 	}
 
 	month := parseMonth(r)

--- a/internal/handlers/files.go
+++ b/internal/handlers/files.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -133,6 +134,11 @@ func (h *FileHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	// Verify project access
 	orgID, err := h.checkProjectAccess(r, user, projectID)
 	if err != nil {
+		if !errors.Is(err, errCrossTenant) {
+			log.Printf("file project authz for user %s project %s: %v", user.ID, projectID, err)
+			jsonError(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 		jsonError(w, "Access denied", http.StatusForbidden)
 		return
 	}
@@ -203,6 +209,11 @@ func (h *FileHandler) GenerateImage(w http.ResponseWriter, r *http.Request) {
 
 	orgID, err := h.checkProjectAccess(r, user, req.ProjectID)
 	if err != nil {
+		if !errors.Is(err, errCrossTenant) {
+			log.Printf("file project authz for user %s project %s: %v", user.ID, req.ProjectID, err)
+			jsonError(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 		jsonError(w, "Access denied", http.StatusForbidden)
 		return
 	}
@@ -276,6 +287,11 @@ func (h *FileHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 
 	orgID, err := h.checkProjectAccess(r, user, ticket.ProjectID)
 	if err != nil {
+		if !errors.Is(err, errCrossTenant) {
+			log.Printf("file project authz for user %s project %s: %v", user.ID, ticket.ProjectID, err)
+			jsonError(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 		jsonError(w, "Access denied", http.StatusForbidden)
 		return
 	}
@@ -365,6 +381,11 @@ func (h *FileHandler) DeleteAttachment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := h.checkProjectAccess(r, user, ticket.ProjectID); err != nil {
+		if !errors.Is(err, errCrossTenant) {
+			log.Printf("file project authz for user %s project %s: %v", user.ID, ticket.ProjectID, err)
+			jsonError(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 		jsonError(w, "Access denied", http.StatusForbidden)
 		return
 	}
@@ -403,12 +424,18 @@ func (h *FileHandler) DeleteAttachment(w http.ResponseWriter, r *http.Request) {
 func (h *FileHandler) checkProjectAccess(r *http.Request, user *models.User, projectID string) (string, error) {
 	proj, err := h.db.GetProjectByID(r.Context(), projectID)
 	if err != nil {
-		return "", fmt.Errorf("project not found")
-	}
-	if user.Role != roleSuperadmin && user.Role != roleStaff {
-		if _, err := h.db.GetOrgMembership(r.Context(), user.ID, proj.OrgID); err != nil {
-			return "", fmt.Errorf("no access")
+		if isRowMiss(err) {
+			return "", errCrossTenant
 		}
+		return "", err
+	}
+	// Was a hand-rolled staff check plus an inline membership lookup that
+	// flattened every error into fmt.Errorf("no access") — so a database
+	// fault reached the user as 403 Forbidden and never appeared in the
+	// logs as infrastructure (#128). authorizeOrgAccess keeps the two
+	// apart and uses the canonical IsStaffOrAbove predicate.
+	if authErr := authorizeOrgAccess(r.Context(), h.db, user, proj.OrgID); authErr != nil {
+		return "", authErr
 	}
 	return proj.OrgID, nil
 }

--- a/internal/handlers/handlers_extended_test.go
+++ b/internal/handlers/handlers_extended_test.go
@@ -163,9 +163,23 @@ func TestProjectCostsForbiddenForNonMember(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	// Client not a member of the org should get 403
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rec.Code)
+	// A non-member now gets 404, not 403 (#128). The costs handler moved
+	// onto authorizeOrgAccess, which deliberately collapses "not a member"
+	// and "no such org" so the status code cannot be used to probe which
+	// orgs exist. The access guarantee this test exists for is unchanged
+	// and strictly stronger — asserted below by checking the response is
+	// indistinguishable from one for an org that does not exist.
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+
+	missReq := httptest.NewRequest(http.MethodGet, "/orgs/no-such-org/projects/no-such-proj/costs", http.NoBody)
+	missReq.AddCookie(cookie)
+	missRec := httptest.NewRecorder()
+	r.ServeHTTP(missRec, missReq)
+	if missRec.Code != rec.Code {
+		t.Fatalf("enumeration: existing-but-forbidden org returned %d, nonexistent returned %d — must match",
+			rec.Code, missRec.Code)
 	}
 }
 

--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -307,7 +307,12 @@ func (h *InviteHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !canManageOrg(h.db, r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("invitation manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -347,7 +352,12 @@ func (h *InviteHandler) ResendInvitation(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !canManageOrg(h.db, r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("invitation manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -391,16 +401,4 @@ func (h *InviteHandler) ResendInvitation(w http.ResponseWriter, r *http.Request)
 	}); err != nil {
 		log.Printf("rendering invitation list partial: %v", err)
 	}
-}
-
-// canManageOrg is a shared helper to check org management permission.
-func canManageOrg(db *models.DB, r *http.Request, user *models.User, orgID string) bool {
-	if auth.IsStaffOrAbove(user.Role) {
-		return true
-	}
-	m, err := db.GetOrgMembership(r.Context(), user.ID, orgID)
-	if err != nil {
-		return false
-	}
-	return auth.CanManageOrg(m.Role)
 }

--- a/internal/handlers/orgs.go
+++ b/internal/handlers/orgs.go
@@ -181,13 +181,14 @@ func (h *OrgHandler) OrgSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Separate question from "may they be here": may they EDIT. The bug
-	// this fix closes was answering only this one and letting the page
-	// render regardless.
-	canManage := auth.IsStaffOrAbove(user.Role)
-	if !canManage {
-		if m, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID); memErr == nil {
-			canManage = auth.CanManageOrg(m.Role)
-		}
+	// #122 closed was answering only this one and letting the page render
+	// regardless. Uses the shared helper so the same predicate backs every
+	// manage decision; a lookup failure degrades to read-only rather than
+	// erroring the page, since the access gate above already succeeded.
+	canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID)
+	if authErr != nil {
+		log.Printf("org settings: resolving manage rights for user %s org %s: %v", user.ID, org.ID, authErr)
+		canManage = false
 	}
 
 	members, err := h.db.ListOrgMembers(r.Context(), org.ID)
@@ -301,25 +302,21 @@ func (h *OrgHandler) buildBudgetSettingsFields(r *http.Request, org *models.Orga
 	}
 }
 
-// canManageOrgMembers checks if the current user has permission to manage members of the given org.
-func (h *OrgHandler) canManageOrgMembers(r *http.Request, user *models.User, orgID string) bool {
-	if auth.IsStaffOrAbove(user.Role) {
-		return true
-	}
-	m, err := h.db.GetOrgMembership(r.Context(), user.ID, orgID)
-	if err != nil {
-		return false
-	}
-	return auth.CanManageOrg(m.Role)
-}
-
 func (h *OrgHandler) renderMemberList(w http.ResponseWriter, r *http.Request, org *models.Organization, user *models.User) {
 	members, err := h.db.ListOrgMembers(r.Context(), org.ID)
 	if err != nil {
 		http.Error(w, "Failed to load members", http.StatusInternalServerError)
 		return
 	}
-	canManage := h.canManageOrgMembers(r, user, org.ID)
+	// Display flag, not a gate — the caller already passed an access check.
+	// On a lookup failure fall back to read-only: hiding buttons is a safe
+	// degradation, where rendering them would invite a request that then
+	// fails. Logged so it does not look like a permissions change.
+	canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID)
+	if authErr != nil {
+		log.Printf("member list: resolving manage rights for user %s org %s: %v", user.ID, org.ID, authErr)
+		canManage = false
+	}
 	if err := h.engine.RenderPartial(w, "member_list.html", map[string]any{
 		"Members":       members,
 		"CanManage":     canManage,
@@ -340,7 +337,12 @@ func (h *OrgHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.canManageOrgMembers(r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("org manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -429,7 +431,12 @@ func (h *OrgHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.canManageOrgMembers(r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("org manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -486,7 +493,12 @@ func (h *OrgHandler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.canManageOrgMembers(r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("org manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -573,7 +585,12 @@ func (h *OrgHandler) UpdateBusinessDetails(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !h.canManageOrgMembers(r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("org manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -624,7 +641,12 @@ func (h *OrgHandler) UpdateMonthlyBudget(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !h.canManageOrgMembers(r, user, org.ID) {
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		// Could not determine the answer — infrastructure, not a denial.
+		log.Printf("org manage authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}

--- a/internal/handlers/projects.go
+++ b/internal/handlers/projects.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"net/url"
@@ -56,10 +57,17 @@ func (h *ProjectHandler) getOrgAndProject(r *http.Request, user *models.User) (*
 		return nil, nil, err
 	}
 
-	if !auth.IsStaffOrAbove(user.Role) {
-		if _, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID); memErr != nil {
-			return nil, nil, memErr
+	// Returns errCrossTenant for a genuine non-member and the underlying
+	// error otherwise, so callers CAN tell them apart. Today every caller
+	// still renders 404 for both, which is safe — but the distinction now
+	// exists in the returned error instead of being lost here, and an
+	// infrastructure fault is logged where it happens rather than
+	// vanishing into a "Not found" page (#128).
+	if authErr := authorizeOrgAccess(r.Context(), h.db, user, org.ID); authErr != nil {
+		if !errors.Is(authErr, errCrossTenant) {
+			log.Printf("project authz for user %s org %s: %v", user.ID, org.ID, authErr)
 		}
+		return nil, nil, authErr
 	}
 
 	proj, err := h.db.GetProject(r.Context(), org.ID, projSlug)
@@ -205,12 +213,13 @@ func (h *ProjectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !auth.IsStaffOrAbove(user.Role) {
-		mem, memErr := h.db.GetOrgMembership(r.Context(), user.ID, org.ID)
-		if memErr != nil || !auth.CanManageOrg(mem.Role) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
-			return
-		}
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		log.Printf("create project authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
 	}
 
 	slug := slugify(name)


### PR DESCRIPTION
## Problem

Access and management gates treated **any** error from the membership lookup as "denied":

```go
if _, err := h.db.GetOrgMembership(ctx, user.ID, org.ID); err != nil {
    // 403 Forbidden
}
```

So a transient Postgres failure reached users as **403 Forbidden** — alarming, points debugging at permissions instead of the database, and never surfaces in logs as the infrastructure fault it actually is.

Fail-closed, so not a vulnerability. But #122 fixed exactly this in `OrgSettings`, leaving the codebase inconsistent: one handler distinguished them, thirteen did not.

## Fix

New `authorizeOrgManage` in `authz.go` answers the management question as `(bool, error)`:
- `(false, nil)` — a genuine denial
- non-nil error — the question could not be answered; caller renders **5xx**

It replaces **two byte-identical helpers** maintained separately (`OrgHandler.canManageOrgMembers` and the package function `canManageOrg` in `invitations.go`), so one predicate now backs every manage decision.

## 15 sites migrated

| Area | Change |
|---|---|
| 5 manage gates in `orgs.go`, 2 in `invitations.go`, 1 in `projects.go` | 500 + log on failure; 403 only for real denial |
| 2 access gates in `costs.go`, `getOrgAndProject` | now `authorizeOrgAccess` |
| `checkProjectAccess` in `files.go` (4 callers) and `assistant.go` | see below |
| Assistant **tool engine** | see below |
| `OrgSettings` canManage flag | degrades to read-only, but logs |

**The two `checkProjectAccess` helpers were worse than the bool case** — they discarded the underlying error into a synthetic `fmt.Errorf("no access")` *before* the caller turned it into 403, destroying the information at the source. `files.go` also hand-rolled its staff check instead of using `auth.IsStaffOrAbove`; it now goes through the canonical predicate.

`★` The assistant's tool engine is the one I'd most wanted fixed: an infra failure previously reached the model as *"you don't have access to this project"* — making the assistant confidently tell a user they lack permissions they actually have.

## ⚠️ Behavior change

**The costs pages now return 404 rather than 403 to a non-member.** `authorizeOrgAccess` deliberately collapses "not a member" and "no such org" so the status code can't be used to probe which orgs exist (same reasoning as #127).

`TestProjectCostsForbiddenForNonMember` was updated **and strengthened** — it now also asserts the response is indistinguishable from one for a nonexistent org. The access guarantee it exists for is unchanged and strictly stronger.

## Deliberately not changed

- `debate.go`'s `budgetExceededMessage` — a documented fallback to the least-informative wording, which is the safe default there.
- The "is this invitee already a member" check in `orgs.go` — asks about a *different* user, and its failure mode is a duplicate invitation, not a wrong authz answer. Worth its own look.

## Tests

New contract test on `authorizeOrgManage`: owner/member/non-member/staff outcomes, plus the key case — **a failed lookup must return an error, not a bare `false`**. Mutation-verified: reverting the helper to swallow errors fails with *"the caller cannot tell this from a genuine denial"*.

Full `go test ./internal/... -p 1`, `go build`, `go vet`, and lint via `bash scripts/lint.sh` (CI's pinned v2.11.4) all pass.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)