### PR TITLE
deploy: pin server & orchestrator images to v0.6.1

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.6.0
+          image: registry.k3s.vlah.sh/smartpm:v0.6.1
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.6.0
+          image: registry.k3s.vlah.sh/smartpm:v0.6.1
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for the **v0.6.1 deploy, already applied to production**. `imagePullPolicy: IfNotPresent` makes the tag the only version pin, so stale manifests would let a routine `kubectl apply` roll production backwards.

`v0.6.1` (tag → `a5ba0f2`, digest `sha256:8f5321df…`).

## What shipped

| Issue | Change |
|---|---|
| **#119** | Opus 4.6 priced at the retired $15/$75 rate → corrected to $5/$25; Haiku added and made the Claude scorer default |
| **#127** | `OrgPage` no longer answers 403-vs-404, which allowed enumerating orgs by slug |
| **#128** | DB failures no longer reported as 403 Forbidden; 15 sites moved onto shared authz helpers |
| **#120** | `golangci-lint` pinned via `.golangci-version`, read by both `scripts/lint.sh` and CI |

## Deploy record

| Step | Result |
|------|--------|
| Migration | **none** — schema stays at 35 |
| Rollout | server ×2 + orchestrator, **0 restarts** |
| Digest check | all 3 pods report `sha256:8f5321df…`, identical to the built image |
| Startup | `Feature Debate Mode wired (3 refiners, 3 scorers)`, **no unpriced-model warning** — confirms the new Haiku default is both wired and priced |
| Smoke | `/login` 200 (0.21s), `/health` 200, no errors |

Historical `project_costs` rows were deliberately not rewritten — they're an audit trail of what was recorded at the time. The pricing correction applies going forward only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)