### PR TITLE
fix(ai): correct Opus 4.6 rate (3x overcharge) and add Haiku pricing (#119)

### DIFF
--- a/internal/ai/anthropic_scorer.go
+++ b/internal/ai/anthropic_scorer.go
@@ -42,9 +42,11 @@ type AnthropicScorer struct {
 // The model should be one of the ai.Model* constants so the pricing table
 // lookup finds a rate; main.go binds it to SCORER_MODEL_CLAUDE.
 //
-// Note this is the most expensive of the three scorers: the pricing table
-// has no cheap Claude tier, so the default is claude-sonnet-4-6 rather
-// than a Haiku-class model.
+// Defaults to claude-haiku-4-5 (issue #119). It was briefly Sonnet
+// because the pricing table had no cheap Claude tier priced yet, which
+// made Claude the expensive scorer by a wide margin; Haiku is 1/3 the
+// input and 1/5 the output price and is the right tier for a small
+// structured scoring call.
 func NewAnthropicScorer(c *AnthropicClient, model string) *AnthropicScorer {
 	return &AnthropicScorer{client: c, model: model}
 }

--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -6,11 +6,16 @@ package ai
 const (
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeOpus46   = "claude-opus-4-6"
-	ModelGPT5Mini       = "gpt-5-mini"
-	ModelGPT5           = "gpt-5"
-	ModelGPT54          = "gpt-5.4"
-	ModelGeminiFlash    = "gemini-2.5-flash"
-	ModelGeminiPro      = "gemini-2.5-pro"
+	// ModelClaudeHaiku45 is Anthropic's cheapest current model. It is the
+	// default debate scorer for the claude provider: scoring is a small
+	// structured task that runs on every accepted round plus the retry
+	// sweep, so it does not need a frontier model (issue #119).
+	ModelClaudeHaiku45 = "claude-haiku-4-5"
+	ModelGPT5Mini      = "gpt-5-mini"
+	ModelGPT5          = "gpt-5"
+	ModelGPT54         = "gpt-5.4"
+	ModelGeminiFlash   = "gemini-2.5-flash"
+	ModelGeminiPro     = "gemini-2.5-pro"
 	// Gemini3FlashPreview is the production-pinned scorer/refiner model
 	// (GEMINI_MODEL in the forgedesk-env cluster Secret). Added 2026-07
 	// after the live-API suite (issue #67) found it un-priced.
@@ -29,16 +34,33 @@ type pricingRate struct {
 //
 // Rates are public list prices. The original set is as of the spec date
 // (2026-04-14); entries added later carry their own date + source in a
-// trailing comment. If a model the handler asks about is absent from this
+// trailing comment.
+//
+// VERIFY AGAINST THE VENDOR, DO NOT COPY FROM MEMORY. Anthropic, OpenAI
+// and Google all cut prices on existing model names, so a rate that was
+// correct when written goes stale in place with nothing to signal it.
+// HasPricing only proves a model HAS an entry, never that the entry is
+// right — a missing price fails loudly at startup (#108), a wrong one
+// silently mis-bills clients until someone re-reads the pricing page
+// (which is exactly what happened to Opus 4.6, see below).
+// Anthropic: https://platform.claude.com/docs/en/about-claude/pricing If a model the handler asks about is absent from this
 // table, ComputeCostMicros returns 0 — the round still records
 // successfully, just without cost data (safer than failing the round on a
 // pricing lookup miss). Because a $0 miss is silent, cmd/server keeps the
 // configured debate models honest at startup via HasPricing (issue #108).
 var pricingTable = map[string]pricingRate{
 	ModelClaudeSonnet46: {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
-	ModelClaudeOpus46:   {inputMicrosPer1k: 15000, outputMicrosPer1k: 75000},
-	ModelGPT5Mini:       {inputMicrosPer1k: 500, outputMicrosPer1k: 2000},
-	ModelGPT5:           {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
+	// Opus 4.6: $5.00/1M in, $25.00/1M out. CORRECTED 2026-08-26 — this
+	// entry read 15000/75000, which is the RETIRED Opus 4.1 / Opus 4 rate.
+	// Anthropic cut Opus pricing at 4.5 and the entry was never updated,
+	// so every Opus call had been recorded at 3x its true cost since then.
+	// Historical project_costs rows are deliberately NOT rewritten: they
+	// are an audit trail of what was recorded at the time.
+	ModelClaudeOpus46: {inputMicrosPer1k: 5000, outputMicrosPer1k: 25000},
+	// haiku-4-5: $1.00/1M in, $5.00/1M out (issue #119).
+	ModelClaudeHaiku45: {inputMicrosPer1k: 1000, outputMicrosPer1k: 5000},
+	ModelGPT5Mini:      {inputMicrosPer1k: 500, outputMicrosPer1k: 2000},
+	ModelGPT5:          {inputMicrosPer1k: 3000, outputMicrosPer1k: 15000},
 	// gpt-5.4: $2.50/1M in, $15.00/1M out (developers.openai.com/api/docs/pricing, 2026-07).
 	ModelGPT54:       {inputMicrosPer1k: 2500, outputMicrosPer1k: 15000},
 	ModelGeminiFlash: {inputMicrosPer1k: 350, outputMicrosPer1k: 2800},

--- a/internal/ai/pricing_test.go
+++ b/internal/ai/pricing_test.go
@@ -18,6 +18,14 @@ func TestComputeCostMicros_KnownModels(t *testing.T) {
 		// is that these now compute a non-zero cost.
 		{"gpt-5.4 1k/1k", ModelGPT54, 1000, 1000, 2500 + 15000},
 		{"gemini-3-flash-preview 1k/1k", ModelGemini3FlashPreview, 1000, 1000, 500 + 3000},
+		// Opus 4.6 was priced at $15/$75 per 1M — the RETIRED Opus 4.1/4.0
+		// rate. Anthropic cut Opus pricing at 4.5 and the entry was never
+		// updated, so every Opus call was recorded at 3x its real cost.
+		// Verified against platform.claude.com/docs/en/about-claude/pricing
+		// on 2026-08-26: Claude Opus 4.6 is $5/MTok in, $25/MTok out.
+		{"claude opus 4.6 1k/1k", ModelClaudeOpus46, 1000, 1000, 5000 + 25000},
+		// Haiku 4.5, added for #119: $1/MTok in, $5/MTok out, same source.
+		{"claude haiku 4.5 1k/1k", ModelClaudeHaiku45, 1000, 1000, 1000 + 5000},
 	}
 	for _, c := range cases {
 		got := ComputeCostMicros(c.model, c.inputTok, c.outTok)
@@ -132,4 +140,46 @@ func TestCostCentsDelta_AccumulatesToBoundedError(t *testing.T) {
 	}
 	// Property: no matter where we stop, |total - totalMicros/10000| < 1
 	// (guaranteed by the delta formula: each delta = floor(new) - floor(old)).
+}
+
+// TestPricingTable_VerifiedRates pins every rate against the figure that
+// was read from Anthropic's published pricing page, so a future edit that
+// mistypes a digit fails here rather than silently mis-billing a client.
+//
+// This exists because the Opus entry was wrong for months and nothing
+// caught it: HasPricing only asserts a model HAS an entry, never that the
+// entry is CORRECT. A missing price fails loudly (issue #108's startup
+// guard); a stale price fails silently and bills someone the wrong amount.
+//
+// Rates verified 2026-08-26 against
+// https://platform.claude.com/docs/en/about-claude/pricing
+// Re-verify when bumping any model, and update the date above.
+func TestPricingTable_VerifiedRates(t *testing.T) {
+	// USD per 1M tokens, as published.
+	perMillion := map[string]struct{ in, out float64 }{
+		ModelClaudeSonnet46: {3, 15},
+		ModelClaudeOpus46:   {5, 25},
+		ModelClaudeHaiku45:  {1, 5},
+	}
+	for model, want := range perMillion {
+		// The table stores micros (millionths of USD) per 1k tokens, so
+		// USD-per-1M and micros-per-1k are numerically identical:
+		// $5/1M = 5,000,000 micros / 1000 blocks = 5000 micros per 1k.
+		wantIn := int64(want.in * 1000)
+		wantOut := int64(want.out * 1000)
+
+		rate, ok := pricingTable[model]
+		if !ok {
+			t.Errorf("%s missing from pricingTable", model)
+			continue
+		}
+		if rate.inputMicrosPer1k != wantIn {
+			t.Errorf("%s input = %d micros/1k, want %d ($%.2f per 1M)",
+				model, rate.inputMicrosPer1k, wantIn, want.in)
+		}
+		if rate.outputMicrosPer1k != wantOut {
+			t.Errorf("%s output = %d micros/1k, want %d ($%.2f per 1M)",
+				model, rate.outputMicrosPer1k, wantOut, want.out)
+		}
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,9 @@ type Config struct {
 	// every accepted round plus the background retry sweep, so each
 	// provider defaults to its cheapest priced model rather than reusing
 	// the refiner's — except Gemini, whose refiner model is already
-	// flash-class, so the scorer follows GEMINI_MODEL.
+	// flash-class, so the scorer follows GEMINI_MODEL. Claude defaulted to
+	// Sonnet only because no cheap Claude tier was priced yet; it is Haiku
+	// now (issue #119), which is 1/3 the input and 1/5 the output price.
 	ScorerModelGemini           string
 	ScorerModelOpenAI           string
 	ScorerModelClaude           string
@@ -212,8 +214,8 @@ func Load() (*Config, error) {
 		// the refiner model defaults above are literals for the same
 		// reason. Constants named in comments so a grep finds both.
 		ScorerModelGemini: envOrDefault("SCORER_MODEL_GEMINI", geminiModel),
-		ScorerModelOpenAI: envOrDefault("SCORER_MODEL_OPENAI", "gpt-5-mini"),        // ai.ModelGPT5Mini
-		ScorerModelClaude: envOrDefault("SCORER_MODEL_CLAUDE", "claude-sonnet-4-6"), // ai.ModelClaudeSonnet46
+		ScorerModelOpenAI: envOrDefault("SCORER_MODEL_OPENAI", "gpt-5-mini"),       // ai.ModelGPT5Mini
+		ScorerModelClaude: envOrDefault("SCORER_MODEL_CLAUDE", "claude-haiku-4-5"), // ai.ModelClaudeHaiku45
 
 		AnthropicInputPrice:         envInt64("ANTHROPIC_INPUT_PRICE", 300),
 		AnthropicOutputPrice:        envInt64("ANTHROPIC_OUTPUT_PRICE", 1500),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -175,8 +175,12 @@ func TestLoad_ScorerModels(t *testing.T) {
 		if cfg.ScorerModelOpenAI != "gpt-5-mini" {
 			t.Errorf("ScorerModelOpenAI = %q, want %q", cfg.ScorerModelOpenAI, "gpt-5-mini")
 		}
-		if cfg.ScorerModelClaude != "claude-sonnet-4-6" {
-			t.Errorf("ScorerModelClaude = %q, want %q", cfg.ScorerModelClaude, "claude-sonnet-4-6")
+		// Haiku, not Sonnet (#119): scoring is a small structured task on
+		// every accepted round, and Haiku is 1/3 the input and 1/5 the
+		// output price of Sonnet. Sonnet was only ever the default because
+		// no cheap Claude tier was priced in the table yet.
+		if cfg.ScorerModelClaude != "claude-haiku-4-5" {
+			t.Errorf("ScorerModelClaude = %q, want %q", cfg.ScorerModelClaude, "claude-haiku-4-5")
 		}
 	})
 

--- a/templates/pages/project_settings.html
+++ b/templates/pages/project_settings.html
@@ -91,8 +91,8 @@
                         </select>
                         <label class="label pt-1">
                             <span class="label-text-alt text-base-content/60">
-                                Scoring runs on every accepted round, so a cheap model is used per provider.
-                                Claude is currently the most expensive option.
+                                Scoring runs on every accepted round, so each provider uses its
+                                cheapest model. Cost is comparable across all three.
                             </span>
                         </label>
                     </div>


### PR DESCRIPTION
Started as #119 (add a cheap Claude tier). Auditing the table against the vendor turned up a **billing error**, which is now the more important half of this PR.

## 1. Opus 4.6 was priced 3× too high

`internal/ai/pricing.go` had `claude-opus-4-6` at **$15 / $75** per 1M tokens.

| | Repo said | Actual (verified 2026-08-26) |
|---|---|---|
| **Claude Opus 4.6** | **$15 / $75** | **$5 / $25** |
| Claude Sonnet 4.6 | $3 / $15 | $3 / $15 ✅ |
| Claude Haiku 4.5 | *(missing)* | $1 / $5 |

$15/$75 is exactly the **retired Opus 4.1 / Opus 4** rate. The entry was correct when written and silently went stale when Anthropic cut Opus pricing at 4.5.

**Impact:** `ANTHROPIC_MODEL_CONTENT` defaults to `claude-opus-4-6`, and both `cmd/server` and `cmd/orchestrator` build clients with it. That spend feeds `project_costs`, which drives the **client-facing costs page** and — since #64 — the **monthly budget cap**. So invoices overstated Opus usage, and budgets would trip at a third of their intended spend.

**Historical `project_costs` rows are deliberately not rewritten.** They're an audit trail of what was recorded at the time; editing them would change figures clients may already have been invoiced against. Fix applies going forward only.

## 2. Haiku added, and made the Claude scorer default (the original #119)

`claude-haiku-4-5` at $1/$5, and `SCORER_MODEL_CLAUDE` now defaults to it. Claude only defaulted to Sonnet because no cheap Claude tier was priced yet — Haiku is **1/3 the input and 1/5 the output** price, and scoring is a small structured call on every accepted round plus the retry sweep.

## Why nothing caught this, and what does now

`★` `HasPricing` (#108) only proves a model **has** an entry, never that the entry is **correct**. A *missing* price fails loudly at startup; a *stale* price fails silently and mis-bills until someone re-reads the vendor's page.

New `TestPricingTable_VerifiedRates` pins each Anthropic rate against the published figure, with the source URL and verification date recorded **in the test**, so a mistyped digit fails in CI rather than on an invoice. The table's doc comment now says plainly: verify against the vendor, don't copy from memory.

**Mutation-verified:** restoring the old Opus rate fails both the new rate test and the cost calculation (`= 90000, want 30000`).

## Also

Corrected the two places that told users Claude was the expensive scorer — the project-settings hint and the `AnthropicScorer` doc comment. The #63/#64 design docs still describe the old state; those record what was true when written and are left alone.

`go build`, `go vet`, full `go test ./internal/... -p 1`, and `bash scripts/lint.sh` (CI's pinned v2.11.4) all pass. `scripts/css.sh` leaves `tw.css` unchanged.

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)