### PR TITLE
deploy: pin server & orchestrator images to v0.7.0

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.6.1
+          image: registry.k3s.vlah.sh/smartpm:v0.7.0
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.6.1
+          image: registry.k3s.vlah.sh/smartpm:v0.7.0
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for the v0.7.0 release, already deployed. `imagePullPolicy` is
`IfNotPresent`, so the tag here is the only version pin — the repo should
describe what is actually running.

## Shipped

| PR | Issue | |
|---|---|---|
| #134 | #92 | pending-invitations list actually refreshes |
| #135 | #95 | real comment author names on ticket detail |
| #137 | #136 | E2E suite executes instead of silently skipping |
| #139 | #129 | debate spend ledger — **migration 000036** |
| #140 | #138 | CI runs the Go test suite |

## Deploy record

- Tag `v0.7.0` → `4b253d1`; image digest
  `sha256:8f5eb7d6875a789eed1a3ace644b11f243854d4559d352cf16df8b15eaf1538e`
- **Migration 000036 applied before the rollout** (additive: new table +
  backfill, so v0.6.1 kept serving through it). Schema **35 → 36**, `dirty=f`.
- Backfill reproduced prod spend exactly: **17,622 micros** across 2 ledger
  rows. Three rounds exist; the third is genuinely zero-cost, and the backfill
  correctly writes no entry for a round that was never billed.
- **Backfill re-run after the rollout** — the step #139 called for, to catch
  rounds written by old code in the migrate→deploy window. `INSERT 0 0` twice,
  totals unchanged: idempotency confirmed against production, not just in test.
- All 3 pods digest-verified on the built image, 0 restarts.
- Startup clean: `Feature Debate Mode wired (3 refiners, 3 scorers)`, no
  unpriced-model warning. `/login` and `/health` 200. No panics.
- All three orgs remain on `monthly_budget_cents = NULL`, so the cap stays
  inert and the enforcement change is behaviourally invisible until someone
  sets a budget.

## One thing I checked and cleared

#137 made the auth rate limiter configurable. Verified the prod secret sets no
`AUTH_RATE_LIMIT_*` keys, so the strict 0.5 rps / burst 5 defaults apply. A live
probe appeared not to throttle, but that was my probe being slower than the
2-second token replenishment, not a regression — the middleware denies correctly
at burst: `[200 200 200 200 200 429 429 429]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)