### PR TITLE
fix(budget): count spend in an append-only ledger, not on deletable rows (#129)

### DIFF
--- a/internal/handlers/debate_budget_test.go
+++ b/internal/handlers/debate_budget_test.go
@@ -251,14 +251,30 @@ func seedSpendForTicket(t *testing.T, db *models.DB, ticket *models.Ticket, cost
 		t.Fatalf("computing next round_number: %v", err)
 	}
 
-	if _, err := db.Pool.Exec(ctx,
+	var roundID string
+	if err := db.Pool.QueryRow(ctx,
 		`INSERT INTO feature_debate_rounds (
 			debate_id, round_number, provider, model, triggered_by,
 			input_text, output_text, status, cost_micros, created_at
-		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', 'out', 'accepted', $4, $5)`,
+		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', 'out', 'accepted', $4, $5)
+		RETURNING id`,
 		deb.ID, roundNum, ticket.CreatedBy, costMicros, createdAt,
-	); err != nil {
+	).Scan(&roundID); err != nil {
 		t.Fatalf("seeding spend round: %v", err)
+	}
+
+	// Enforcement reads the append-only spend ledger, not the round row: undo
+	// deletes rounds, and deleting user content must not delete the record of
+	// money already paid (#129). Real round creation writes both in one
+	// transaction, so a fixture that wrote only the round would describe a
+	// state the application cannot produce, and these cap tests would be
+	// asserting against a figure the running system never sees.
+	if _, err := db.Pool.Exec(ctx,
+		`INSERT INTO debate_spend (org_id, debate_id, round_id, kind, cost_micros, incurred_at)
+		 SELECT d.org_id, d.id, $2, 'round', $3, $4 FROM feature_debates d WHERE d.id = $1`,
+		deb.ID, roundID, costMicros, createdAt,
+	); err != nil {
+		t.Fatalf("seeding spend ledger: %v", err)
 	}
 }
 
@@ -434,14 +450,25 @@ func TestCreateRound_ScorerCostCountsTowardCap(t *testing.T) {
 	}
 	// Zero refiner cost, ALL of it scorer cost — this must still trip
 	// the cap, proving the aggregate isn't refiner-cost-only.
-	if _, err := db.Pool.Exec(context.Background(),
+	var scorerRoundID string
+	if err := db.Pool.QueryRow(context.Background(),
 		`INSERT INTO feature_debate_rounds (
 			debate_id, round_number, provider, model, triggered_by,
 			input_text, output_text, status, cost_micros, scorer_cost_micros, created_at
-		) VALUES ($1, 1, 'claude', 'claude-test', $2, 'in', 'out', 'accepted', 0, $3, now())`,
+		) VALUES ($1, 1, 'claude', 'claude-test', $2, 'in', 'out', 'accepted', 0, $3, now())
+		RETURNING id`,
 		deb.ID, ticket.CreatedBy, 100*microsPerCentDebate,
-	); err != nil {
+	).Scan(&scorerRoundID); err != nil {
 		t.Fatalf("seeding scorer-cost round: %v", err)
+	}
+	// The ledger is what enforcement reads; a scorer charge is its own entry
+	// there because a round can be scored more than once (#129).
+	if _, err := db.Pool.Exec(context.Background(),
+		`INSERT INTO debate_spend (org_id, debate_id, round_id, kind, cost_micros)
+		 SELECT d.org_id, d.id, $2, 'scorer', $3 FROM feature_debates d WHERE d.id = $1`,
+		deb.ID, scorerRoundID, 100*microsPerCentDebate,
+	); err != nil {
+		t.Fatalf("seeding scorer spend ledger: %v", err)
 	}
 
 	rec := postCreateRound(t, r, ticket, cookie)

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -903,17 +903,52 @@ func (db *DB) UpdateOrgMonthlyBudget(ctx context.Context, orgID, actorUserID str
 // contract in internal/handlers/debate.go.
 func (db *DB) SumOrgDebateSpendMicros(ctx context.Context, orgID string, from, to time.Time) (int64, error) {
 	var sum int64
+	// Reads the append-only ledger, NOT feature_debate_rounds. Undo hard-deletes
+	// rounds, so summing them let a user reclaim headroom for money already paid
+	// to the provider (#129). Both callers — the cap check in debate.go and the
+	// org settings spend display — go through here, so they cannot disagree.
 	err := db.Pool.QueryRow(ctx,
-		`SELECT COALESCE(SUM(COALESCE(r.cost_micros,0) + COALESCE(r.scorer_cost_micros,0)), 0)::BIGINT
-		   FROM feature_debate_rounds r
-		   JOIN feature_debates d ON d.id = r.debate_id
-		  WHERE d.org_id = $1 AND r.created_at >= $2 AND r.created_at < $3`,
+		`SELECT COALESCE(SUM(cost_micros), 0)::BIGINT
+		   FROM debate_spend
+		  WHERE org_id = $1 AND incurred_at >= $2 AND incurred_at < $3`,
 		orgID, from, to,
 	).Scan(&sum)
 	if err != nil {
 		return 0, fmt.Errorf("summing org debate spend: %w", err)
 	}
 	return sum, nil
+}
+
+// RecordDebateSpendTx appends one charge to the spend ledger.
+//
+// MUST be called inside the same transaction that records the cost, so the
+// ledger cannot commit without the thing it is charging for, or vice versa.
+//
+// org_id is resolved by sub-select from the debate rather than passed in: the
+// caller already holds the debate row and this keeps the two from drifting.
+//
+// There is deliberately NO uniqueness or upsert here. Every call represents a
+// separate provider call that was really billed — notably the effort scorer,
+// which the retry sweep runs again on a round it already scored. Collapsing
+// those would silently discard real charges, which is the same class of bug
+// this table exists to fix.
+func (db *DB) RecordDebateSpendTx(
+	ctx context.Context, tx pgx.Tx, debateID, roundID, kind string, costMicros int64,
+) error {
+	if costMicros <= 0 {
+		return nil // nothing was billed; no ledger entry to make
+	}
+	_, err := tx.Exec(ctx,
+		`INSERT INTO debate_spend (org_id, debate_id, round_id, kind, cost_micros)
+		 SELECT d.org_id, d.id, $2, $3, $4
+		   FROM feature_debates d
+		  WHERE d.id = $1`,
+		debateID, roundID, kind, costMicros,
+	)
+	if err != nil {
+		return fmt.Errorf("recording debate spend: %w", err)
+	}
+	return nil
 }
 
 // CurrentUTCMonthRange returns [start,end) of the UTC month containing
@@ -2742,6 +2777,12 @@ func (db *DB) InsertDebateRoundTx(
 		return nil, 0, err
 	}
 
+	// Same transaction as the round INSERT: the charge and the record of it
+	// commit together or not at all (#129).
+	if spendErr := db.RecordDebateSpendTx(ctx, tx, in.DebateID, r.ID, "round", in.CostMicros); spendErr != nil {
+		return nil, 0, spendErr
+	}
+
 	newTotalMicros := oldTotalMicros + in.CostMicros
 	if _, err = tx.Exec(ctx, `
 		UPDATE feature_debates
@@ -2956,11 +2997,24 @@ func (db *DB) UpdateEffortScoreCondTx(
 // for the call, and the canonical per-round audit trail must reflect
 // that).
 func (db *DB) UpdateScorerCostMicros(ctx context.Context, tx pgx.Tx, roundID string, cost int64) error {
-	_, err := tx.Exec(ctx,
+	if _, err := tx.Exec(ctx,
 		`UPDATE feature_debate_rounds SET scorer_cost_micros = $1 WHERE id = $2`,
 		cost, roundID,
-	)
-	return err
+	); err != nil {
+		return err
+	}
+
+	// The column above is a SET, so a re-score overwrites the previous
+	// attempt's cost and the earlier charge disappears. Every scorer call is
+	// separately billed, so the ledger gets its own row per call and the month
+	// total counts all of them (#129).
+	var debateID string
+	if err := tx.QueryRow(ctx,
+		`SELECT debate_id FROM feature_debate_rounds WHERE id = $1`, roundID,
+	).Scan(&debateID); err != nil {
+		return fmt.Errorf("resolving debate for scorer spend: %w", err)
+	}
+	return db.RecordDebateSpendTx(ctx, tx, debateID, roundID, "scorer", cost)
 }
 
 // StaleEffortDebate is one debate claimed by the effort-score retry

--- a/internal/models/queries_budget_test.go
+++ b/internal/models/queries_budget_test.go
@@ -213,14 +213,41 @@ func seedRoundAt(t *testing.T, db *DB, debateID, triggeredBy string, roundNum in
 	costMicros, scorerCostMicros *int64, status string, createdAt time.Time,
 ) {
 	t.Helper()
-	if _, err := db.Pool.Exec(context.Background(),
+	ctx := context.Background()
+	var roundID string
+	if err := db.Pool.QueryRow(ctx,
 		`INSERT INTO feature_debate_rounds (
 			debate_id, round_number, provider, model, triggered_by,
 			input_text, output_text, status, cost_micros, scorer_cost_micros, created_at
-		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', 'out', $4, $5, $6, $7)`,
+		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', 'out', $4, $5, $6, $7)
+		RETURNING id`,
 		debateID, roundNum, triggeredBy, status, costMicros, scorerCostMicros, createdAt,
-	); err != nil {
+	).Scan(&roundID); err != nil {
 		t.Fatalf("seedRoundAt: %v", err)
+	}
+
+	// Mirror what real round creation does: a billed round also appends to the
+	// spend ledger, which is what enforcement reads (#129). Seeding only the
+	// round row would describe a state the application cannot produce, and the
+	// aggregate tests would be measuring a fiction. incurred_at tracks
+	// created_at so the month-boundary cases still land where they intend.
+	seedSpendAt(t, db, debateID, roundID, "round", costMicros, createdAt)
+	seedSpendAt(t, db, debateID, roundID, "scorer", scorerCostMicros, createdAt)
+}
+
+// seedSpendAt appends one ledger charge, skipping the no-charge case so a NULL
+// cost column does not become a zero-value row.
+func seedSpendAt(t *testing.T, db *DB, debateID, roundID, kind string, costMicros *int64, incurredAt time.Time) {
+	t.Helper()
+	if costMicros == nil || *costMicros <= 0 {
+		return
+	}
+	if _, err := db.Pool.Exec(context.Background(),
+		`INSERT INTO debate_spend (org_id, debate_id, round_id, kind, cost_micros, incurred_at)
+		 SELECT d.org_id, d.id, $2, $3, $4, $5 FROM feature_debates d WHERE d.id = $1`,
+		debateID, roundID, kind, *costMicros, incurredAt,
+	); err != nil {
+		t.Fatalf("seedSpendAt(%s): %v", kind, err)
 	}
 }
 

--- a/internal/models/queries_spend_backfill_test.go
+++ b/internal/models/queries_spend_backfill_test.go
@@ -1,0 +1,107 @@
+package models
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// backfillStatements pulls the INSERT statements out of the real migration
+// file rather than restating them here. A copy in the test would be free to
+// drift from the SQL that actually ships, and the backfill runs exactly once
+// against production — there is no second chance to notice.
+func backfillStatements(t *testing.T) []string {
+	t.Helper()
+	path := filepath.Join(testutil.ProjectRoot(), "migrations", "000036_debate_spend_ledger.up.sql")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading migration: %v", err)
+	}
+
+	var out []string
+	for stmt := range strings.SplitSeq(string(src), ";") {
+		if regexp.MustCompile(`(?is)INSERT\s+INTO\s+debate_spend`).MatchString(stmt) {
+			out = append(out, stmt+";")
+		}
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 backfill INSERTs in the migration, found %d — "+
+			"if the migration changed shape this test is no longer testing it", len(out))
+	}
+	return out
+}
+
+// TestBackfillRecoversPreMigrationSpend covers the deploy-time trap in #129.
+//
+// Enforcement now reads debate_spend. Pointing it at an empty table would drop
+// every org's observed spend to zero and silently lift every cap for the rest
+// of the month, which is a worse failure than the bug being fixed. The
+// migration backfills from surviving rounds; this proves that it does.
+//
+// It also proves the backfill is re-runnable. Migrations here are applied
+// BEFORE the new image rolls out, so rounds created in that window are written
+// by old code that knows nothing about the ledger. Running the same backfill
+// again after the rollout must pick those up without double-counting the rows
+// it already inserted.
+func TestBackfillRecoversPreMigrationSpend(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "desc")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from, to := CurrentUTCMonthRange(now)
+	seedRoundAt(t, db, deb.ID, userID, 1, int64Ptr(1_000_000), int64Ptr(250_000), "accepted", from.Add(time.Hour))
+	seedRoundAt(t, db, deb.ID, userID, 2, int64Ptr(500_000), nil, "rejected", from.Add(2*time.Hour))
+
+	const wantTotal = int64(1_000_000 + 250_000 + 500_000)
+
+	// Simulate the pre-migration world: the round rows exist and carry their
+	// costs, but nothing has ever written the ledger.
+	if _, delErr := db.Pool.Exec(ctx, `DELETE FROM debate_spend`); delErr != nil {
+		t.Fatalf("clearing ledger: %v", delErr)
+	}
+	if spend, sErr := db.SumOrgDebateSpendMicros(ctx, orgID, from, to); sErr != nil || spend != 0 {
+		t.Fatalf("precondition: spend = %d (err %v), want 0 before backfill", spend, sErr)
+	}
+
+	stmts := backfillStatements(t)
+	for _, stmt := range stmts {
+		if _, execErr := db.Pool.Exec(ctx, stmt); execErr != nil {
+			t.Fatalf("running backfill: %v", execErr)
+		}
+	}
+
+	got, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros: %v", err)
+	}
+	if got != wantTotal {
+		t.Fatalf("after backfill spend = %d, want %d — caps would be wrong for the rest of the month", got, wantTotal)
+	}
+
+	// Re-run: must be a no-op, not a doubling.
+	for _, stmt := range stmts {
+		if _, execErr := db.Pool.Exec(ctx, stmt); execErr != nil {
+			t.Fatalf("re-running backfill: %v", execErr)
+		}
+	}
+	again, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros (second): %v", err)
+	}
+	if again != wantTotal {
+		t.Errorf("backfill is not idempotent: re-running took spend %d -> %d", wantTotal, again)
+	}
+}

--- a/internal/models/queries_spend_undo_test.go
+++ b/internal/models/queries_spend_undo_test.go
@@ -72,3 +72,71 @@ func TestUndoDoesNotReclaimBudgetHeadroom(t *testing.T) {
 		)
 	}
 }
+
+// TestRepeatedScorerChargesAreBothCounted pins the second leak found while
+// fixing #129, same root cause.
+//
+// applyScoreResult is shared by the accept path and the background retry
+// sweep (its own comment says so), and both route the cost through
+// UpdateScorerCostMicros, which does `SET scorer_cost_micros = $1`. When the
+// sweep re-scores a round — which is the entire point of the retry machinery,
+// complete with effort_retry_attempts and exponential backoff — a second real
+// provider call is billed and its cost REPLACES the first. N calls paid, one
+// recorded.
+//
+// The assertion is a truth about money, not about the schema: if the provider
+// billed twice, the month must count both.
+func TestRepeatedScorerChargesAreBothCounted(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "desc")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from, to := CurrentUTCMonthRange(now)
+	seedRoundAt(t, db, deb.ID, userID, 1, int64Ptr(1_000_000), nil, "accepted", from.Add(time.Hour))
+
+	var roundID string
+	if scanErr := db.Pool.QueryRow(ctx,
+		`SELECT id FROM feature_debate_rounds WHERE debate_id = $1 AND round_number = 1`,
+		deb.ID,
+	).Scan(&roundID); scanErr != nil {
+		t.Fatalf("looking up round: %v", scanErr)
+	}
+
+	// Two scorer calls on the same round: the accept-path score, then a
+	// retry-sweep re-score. Both were really billed.
+	const firstCharge = int64(200_000)
+	const secondCharge = int64(300_000)
+	for _, charge := range []int64{firstCharge, secondCharge} {
+		tx, txErr := db.Pool.Begin(ctx)
+		if txErr != nil {
+			t.Fatalf("Begin: %v", txErr)
+		}
+		if uErr := db.UpdateScorerCostMicros(ctx, tx, roundID, charge); uErr != nil {
+			_ = tx.Rollback(ctx)
+			t.Fatalf("UpdateScorerCostMicros(%d): %v", charge, uErr)
+		}
+		if cErr := tx.Commit(ctx); cErr != nil {
+			t.Fatalf("Commit: %v", cErr)
+		}
+	}
+
+	spent, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros: %v", err)
+	}
+
+	want := int64(1_000_000) + firstCharge + secondCharge
+	if spent != want {
+		t.Errorf(
+			"spend = %d, want %d: the first scorer charge of %d micros was overwritten by the second and is uncounted",
+			spent, want, firstCharge,
+		)
+	}
+}

--- a/internal/models/queries_spend_undo_test.go
+++ b/internal/models/queries_spend_undo_test.go
@@ -1,0 +1,74 @@
+package models
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// TestUndoDoesNotReclaimBudgetHeadroom pins #129.
+//
+// Budget enforcement sums the cost columns on live round rows, and undo
+// hard-deletes rounds. The provider call already happened and the invoice is
+// real, so deleting the row must not reduce what the monthly cap counts —
+// otherwise an org near its cap buys back headroom for money it has spent.
+//
+// The assertion is deliberately independent of HOW that is fixed (ledger,
+// soft-delete, accumulator): spend observed for the month must not go down
+// because a user undid something.
+func TestUndoDoesNotReclaimBudgetHeadroom(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "desc")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from, to := CurrentUTCMonthRange(now)
+	inRange := from.Add(time.Hour)
+
+	// Three rounds really billed this month: 1.00 + (0.50 + 0.25) + 0.10.
+	seedRoundAt(t, db, deb.ID, userID, 1, int64Ptr(1_000_000), nil, "accepted", inRange)
+	seedRoundAt(t, db, deb.ID, userID, 2, int64Ptr(500_000), int64Ptr(250_000), "accepted", inRange)
+	seedRoundAt(t, db, deb.ID, userID, 3, int64Ptr(100_000), nil, "accepted", inRange)
+
+	spentBefore, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros (before): %v", err)
+	}
+	const wantBefore = int64(1_000_000 + 500_000 + 250_000 + 100_000)
+	if spentBefore != wantBefore {
+		t.Fatalf("spend before undo = %d, want %d", spentBefore, wantBefore)
+	}
+
+	// Undo rounds 2 and 3 — a legitimate, expected user action.
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if uErr := db.UndoRoundsFromTx(ctx, tx, deb.ID, 2); uErr != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("UndoRoundsFromTx: %v", uErr)
+	}
+	if cErr := tx.Commit(ctx); cErr != nil {
+		t.Fatalf("Commit: %v", cErr)
+	}
+
+	spentAfter, err := db.SumOrgDebateSpendMicros(ctx, orgID, from, to)
+	if err != nil {
+		t.Fatalf("SumOrgDebateSpendMicros (after): %v", err)
+	}
+
+	if spentAfter != spentBefore {
+		t.Errorf(
+			"undo reclaimed budget headroom: spend went %d -> %d (gave back %d micros already paid to the provider)",
+			spentBefore, spentAfter, spentBefore-spentAfter,
+		)
+	}
+}

--- a/migrations/000036_debate_spend_ledger.down.sql
+++ b/migrations/000036_debate_spend_ledger.down.sql
@@ -1,0 +1,5 @@
+-- Dropping the ledger returns enforcement to summing live round rows, which is
+-- the #129 bug: undo reclaims headroom for money already spent. Rolling back
+-- loses every spend record for rounds that were undone while this was live —
+-- that history exists nowhere else.
+DROP TABLE IF EXISTS debate_spend;

--- a/migrations/000036_debate_spend_ledger.up.sql
+++ b/migrations/000036_debate_spend_ledger.up.sql
@@ -1,0 +1,67 @@
+-- Append-only record of money actually paid to AI providers for debates (#129).
+--
+-- WHY THIS EXISTS AND IS NOT JUST A COLUMN ON feature_debate_rounds:
+-- budget enforcement summed cost_micros + scorer_cost_micros over live round
+-- rows, but undo HARD-DELETES rounds. The provider call already happened and
+-- the invoice is real, so deleting user content was silently deleting the
+-- accounting with it — an org near its cap could undo to buy back headroom for
+-- money it had already spent.
+--
+-- The root error was a category confusion: spend is an immutable financial
+-- fact, a round is mutable user content. One row served both, so editing the
+-- content edited the books.
+CREATE TABLE debate_spend (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id      UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    -- Deliberately NOT foreign keys. ON DELETE CASCADE would reintroduce the
+    -- exact bug this table fixes; ON DELETE SET NULL would work but costs the
+    -- audit trail. These are provenance, not referential integrity — the
+    -- spend must outlive the round and the debate that caused it.
+    debate_id   UUID,
+    round_id    UUID,
+
+    kind        TEXT   NOT NULL CHECK (kind IN ('round', 'scorer')),
+    cost_micros BIGINT NOT NULL CHECK (cost_micros >= 0),
+    incurred_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Enforcement scans one org's entries over a month range.
+CREATE INDEX debate_spend_org_incurred_idx ON debate_spend (org_id, incurred_at);
+
+-- Backfill so the cap does not silently reset on deploy.
+--
+-- Without this, switching enforcement to an empty ledger would drop every
+-- org's observed spend to zero and lift every cap for the rest of the month.
+--
+-- NOT EXISTS makes this re-runnable. That matters because migrations run
+-- BEFORE the new image rolls out: rounds created in the window between the
+-- migration and the rollout are written by old code that does not know about
+-- this table, so they land in feature_debate_rounds only. Re-running the same
+-- backfill after the rollout picks them up without duplicating anything.
+--
+-- Deliberately NOT a UNIQUE constraint: a round can legitimately carry SEVERAL
+-- scorer charges (the retry sweep re-scores, and every attempt is a real billed
+-- call). A uniqueness rule here would silently discard genuine charges.
+INSERT INTO debate_spend (org_id, debate_id, round_id, kind, cost_micros, incurred_at)
+SELECT d.org_id, r.debate_id, r.id, 'round', r.cost_micros, r.created_at
+  FROM feature_debate_rounds r
+  JOIN feature_debates d ON d.id = r.debate_id
+ WHERE COALESCE(r.cost_micros, 0) > 0
+   AND NOT EXISTS (
+        SELECT 1 FROM debate_spend s
+         WHERE s.round_id = r.id AND s.kind = 'round');
+
+INSERT INTO debate_spend (org_id, debate_id, round_id, kind, cost_micros, incurred_at)
+SELECT d.org_id, r.debate_id, r.id, 'scorer', r.scorer_cost_micros, r.created_at
+  FROM feature_debate_rounds r
+  JOIN feature_debates d ON d.id = r.debate_id
+ WHERE COALESCE(r.scorer_cost_micros, 0) > 0
+   AND NOT EXISTS (
+        SELECT 1 FROM debate_spend s
+         WHERE s.round_id = r.id AND s.kind = 'scorer');
+
+-- The backfill is a FLOOR, not a reconstruction. Rounds undone before this
+-- migration are gone, and their spend is unrecoverable. Likewise a round that
+-- was scored more than once only ever kept its LAST scorer cost, so earlier
+-- attempts cannot be recovered either.


### PR DESCRIPTION
Closes #129.

## The bug

Budget enforcement summed `cost_micros + scorer_cost_micros` over live
`feature_debate_rounds`. Undo hard-deletes rounds. So undoing handed back
headroom for money already paid to the provider — the call happened, the
invoice is real, and the only record enforcement counted went with the row.

Measured before fixing:

```
undo reclaimed budget headroom: spend went 1850000 -> 1000000
(gave back 850000 micros already paid to the provider)
```

## A second leak, same root cause

Found while fixing the first. `UpdateScorerCostMicros` does
`SET scorer_cost_micros = $1`, and `applyScoreResult` is shared by the accept
path and the background retry sweep — its own comment says so. Both call
`scorer.Score(...)` **before** it, so a re-score is a second *real billed call*,
and its cost overwrote the first. N calls paid, one recorded. The retry sweep
exists to re-score, complete with `effort_retry_attempts` and exponential
backoff, so this is a designed-for path, not a corner.

```
spend = 1300000, want 1500000: the first scorer charge of 200000 micros
was overwritten by the second and is uncounted
```

Both are one category error: **spend is an immutable financial fact, a round is
mutable user content.** One row served both, so editing content edited the
books. `debate_spend` separates them; undo keeps hard-deleting rounds and the
ledger is simply not its business.

## Why not soft-delete rounds

The issue proposed that, and I recommended it there. Reading the code reversed
it — soft-delete is the *larger* change:

- **16+ read sites** on `feature_debate_rounds` would each need the filter. Miss
  one and undone rounds reappear in the UI: a visible bug introduced to fix an
  invisible one.
- `CreateRound` picks `MAX(round_number) + 1`. Filter undone rows out of that
  and the next insert **collides with the soft-deleted row** on
  `UNIQUE (debate_id, round_number)`. Leave them in and round numbers gap.
- `last_scored_round_id` is `ON DELETE SET NULL` *specifically because undo
  deletes* — the migration comment says so. Stop deleting and that FK points at
  undone rounds.

The ledger touches two write sites, both already inside the transaction that
records the cost, and one read site. Zero existing round queries change.

## One reviewer finding I rejected, with evidence

Codex's top finding was that repeated `applyScoreResult` runs would
double-count, and proposed `UNIQUE (debate_id, round_id, kind)` with
`ON CONFLICT DO NOTHING`.

That is backwards here. Both call sites invoke the scorer **before**
`applyScoreResult`, and on error they log and return — nothing ever re-applies
the same result. Two invocations mean two distinct paid calls. The proposed
constraint would have silently discarded the second real charge, cementing the
under-count above. Mutation M2 below demonstrates it: adding that guard turns
the scorer test red.

There is therefore **no uniqueness on `(round_id, kind)`, deliberately**, and a
comment in `RecordDebateSpendTx` says why so nobody "fixes" it later.

## Evidence

**What would be true if this were broken?** Spend counted for a month would
fall when a user undid content, or a second billed scorer call would go
uncounted.

Both tests were written first and observed failing against the old code.

| Mutation | Result |
|---|---|
| M1 — aggregate reads rounds again (the original bug) | RED, both tests |
| M2 — dedupe scorer charges (the reviewer's proposal) | RED, scorer test only |
| M3 — drop `NOT EXISTS` from the backfill | RED — `re-running took spend 1750000 -> 3500000` |
| M4 — backfill forgets the scorer half | RED |
| restored | green |

Full `./internal/...` suite green (`-p 1 -count=1`), `bash scripts/lint.sh`
0 issues. Migration applies and reverts cleanly (`36/d` then `36/u`).

## Deploy — read before rolling out

**The backfill is the point.** Pointing enforcement at an empty ledger would
zero every org's observed spend and lift every cap for the rest of the month —
worse than the bug. `TestBackfillRecoversPreMigrationSpend` proves it works,
and it executes the INSERTs **parsed out of the real migration file**, so a
copy in the test cannot drift from the SQL that ships.

Migrations here run **before** the image rolls out, so rounds created in that
window are written by old code that knows nothing about the ledger. The
backfill uses `NOT EXISTS` and is therefore re-runnable: **run it once more
after the rollout** to sweep up that window. Re-running is proven idempotent.

Rolling the image back returns enforcement to summing rounds — i.e. back to
this bug, not to something worse. But spend for rounds undone while the ledger
was live exists nowhere else, so a rollback loses it permanently.

The backfill is a **floor, not a reconstruction**: rounds undone before this
ships, and scorer charges already overwritten, are unrecoverable.

## Fixture changes worth a look in review

Three test fixtures seeded spend straight into `feature_debate_rounds`. They now
write the ledger too, because real round creation writes both in one
transaction — a fixture that wrote only the round would describe a state the
application cannot produce, and the cap tests would assert against a figure the
running system never sees.

## Not in scope

`ComputeCostMicros` returns 0 for models absent from `pricingTable`, so an org
on an unpriced model accrues no observed spend and never trips its cap. Noted in
#129, covered by the `HasPricing` startup warning, and a different failure.

**Separately: none of these tests run in CI** — nothing in `.github/workflows/`
runs `go test`, and `SetupTestDB` skips rather than fails when Postgres is
absent. Filed as #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)