### PR TITLE
fix(orgs): make the pending-invitations list actually refresh (#92)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -316,6 +316,7 @@ func main() {
 		r.Post("/orgs", orgH.CreateOrg)
 		r.Get("/orgs/{orgSlug}", orgH.OrgPage)
 		r.Get("/orgs/{orgSlug}/settings", orgH.OrgSettings)
+		r.Get("/orgs/{orgSlug}/invitations/list", inviteH.InvitationList)
 		r.Post("/orgs/{orgSlug}/invitations", orgH.InviteMember)
 		r.Delete("/orgs/{orgSlug}/invitations/{invitationID}", inviteH.RevokeInvitation)
 		r.Post("/orgs/{orgSlug}/invitations/{invitationID}/resend", inviteH.ResendInvitation)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -87,6 +87,7 @@ func setupTestRouter(t *testing.T) (*chi.Mux, *models.DB, *auth.SessionStore, *r
 		r.Get("/orgs/{orgSlug}/settings", orgH.OrgSettings)
 		r.Post("/orgs/{orgSlug}/settings/business", orgH.UpdateBusinessDetails)
 		r.Post("/orgs/{orgSlug}/settings/budget", orgH.UpdateMonthlyBudget)
+		r.Get("/orgs/{orgSlug}/invitations/list", inviteH.InvitationList)
 		r.Post("/orgs/{orgSlug}/invitations", orgH.InviteMember)
 		r.Delete("/orgs/{orgSlug}/invitations/{invitationID}", inviteH.RevokeInvitation)
 		r.Post("/orgs/{orgSlug}/projects", projH.CreateProject)

--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/madalin/forgedesk/internal/auth"
 	"github.com/madalin/forgedesk/internal/mail"
 	"github.com/madalin/forgedesk/internal/middleware"
@@ -296,6 +298,59 @@ func (h *InviteHandler) DeclineInvitation(w http.ResponseWriter, r *http.Request
 }
 
 // RevokeInvitation revokes a pending invitation (org admin action).
+// InvitationList renders the pending-invitations partial for one org.
+//
+// Exists so the invite form's htmx.trigger('#invitation-list', 'refresh')
+// has something to call: the container previously had no hx-get, so the
+// event fired into nothing and the list stayed stale until a manual
+// reload (#92).
+//
+// Manager-gated, not merely member-gated: pending invitations carry
+// invitee email addresses, and the template already renders this section
+// behind CanManage. An endpoint that returns the same markup has to
+// enforce the same rule — a template guard is not access control.
+func (h *InviteHandler) InvitationList(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	slug := r.PathValue("orgSlug")
+
+	org, err := h.db.GetOrgBySlug(r.Context(), slug)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "Organization not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("invitation list: looking up org %q: %v", slug, err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if canManage, authErr := authorizeOrgManage(r.Context(), h.db, user, org.ID); authErr != nil {
+		log.Printf("invitation list authz for user %s org %s: %v", user.ID, org.ID, authErr)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	} else if !canManage {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	invitations, err := h.db.ListOrgInvitations(r.Context(), org.ID)
+	if err != nil {
+		log.Printf("invitation list: loading invitations for org %s: %v", org.ID, err)
+		http.Error(w, "Failed to load invitations", http.StatusInternalServerError)
+		return
+	}
+
+	// CanManage is unconditionally true: the gate above already refused
+	// anyone who is not a manager, so reaching here proves it.
+	if err := h.engine.RenderPartial(w, "invitation_list.html", map[string]any{
+		"Invitations": invitations,
+		"OrgSlug":     org.Slug,
+		"CanManage":   true,
+	}); err != nil {
+		log.Printf("rendering invitation list partial: %v", err)
+	}
+}
+
 func (h *InviteHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request) {
 	user := middleware.GetUser(r)
 	orgSlug := r.PathValue("orgSlug")

--- a/internal/handlers/invitations_list_test.go
+++ b/internal/handlers/invitations_list_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// The invite form fires htmx.trigger('#invitation-list', 'refresh'), but the
+// container had no hx-get/hx-trigger, so the event went nowhere and the
+// pending list stayed stale until a manual reload (#92). This asserts the
+// wiring exists in the template — the trigger and the listener have to
+// agree, and nothing else in the test suite would notice if they stopped.
+func TestOrgSettingsTemplate_InvitationListIsWiredForRefresh(t *testing.T) {
+	body, err := os.ReadFile(testutil.ProjectRoot() + "/templates/pages/org_settings.html")
+	if err != nil {
+		t.Fatalf("reading template: %v", err)
+	}
+	tpl := string(body)
+
+	if !strings.Contains(tpl, `htmx.trigger('#invitation-list', 'refresh')`) {
+		t.Fatal("invite form no longer triggers a refresh — if that was removed on purpose, remove this test too")
+	}
+
+	// The container must listen for exactly the event the form sends.
+	idx := strings.Index(tpl, `id="invitation-list"`)
+	if idx < 0 {
+		t.Fatal(`#invitation-list container not found`)
+	}
+	// Look at the enclosing tag only, not the whole file.
+	start := strings.LastIndex(tpl[:idx], "<")
+	end := strings.Index(tpl[idx:], ">") + idx
+	tag := tpl[start:end]
+
+	for _, want := range []string{
+		`hx-get="/orgs/`,
+		`hx-trigger="refresh"`,
+		`hx-swap="innerHTML"`,
+	} {
+		if !strings.Contains(tag, want) {
+			t.Errorf("#invitation-list tag missing %s — the refresh trigger has nothing to act on.\ntag: %s", want, tag)
+		}
+	}
+}
+
+func seedOrgWithInvitation(t *testing.T, db *models.DB, slug string) *models.Organization {
+	t.Helper()
+	ctx := context.Background()
+	org, err := db.CreateOrg(ctx, "Inv Org "+slug, slug)
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	hash, _ := auth.HashPassword("TestPassword123!")
+	inviter, err := db.CreateUser(ctx, "inviter-"+slug+"@test.com", hash, "Inviter", "client")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := db.CreateInvitation(ctx, "invitee-"+slug+"@test.com", org.ID, "member",
+		"tokenhash-"+slug, inviter.ID, time.Now().Add(72*time.Hour)); err != nil {
+		t.Fatalf("CreateInvitation: %v", err)
+	}
+	return org
+}
+
+// The list is manager-only: pending invitations expose invitee email
+// addresses, and the template already renders that section behind
+// CanManage. The GET endpoint must enforce the same thing rather than
+// relying on the template to hide it.
+func TestInvitationList_RoleMatrix(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	ctx := context.Background()
+
+	org := seedOrgWithInvitation(t, db, "inv-matrix-org")
+	createAuthenticatedUser(t, db, sessions, "first-sa-inv@test.com", "superadmin")
+
+	mkUser := func(email, platformRole, orgRole string) *http.Cookie {
+		t.Helper()
+		// Shared helper across ~40 tests; it manages its own background
+		// context and threading this one through would change its signature
+		// everywhere.
+		cookie := createAuthenticatedUser(t, db, sessions, email, platformRole) //nolint:contextcheck // shared helper manages its own ctx
+		if orgRole != "" {
+			var uid string
+			if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = $1`, email).Scan(&uid); err != nil {
+				t.Fatalf("look up %s: %v", email, err)
+			}
+			if _, err := db.Pool.Exec(ctx,
+				`INSERT INTO org_memberships (user_id, org_id, role) VALUES ($1,$2,$3)`, uid, org.ID, orgRole); err != nil {
+				t.Fatalf("membership: %v", err)
+			}
+		}
+		return cookie
+	}
+
+	cases := []struct {
+		name     string
+		cookie   *http.Cookie
+		wantCode int
+		wantsPII bool
+	}{
+		{"owner sees the list", mkUser("owner-inv@test.com", "client", "owner"), http.StatusOK, true},
+		{"staff sees any org's list", mkUser("staff-inv@test.com", "staff", ""), http.StatusOK, true},
+		{"plain member cannot", mkUser("member-inv@test.com", "client", "member"), http.StatusForbidden, false},
+		{"non-member cannot", mkUser("outsider-inv@test.com", "client", ""), http.StatusForbidden, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/orgs/inv-matrix-org/invitations/list", http.NoBody)
+			req.AddCookie(tc.cookie)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("got %d, want %d", rec.Code, tc.wantCode)
+			}
+			leaked := strings.Contains(rec.Body.String(), "invitee-inv-matrix-org@test.com")
+			if leaked != tc.wantsPII {
+				t.Errorf("invitee email present = %v, want %v", leaked, tc.wantsPII)
+			}
+		})
+	}
+}

--- a/templates/pages/org_settings.html
+++ b/templates/pages/org_settings.html
@@ -277,7 +277,16 @@
     <div class="card bg-base-100 border border-base-300 shadow-sm">
         <div class="card-body p-6 gap-3">
             <h2 class="text-lg font-semibold">Pending Invitations</h2>
-            <div class="divide-y divide-base-300" id="invitation-list">
+            {{/* hx-get/hx-trigger are what make the invite form's
+                 htmx.trigger('#invitation-list', 'refresh') do anything —
+                 without them the event fires into nothing and the list
+                 stays stale until a reload (#92). The event name here and
+                 the one in the form's hx-on::after-request must match. */}}
+            <div class="divide-y divide-base-300"
+                 id="invitation-list"
+                 hx-get="/orgs/{{.OrgSlug}}/invitations/list"
+                 hx-trigger="refresh"
+                 hx-swap="innerHTML">
                 {{template "invitation_list.html" .}}
             </div>
         </div>


### PR DESCRIPTION
## Problem

The invite form has called `htmx.trigger('#invitation-list', 'refresh')` since before the v0.3.0 CSS migration — but the container had **no `hx-get` and no `hx-trigger`**. The event fired into nothing, and the pending-invitations list stayed stale until the user reloaded.

`★` A trigger with no listener is invisible to review: **both halves look correct on their own.** The form legitimately announces "something changed"; the container legitimately renders a list. Only the pairing is broken, and nothing in the codebase asserted they agreed.

## Fix

- New `GET /orgs/{orgSlug}/invitations/list` returning the same `invitation_list.html` partial that `RevokeInvitation` and `ResendInvitation` already swap into that container.
- Container wired with `hx-get` / `hx-trigger="refresh"` / `hx-swap="innerHTML"`.

## The part the issue didn't mention: authorization

The endpoint is **manager-gated, not member-gated.** Pending invitations carry **invitee email addresses**, and the template already renders that section behind `CanManage`. An endpoint serving the same markup must enforce the same rule — a template guard is not access control.

That's the lesson from #122, where the business-details card was withheld only by an `{{if}}` written for UI reasons and would have leaked the moment anyone refactored the template. Uses `authorizeOrgManage` from #128, so a database failure returns 500 rather than being reported as a denial.

| Role | Result |
|---|---|
| Owner / admin | 200 + list |
| Staff (any org) | 200 + list |
| Plain member | **403**, no invitee email in the body |
| Non-member | **403**, no invitee email in the body |

## Tests

- **Template test** asserting the trigger and the listener agree — this is the actual bug, and nothing else in the suite would notice if they drifted apart again.
- **Full role matrix** through the real router, asserting both status *and* absence of the invitee's email.

**Mutation-verified both:** removing `hx-trigger` reproduces the original dead trigger; swapping the manager gate for a membership gate leaks the invitee's email to a plain member.

**No E2E test**, stated rather than silently skipped: CI runs exactly one self-registering Playwright spec and it's the *debate* spec — this is org settings. The template test covers the wiring E2E would have caught here.

`go build`, `go vet`, full `go test ./internal/... -p 1`, `bash scripts/lint.sh` (CI's pinned v2.11.4), and `scripts/css.sh` (leaves `tw.css` unchanged) all pass.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)