### PR TITLE
deploy: pin server & orchestrator images to v0.7.1

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.7.0
+          image: registry.k3s.vlah.sh/smartpm:v0.7.1
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.7.0
+          image: registry.k3s.vlah.sh/smartpm:v0.7.1
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for v0.7.1, already deployed.

## Shipped

| PR | Issue | |
|---|---|---|
| #143 | #142 | bound Argon2id concurrency — the unauthenticated login OOM |
| #144 | #136 | shared E2E session; CI runs six specs in one invocation |

No migration. Schema stays **36**.

## Deploy record

- Tag `v0.7.1` → `f4840b2`; digest
  `sha256:6c55221fe4c4d2482f20474f3cea527f6ffe58ef20cc115f52fe3a6f9e74c4bc`
- All 3 pods digest-verified, **0 restarts**
- Startup clean: `Feature Debate Mode wired (3 refiners, 3 scorers)`, no
  unpriced-model warning. `/login` 200.
- `GOMEMLIMIT=200MiB` is now actually applied — it merged into
  `deployment.yaml` with #143 but had never been rolled out.

## The security fix, verified against production

Last release I OOM-killed a pod by probing `/login`, which is how #142 was
found. So this deploy's check was to repeat that probe and confirm the outcome
has changed.

**12 concurrent unauthenticated login POSTs — the shape that killed a pod on
v0.7.0:**

| | v0.7.0 | v0.7.1 |
|---|---|---|
| pod restarts | OOMKilled, exit 137 | **0** |
| OOMKill events | yes | none |
| responses | — | 12 × 200 |
| memory after | — | 85Mi against a 256Mi limit |

All 200s rather than 503s is the **correct** result, not a sign the gate is
inactive: with two replicas and a ceiling of 2, twelve requests queue briefly
and drain well inside the 2-second wait. Shedding is the valve for heavier
sustained load; at this volume the fix means everyone gets served instead of
the pod dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)