### PR TITLE
fix(comments): show real author names on ticket detail (#95)

### DIFF
--- a/e2e/tests/04-tickets.spec.js
+++ b/e2e/tests/04-tickets.spec.js
@@ -131,6 +131,41 @@ test.describe('Tickets & Comments', () => {
     }
   });
 
+  // #95: the ticket page rendered stored comments with a hardcoded "User"
+  // byline while the HTMX partial for a just-posted comment showed the real
+  // name, so reloading renamed the author. Only a browser sees both states,
+  // which is why this assertion lives here and not in a handler test.
+  //
+  // Deliberately written without the `if (await ...isVisible())` guard used
+  // by the tests above: a guard like that turns a missing ticket into a
+  // silent pass, and this test exists to catch a rendering regression.
+  test('comment author name survives a reload', async ({ page }) => {
+    test.skip(!projectId, 'Project ID not found');
+
+    await fullLogin(page, { ...testUser, totpSecret });
+    await page.goto('/orgs/ticket-org/projects/ticket-project/features');
+
+    await page.click('a:has-text("E2E Epic Feature")');
+    await page.waitForLoadState('networkidle');
+
+    const body = 'Comment authored by a named user';
+    await page.fill('textarea[name="body"]', body);
+    await page.click('button:has-text("Comment")');
+    await page.waitForTimeout(1000);
+
+    // Freshly posted, via the HTMX partial.
+    const bylines = page.locator('#comments span.font-medium');
+    await expect(bylines.filter({ hasText: testUser.name })).toHaveCount(1);
+
+    // Same comment after a full server-side re-render. Before #95 this
+    // flipped to the generic "User".
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('body')).toContainText(body);
+    await expect(bylines.filter({ hasText: testUser.name })).toHaveCount(1);
+    await expect(bylines.filter({ hasText: /^User$/ })).toHaveCount(0);
+  });
+
   test('update ticket status', async ({ page }) => {
     test.skip(!projectId, 'Project ID not found');
 

--- a/internal/handlers/comments.go
+++ b/internal/handlers/comments.go
@@ -50,7 +50,7 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// Return the new comment as an HTMX partial (no reactions yet on a brand-new comment)
 	if err := h.engine.RenderPartial(w, "comment.html", map[string]any{
 		"Comment":          comment,
-		"UserName":         user.Name,
+		"AuthorName":       models.CommentAuthorName(comment.AgentName, &user.Name),
 		"CommentReactions": []models.ReactionGroup(nil),
 	}); err != nil {
 		log.Printf("rendering comment partial: %v", err)

--- a/internal/handlers/comments_author_test.go
+++ b/internal/handlers/comments_author_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/auth"
+	"github.com/madalin/forgedesk/internal/models"
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// authorSpan is the exact markup both render paths must produce for a
+// comment's author. Asserting on the span rather than the bare name keeps
+// these tests from passing on an incidental occurrence of "User" or a
+// person's name elsewhere on the ticket page.
+func authorSpan(name string) string {
+	return `<span class="font-medium">` + name + `</span>`
+}
+
+// TestTicketDetailShowsCommentAuthorNames locks in #95: the ticket detail
+// page rendered every existing comment with a hardcoded generic "User",
+// because its inline {{range .Comments}} loop only had a models.Comment
+// (which carries user_id, not the user's name). The real name appeared
+// only on the comment you had just posted, via the HTMX partial — so the
+// same comment was labeled differently before and after a reload.
+func TestTicketDetailShowsCommentAuthorNames(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	cookie := createAuthenticatedUser(t, db, sessions, "viewer95@test.com", "superadmin")
+	ctx := context.Background()
+
+	org, _ := db.CreateOrg(ctx, "Author Org", "author-org-95")
+	proj, _ := db.CreateProject(ctx, org.ID, "Author Proj", "author-proj-95")
+	viewer, _ := db.GetUserByEmail(ctx, "viewer95@test.com")
+
+	// A second, differently-named human so the assertion cannot pass on
+	// the viewer's own name leaking in from the navbar.
+	hash, _ := auth.HashPassword("TestPassword123!")
+	author, err := db.CreateUser(ctx, "alice95@test.com", hash, "Alice Author", "client")
+	if err != nil {
+		t.Fatalf("creating comment author: %v", err)
+	}
+
+	ticket := &models.Ticket{
+		ProjectID: proj.ID, Type: "task", Title: "Author Task",
+		Status: "backlog", Priority: "medium", CreatedBy: viewer.ID,
+	}
+	if err := db.CreateTicket(ctx, ticket); err != nil {
+		t.Fatalf("creating ticket: %v", err)
+	}
+
+	if _, err := db.CreateComment(ctx, ticket.ID, &author.ID, nil, "human comment"); err != nil {
+		t.Fatalf("creating human comment: %v", err)
+	}
+	agent := "claude"
+	if _, err := db.CreateComment(ctx, ticket.ID, nil, &agent, "agent comment"); err != nil {
+		t.Fatalf("creating agent comment: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/tickets/"+ticket.ID, http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, authorSpan("Alice Author")) {
+		t.Errorf("ticket page did not show the human comment author's real name")
+	}
+	// Agent comments stay behind a single generic label on purpose: clients
+	// must not see which agent (claude/gemini/codex/mistral) produced a
+	// comment. This is the one case where a generic name is correct.
+	if !strings.Contains(body, authorSpan("ForgeDesk Bot")) {
+		t.Errorf("ticket page did not label the agent comment as ForgeDesk Bot")
+	}
+	if strings.Contains(body, authorSpan("User")) {
+		t.Errorf("ticket page still renders the hardcoded generic \"User\" author")
+	}
+	if strings.Contains(body, authorSpan("claude")) {
+		t.Errorf("ticket page leaked the underlying agent name to the client")
+	}
+}
+
+// TestCreateCommentPartialShowsAuthorName is the other half of #95: the
+// HTMX partial must label the new comment with the same span the full
+// page produces, so posting then reloading does not rename the author.
+func TestCreateCommentPartialShowsAuthorName(t *testing.T) {
+	r, db, sessions, _ := setupTestRouter(t)
+	cookie := createAuthenticatedUser(t, db, sessions, "poster95@test.com", "superadmin")
+	ctx := context.Background()
+
+	org, _ := db.CreateOrg(ctx, "Poster Org", "poster-org-95")
+	proj, _ := db.CreateProject(ctx, org.ID, "Poster Proj", "poster-proj-95")
+	user, _ := db.GetUserByEmail(ctx, "poster95@test.com")
+	ticket := &models.Ticket{
+		ProjectID: proj.ID, Type: "task", Title: "Poster Task",
+		Status: "backlog", Priority: "medium", CreatedBy: user.ID,
+	}
+	if err := db.CreateTicket(ctx, ticket); err != nil {
+		t.Fatalf("creating ticket: %v", err)
+	}
+
+	form := url.Values{"body": {"hello"}}
+	req := httptest.NewRequest(http.MethodPost, "/tickets/"+ticket.ID+"/comments", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), authorSpan(user.Name)) {
+		t.Errorf("HTMX comment partial did not show the author name %q: %s", user.Name, rec.Body.String())
+	}
+}
+
+// TestTicketDetailDelegatesCommentMarkup guards the structural half of
+// #95. The bug existed because comment markup lived in two places that
+// had to be edited in lockstep; #37 had already patched one copy and left
+// a comment in each saying "keep this matching the other". Behavioral
+// assertions above catch today's divergence, but only this one catches
+// someone re-inlining the markup and starting the drift over.
+func TestTicketDetailDelegatesCommentMarkup(t *testing.T) {
+	page := filepath.Join(testutil.ProjectRoot(), "templates", "pages", "ticket_detail.html")
+	src, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatalf("reading ticket_detail.html: %v", err)
+	}
+	if !strings.Contains(string(src), `{{template "comment.html"`) {
+		t.Errorf("ticket_detail.html must render comments via the comment.html partial")
+	}
+	if strings.Contains(string(src), "comment-body") {
+		t.Errorf("ticket_detail.html still carries its own copy of the comment markup; it belongs only in components/comment.html")
+	}
+}

--- a/internal/handlers/tickets.go
+++ b/internal/handlers/tickets.go
@@ -55,7 +55,7 @@ type ticketDetailData struct {
 	Ticket           *models.Ticket
 	CommentReactions map[string][]models.ReactionGroup
 	Children         []models.Ticket
-	Comments         []models.Comment
+	Comments         []models.CommentWithAuthor
 	Attachments      []models.TicketAttachment
 	TicketReactions  []models.ReactionGroup
 	IsStaff          bool
@@ -85,7 +85,7 @@ func (h *TicketHandler) TicketDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	children, _ := h.db.ListTicketsByParent(r.Context(), ticket.ID)
-	comments, _ := h.db.ListComments(r.Context(), ticket.ID)
+	comments, _ := h.db.ListCommentsWithAuthors(r.Context(), ticket.ID)
 	attachments, _ := h.db.ListAttachmentsByTicket(r.Context(), ticket.ID)
 
 	// Load reactions for ticket

--- a/internal/models/comment_author_test.go
+++ b/internal/models/comment_author_test.go
@@ -1,0 +1,33 @@
+package models
+
+import "testing"
+
+// TestCommentAuthorName pins the three cases the ticket page and the HTMX
+// partial both route through (#95). The deleted-user case is here rather
+// than in a handler test because deleting a user with comments is awkward
+// to stage through HTTP, and it is the case most likely to regress: it is
+// the only one that depends on a NULL surviving the LEFT JOIN.
+func TestCommentAuthorName(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	tests := []struct {
+		name      string
+		agentName *string
+		userName  *string
+		want      string
+	}{
+		{"human comment shows the real name", nil, str("Alice Author"), "Alice Author"},
+		{"agent comment is never named to the client", str("claude"), nil, "ForgeDesk Bot"},
+		{"agent wins even if a user row is somehow joined", str("gemini"), str("Alice"), "ForgeDesk Bot"},
+		{"deleted author falls back rather than showing a blank byline", nil, nil, "User"},
+		{"empty name is treated as no name", nil, str(""), "User"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CommentAuthorName(tt.agentName, tt.userName); got != tt.want {
+				t.Errorf("CommentAuthorName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -117,6 +117,38 @@ type Comment struct {
 	BodyMarkdown string    `db:"body_markdown"`
 }
 
+// CommentWithAuthor is a Comment plus the single name to display for its
+// author. It is a distinct type rather than a joined `AuthorName` field on
+// Comment (the convention used by BriefRevision/AIMessage above) so the
+// compiler stops an author-less []Comment from reaching a render path: the
+// bug this fixes (#95) was precisely two render paths disagreeing about the
+// author, and a zero-value string would have shown a blank byline instead
+// of failing loudly.
+type CommentWithAuthor struct {
+	Comment
+	AuthorName string
+}
+
+// CommentAuthorName resolves the one name shown for a comment. Both render
+// paths call it so neither can drift from the other again.
+//
+// Agent comments collapse to a single generic label on purpose: the client
+// role must not see which agent produced the work (CLAUDE.md: "client
+// (per-org, no agent internals visible)"), so agent_name is never rendered.
+//
+// No agent and no user name means the author row is gone — a deleted user.
+// "User" is the honest fallback; an empty byline would look like a bug.
+func CommentAuthorName(agentName, userName *string) string {
+	switch {
+	case agentName != nil:
+		return "ForgeDesk Bot"
+	case userName != nil && *userName != "":
+		return *userName
+	default:
+		return "User"
+	}
+}
+
 type TicketActivity struct {
 	CreatedAt   time.Time `db:"created_at"`
 	UserID      *string   `db:"user_id"`

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -1650,6 +1650,9 @@ func (db *DB) ListCommentsWithAuthors(ctx context.Context, ticketID string) ([]C
 	var comments []CommentWithAuthor
 	for rows.Next() {
 		var cw CommentWithAuthor
+		// Scanned into a local rather than a struct field: the comments
+		// table has user_id/agent_name but no name, so the author's name
+		// exists only for the lifetime of this joined row.
 		var userName *string
 		if err := rows.Scan(&cw.ID, &cw.TicketID, &cw.UserID, &cw.AgentName,
 			&cw.BodyMarkdown, &cw.CreatedAt, &userName); err != nil {

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -1626,6 +1626,41 @@ func (db *DB) ListComments(ctx context.Context, ticketID string) ([]Comment, err
 	return comments, rows.Err()
 }
 
+// ListCommentsWithAuthors returns a ticket's comments for rendering, each
+// carrying a resolved display name.
+//
+// The plain ListComments above is deliberately kept for the AI-context
+// builders (orchestrator, assistant): they hand raw user_id/agent_name to a
+// third-party LLM and must NOT start shipping real people's names into
+// provider prompts just because the ticket page needed them.
+//
+// LEFT JOIN, not JOIN: agent comments have user_id IS NULL, and an inner
+// join would silently drop every bot comment from the page.
+func (db *DB) ListCommentsWithAuthors(ctx context.Context, ticketID string) ([]CommentWithAuthor, error) {
+	rows, err := db.Pool.Query(ctx,
+		`SELECT c.id, c.ticket_id, c.user_id, c.agent_name, c.body_markdown, c.created_at, u.name
+		 FROM comments c
+		 LEFT JOIN users u ON u.id = c.user_id
+		 WHERE c.ticket_id = $1 ORDER BY c.created_at`, ticketID)
+	if err != nil {
+		return nil, fmt.Errorf("listing comments with authors: %w", err)
+	}
+	defer rows.Close()
+
+	var comments []CommentWithAuthor
+	for rows.Next() {
+		var cw CommentWithAuthor
+		var userName *string
+		if err := rows.Scan(&cw.ID, &cw.TicketID, &cw.UserID, &cw.AgentName,
+			&cw.BodyMarkdown, &cw.CreatedAt, &userName); err != nil {
+			return nil, fmt.Errorf("scanning comment with author: %w", err)
+		}
+		cw.AuthorName = CommentAuthorName(cw.AgentName, userName)
+		comments = append(comments, cw)
+	}
+	return comments, rows.Err()
+}
+
 // ── Activities ────────────────────────────────────────────────────
 
 func (db *DB) CreateActivity(ctx context.Context, ticketID string, userID, agentName *string, action, detailsJSON string) error {

--- a/templates/components/comment.html
+++ b/templates/components/comment.html
@@ -4,7 +4,7 @@
      until reload when the full page re-rendered it properly. (#37) */}}
 <div class="border-l-2 border-base-300 pl-4">
     <div class="flex items-center gap-2 text-xs mb-1">
-        <span class="font-medium">{{.UserName}}</span>
+        <span class="font-medium">{{.AuthorName}}</span>
         <span class="text-base-content/50">·</span>
         <span class="text-base-content/60">{{formatDateTime .Comment.CreatedAt}}</span>
     </div>

--- a/templates/pages/ticket_detail.html
+++ b/templates/pages/ticket_detail.html
@@ -308,21 +308,15 @@
             <h3 class="text-base font-semibold">Comments</h3>
             <div id="comments" class="flex flex-col gap-4">
                 {{$cr := .CommentReactions}}
+                {{/* Delegated to components/comment.html rather than
+                     inlined: this loop and the partial used for HTMX-posted
+                     comments used to be near-duplicates kept in sync by
+                     hand, and they drifted — the loop hardcoded a generic
+                     "User" byline while the partial showed the real name,
+                     so a comment was renamed by a page reload (#95). One
+                     copy means they cannot disagree again. */}}
                 {{range .Comments}}
-                <div class="border-l-2 border-base-300 pl-4">
-                    <div class="flex items-center gap-2 text-xs mb-1">
-                        <span class="font-medium">{{if .AgentName}}ForgeDesk Bot{{else}}User{{end}}</span>
-                        <span class="text-base-content/50">·</span>
-                        <span class="text-base-content/60">{{formatDateTime .CreatedAt}}</span>
-                    </div>
-                    {{/* comment-body class retained alongside prose so the
-                         #37 partial-render regression test has a stable
-                         landmark independent of Tailwind refactors. Also
-                         matches the comment.html partial used for HTMX-
-                         posted comments after initial load. */}}
-                    <div class="comment-body prose prose-sm max-w-none">{{markdown .BodyMarkdown}}</div>
-                    {{template "reactions.html" dict "TargetType" "comment" "TargetID" .ID "Groups" (index $cr .ID)}}
-                </div>
+                {{template "comment.html" dict "Comment" .Comment "AuthorName" .AuthorName "CommentReactions" (index $cr .Comment.ID)}}
                 {{end}}
             </div>
 


### PR DESCRIPTION
Closes #95.

## The bug

The ticket detail page rendered stored comments through its own inline
`{{range .Comments}}` loop, while comments posted over HTMX rendered through
`templates/components/comment.html`. The two were near-duplicate markup kept in
sync by hand — each even carried a comment telling the next reader to keep it
matching the other — and they had drifted.

The inline loop hardcoded a generic `User` byline, because all it had was a
`models.Comment`, which carries `user_id` but not the user's name. Visible
symptom: post a comment and it shows your name; reload and the same comment is
now authored by "User".

## The fix

One render path instead of two.

- `models.CommentAuthorName` is the single resolver **both** paths call, so they
  cannot drift again.
- `db.ListCommentsWithAuthors` **LEFT** JOINs users. Inner would have silently
  dropped every agent comment, which has `user_id IS NULL`.
- `ticket_detail.html` deletes its comment markup and delegates to the partial.

Two things preserved deliberately:

- **Agent comments still show the generic "ForgeDesk Bot"**, never the real
  agent (claude/gemini/codex/mistral). Clients must not see agent internals.
  The naive "delegate to the partial" fix drops this, because the partial only
  knew about human users — that would have traded one bug for another.
- **The un-joined `ListComments` stays** for the orchestrator and assistant AI
  context builders. They hand raw `user_id`/`agent_name` to third-party LLMs;
  joining names there would have started shipping real people's names into
  provider prompts as a side effect of a rendering fix.

`CommentWithAuthor` is a distinct embedded type rather than a joined field on
`Comment` (the `BriefRevision`/`AIMessage` convention in this repo). That
deviation is deliberate and is the one thing worth arguing about in review: it
makes the compiler reject an author-less comment list reaching a render path,
where a zero-value string would have rendered a blank byline instead of failing.
It did in fact catch `ticketDetailData.Comments` during implementation.

## Evidence

**What would be true if this were broken?** The page and the partial would
disagree about a comment's author, or agent comments would vanish or be named.

- `TestTicketDetailShowsCommentAuthorNames` — drives the real router with a real
  URL, seeds a comment by "Alice Author" plus an agent comment, and asserts on
  the exact byline span: real name present, `ForgeDesk Bot` present, generic
  `User` absent, agent name `claude` absent.
- `TestCreateCommentPartialShowsAuthorName` — the HTMX half produces the same span.
- `TestTicketDetailDelegatesCommentMarkup` — structural guard. The behavioural
  tests catch today's divergence; only this one catches someone re-inlining the
  markup and starting the drift over.
- `TestCommentAuthorName` — the resolver, including the deleted-author fallback,
  which is the case that depends on a NULL surviving the LEFT JOIN.

**Mutation-tested** (broke it, watched it go red, restored):

| Mutation | Result |
|---|---|
| `LEFT JOIN` -> `JOIN` | RED — agent comment dropped |
| return the real agent name | RED — two assertions, including the leak guard |
| partial byline back to literal `User` | RED — both render paths |
| drop the empty-name guard in the resolver | RED — unit test |

Full `./internal/...` suite green (`-p 1 -count=1`), `bash scripts/lint.sh` 0 issues.

Reviewed by codex-reviewer (approve, no defects; independently confirmed no
third comment render path exists anywhere in the repo) and vibe-reviewer
(comprehension pass; its one actionable note is applied in f41da59).

## E2E: written, NOT executed — stated per policy

`e2e/tests/04-tickets.spec.js` gains `comment author name survives a reload`,
which is the browser-shaped assertion for this bug: post, assert the byline,
reload, assert the byline again. It is written with hard assertions rather than
the `if (await ...isVisible())` guard used by its neighbours.

**It could not be run, for reasons that predate this PR.** The whole suite
self-skips. Filed separately — see the follow-up issue. Summary:

1. `RegisterPage` (`internal/handlers/auth.go:103`) redirects once **one** user
   exists — registration is first-user-only. Every spec file calls
   `registerUser` in its own `beforeAll`, so at most one spec can self-provision
   per database, and only against a freshly wiped volume.
2. `beforeAll` scrapes `projectId` out of page HTML; when step 1 fails the scrape
   returns empty, and `test.skip(!projectId)` turns the whole broken suite into
   a green "8 skipped".

I verified 1 directly (`/register` -> 303 to `/login` with any user present) and
confirmed the app itself is healthy — login, 2FA setup, and `/dashboard` all work
against a clean stack. Repairing the harness is its own task and is not in scope
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)