### PR TITLE
ci: run the Go test suite, and stop it passing when there is no database (#138)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  go-test:
+    name: go test
+    runs-on: ubuntu-latest
+    # The suite is serial (-p 1) and Argon2id hashing is deliberately slow, so
+    # it is not fast. Cap the job so a hung container cannot hold the runner.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Reuse the compose stack rather than a bare `services:` block, so CI runs
+      # against the same Postgres version and the same pinned migrate image as
+      # a developer does locally. Only postgres and migrate are needed — these
+      # are not browser tests, so the app container stays down.
+      - name: Start Postgres and apply migrations
+        run: |
+          docker compose -f docker-compose.test.yml up -d postgres
+          docker compose -f docker-compose.test.yml up --exit-code-from migrate migrate
+
+      # REQUIRE_TEST_DB turns "database unreachable" from a skip into a hard
+      # failure. Without it a misconfigured service container would make the
+      # whole suite report ok while executing nothing, which is the exact
+      # failure this workflow exists to prevent (#138).
+      - name: Run tests
+        env:
+          TEST_DATABASE_URL: postgres://testuser:testpass@localhost:5433/forgedesk_test?sslmode=disable
+          REQUIRE_TEST_DB: "1"
+        run: go test ./internal/... -p 1 -count=1 -timeout 300s
+
+      - name: Postgres logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.test.yml logs postgres

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -18,8 +19,26 @@ const (
 	TestSecret = "test-session-secret-32-chars-long!"
 )
 
+// requireTestDB reports whether an unreachable test database must FAIL the
+// test rather than skip it.
+//
+// Skipping is the right default for a developer with no Postgres running. It is
+// the wrong behavior in CI, where it makes the entire integration suite report
+// `ok` and exit 0 while executing nothing — indistinguishable from a working
+// run (#138). So CI declares the database as a precondition by setting
+// REQUIRE_TEST_DB, and a missing database becomes a hard failure.
+//
+// This is the one legitimate shape for a runtime skip: an explicitly declared
+// opt-in, not an inference from "the thing under test appears to be missing".
+func requireTestDB() bool {
+	v := strings.TrimSpace(os.Getenv("REQUIRE_TEST_DB"))
+	return v != "" && v != "0" && !strings.EqualFold(v, "false")
+}
+
 // SetupTestDB connects to the test database and cleans all data.
-// Skips the test if the test database is not reachable.
+//
+// Skips the test if the test database is not reachable — unless REQUIRE_TEST_DB
+// is set, in which case it fails. See requireTestDB.
 func SetupTestDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 
@@ -28,14 +47,24 @@ func SetupTestDB(t *testing.T) *pgxpool.Pool {
 		dbURL = TestDBURL
 	}
 
+	unreachable := func(format string, args ...any) {
+		t.Helper()
+		if requireTestDB() {
+			t.Fatalf("REQUIRE_TEST_DB is set: "+format, args...)
+		}
+		t.Skipf("skipping integration test: "+format, args...)
+	}
+
 	pool, err := pgxpool.New(context.Background(), dbURL)
 	if err != nil {
-		t.Skipf("skipping integration test: cannot connect to test DB: %v", err)
+		unreachable("cannot connect to test DB: %v", err)
+		return nil
 	}
 
 	if err := pool.Ping(context.Background()); err != nil {
 		pool.Close()
-		t.Skipf("skipping integration test: cannot ping test DB: %v", err)
+		unreachable("cannot ping test DB: %v", err)
+		return nil
 	}
 
 	// Clean all tables (order matters due to foreign keys).
@@ -50,6 +79,11 @@ func SetupTestDB(t *testing.T) *pgxpool.Pool {
 		"project_costs",
 		"ticket_activities",
 		"comments",
+		// Appended by #129. Listed explicitly even though its org_id FK is
+		// ON DELETE CASCADE, matching this list's children-first convention:
+		// if that FK is ever relaxed, spend rows would otherwise start
+		// leaking between tests silently.
+		"debate_spend",
 		// Debate rounds reference debates; debates reference tickets + users
 		// (ON DELETE RESTRICT on started_by/triggered_by), so purge rounds
 		// first, then debates, then the rest.

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,42 @@
+package testutil
+
+import "testing"
+
+// TestRequireTestDB pins the opt-in that stops CI from passing by not running.
+//
+// The default must stay "skip" so a developer without Postgres is not blocked.
+// The opt-in must be an explicit declaration, and the obvious ways of writing
+// "off" must not accidentally read as "on" — a CI file that sets
+// REQUIRE_TEST_DB=false and silently got hard failures would be its own
+// confusing outage.
+func TestRequireTestDB(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  bool
+	}{
+		{"unset skips, so local runs without Postgres still work", "", false, false},
+		{"empty is not a declaration", "", true, false},
+		{"whitespace is not a declaration", "   ", true, false},
+		{"0 means off", "0", true, false},
+		{"false means off", "false", true, false},
+		{"FALSE means off", "FALSE", true, false},
+		{"1 requires the database", "1", true, true},
+		{"true requires the database", "true", true, true},
+		{"any other value requires the database", "yes", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("REQUIRE_TEST_DB", tt.value)
+			} else {
+				t.Setenv("REQUIRE_TEST_DB", "")
+			}
+			if got := requireTestDB(); got != tt.want {
+				t.Errorf("requireTestDB() with %q = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #138.

## The problem

Nothing in `.github/workflows/` ran `go test`:

```
$ grep -rn "go test" .github/workflows/
(no matches)
```

The `./internal/...` suite — auth, RBAC, tenant isolation, budget enforcement,
AI cost accounting — ran only when a human remembered to run it locally. A PR
could be green on all four checks with a completely broken suite. #129 landed
money-handling tests that CI would never have executed.

**The second half matters more.** `SetupTestDB` called `t.Skipf` when Postgres
was unreachable, so the whole integration suite reported `ok` and exited 0 with
no database at all:

```
$ TEST_DATABASE_URL=postgres://nobody@127.0.0.1:59999/nope go test ./internal/models/ -run TestUndo...
ok    github.com/madalin/forgedesk/internal/models   0.003s
```

Adding a test job without noticing that would have produced a green check that
ran nothing — the same failure #136 just removed from the Playwright suite, and
indistinguishable from a working one.

## What this does

**`.github/workflows/test.yml`.** Drives the compose stack rather than a bare
`services:` block, so CI gets the same Postgres version and the same pinned
migrate image a developer uses locally, and so a broken migration fails the job.

**`REQUIRE_TEST_DB`.** Set in CI, it turns an unreachable database from a skip
into a hard failure. Unset, it still skips — a developer without Postgres is not
blocked. That is the one legitimate shape for a runtime skip: an explicitly
declared precondition, not an inference from "the thing under test appears to be
missing".

**`debate_spend` added to the test cleanup list.** Its `org_id` FK is
`ON DELETE CASCADE` so it is already purged transitively, but this list's stated
convention is explicit children-first precisely so relaxing an FK cannot start
leaking rows between tests unnoticed. Missed when #129 added the table.

## Evidence

**What would be true if this were broken?** The new job would pass while running
nothing, or fail to catch a genuinely failing test or migration.

**The guard converts a silent pass into a failure** — the whole point:

| | no database |
|---|---|
| before | `ok ... 0.003s` |
| after, `REQUIRE_TEST_DB=1` | `FAIL — REQUIRE_TEST_DB is set: cannot ping test DB: ... connection refused` |

**A broken migration fails the step.** Dropped a deliberately invalid
`000037_deliberately_broken.up.sql` in and ran the workflow's own migrate
command: exit `1`. Removed it and re-ran against a clean volume: exit `0`. (The
file is not part of this PR — it was a throwaway probe.)

**Postgres survives the migrate step.** `--exit-code-from migrate` implies
`--abort-on-container-exit`, so I checked it does not tear the database down
before the tests run. It does not — `postgres running` afterwards.

**The job is not vacuous.** Ran the workflow's exact test step locally with its
own env: suite green, **1022 test events, 0 skips**.

`TestRequireTestDB` covers the parsing, including that `0`/`false`/`FALSE` mean
off — a CI file setting `REQUIRE_TEST_DB=false` and silently getting hard
failures would be its own confusing outage. Mutation-tested: reducing the guard
to `v != ""` turns those three cases red.

`bash scripts/lint.sh` 0 issues.

## Note on this PR's own checks

The new `go test` job will run on this PR, so its first real proof is the check
itself. Worth glancing at the log to confirm it reports a real test count rather
than a suspiciously fast pass — that is the failure mode being fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)