### PR TITLE
test(e2e): migrate org-management and debate specs; give 08 its own account (#136)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,9 @@ jobs:
             04-tickets.spec.js \
             05-admin.spec.js \
             06-ticket-detail.spec.js \
+            07-org-management.spec.js \
             09-rbac-journeys.spec.js \
+            11-debate.spec.js \
             12-debate-fake.spec.js
 
       - name: App logs on failure

--- a/e2e/tests/07-org-management.spec.js
+++ b/e2e/tests/07-org-management.spec.js
@@ -4,7 +4,7 @@
 let rootCookies = [];
 
 const { test, expect } = require('@playwright/test');
-const { useSession, rootSession } = require('./helpers');
+const { useSession, rootSession, setup2FA } = require('./helpers');
 
 // --- Test users ---
 const superadminUser = {
@@ -28,9 +28,12 @@ const adminUser = {
 const ORG_NAME = 'OrgMgmt Test Org';
 const ORG_SLUG = 'orgmgmt-test-org';
 
-let superadminTotpSecret = '';
-let memberTotpSecret = '';
-let adminTotpSecret = '';
+// Sessions for the two users this spec creates through the invite UI. They are
+// captured at registration rather than re-logged-in per test: a second login
+// inside the same 30s window replays a TOTP code, which ValidateTOTPOnce
+// rejects (#136).
+let memberCookies = [];
+let adminCookies = [];
 let inviteURL = '';
 
 test.describe('Organization Management', () => {
@@ -108,10 +111,12 @@ test.describe('Organization Management', () => {
     // Page should contain "Members" heading
     await expect(page.locator('body')).toContainText('Members');
 
-    // The member list should show the superadmin user
+    // The creator is whoever the shared session belongs to, not this spec's
+    // old private superadmin (#136).
+    const creator = rootSession().user;
     const memberList = page.locator('#member-list');
-    await expect(memberList).toContainText(superadminUser.name);
-    await expect(memberList).toContainText(superadminUser.email);
+    await expect(memberList).toContainText(creator.name);
+    await expect(memberList).toContainText(creator.email);
 
     // The creator should be shown as "owner"
     await expect(memberList).toContainText('owner');
@@ -272,13 +277,16 @@ test.describe('Organization Management', () => {
     // Should be redirected to 2FA setup
     await page.waitForURL('**/setup-2fa', { timeout: 10000 });
 
-    // Complete 2FA setup
+    // Complete 2FA setup, then keep the session: the tests below need to act
+    // AS this member, not as the owner who invited them.
     const result = await setup2FA(page);
-    memberTotpSecret = result.secret;
+    expect(result.secret).toBeTruthy();
+    memberCookies = await page.context().cookies();
   });
 
   test('member can access org page after joining', async ({ page }) => {
-    await useSession(page, rootCookies);
+    // As the MEMBER. Running this as the owner would assert nothing about membership.
+    await useSession(page, memberCookies);
 
     // Navigate to the org page
     await page.goto(`/orgs/${ORG_SLUG}`);
@@ -419,11 +427,13 @@ test.describe('Organization Management', () => {
     // Complete 2FA setup
     await page.waitForURL('**/setup-2fa', { timeout: 10000 });
     const result = await setup2FA(page);
-    adminTotpSecret = result.secret;
+    expect(result.secret).toBeTruthy();
+    adminCookies = await page.context().cookies();
   });
 
   test('org admin can access settings and sees invite form and member list', async ({ page }) => {
-    await useSession(page, rootCookies);
+    // As the ORG ADMIN — the whole point is that a non-owner admin can do this.
+    await useSession(page, adminCookies);
 
     await page.goto(`/orgs/${ORG_SLUG}/settings`);
     await page.waitForLoadState('networkidle');
@@ -431,30 +441,37 @@ test.describe('Organization Management', () => {
     // Admin should see the Members section
     await expect(page.locator('body')).toContainText('Members');
 
-    // Admin should see the Invite Member form
-    await expect(page.locator('input[name="email"]')).toBeVisible();
-    await expect(page.locator('select[name="role"]')).toBeVisible();
-    await expect(page.locator('button:has-text("Invite")')).toBeVisible();
+    // Admin should see the Invite Member form. Scope the role select to that
+    // form: an admin also sees a per-member role select in the member list, so
+    // a bare select[name="role"] matches both.
+    const inviteForm = page.locator('form').filter({ has: page.locator('button:has-text("Invite")') });
+    await expect(inviteForm.locator('input[name="email"]')).toBeVisible();
+    await expect(inviteForm.locator('select[name="role"]')).toBeVisible();
+    await expect(inviteForm.locator('button:has-text("Invite")')).toBeVisible();
 
     // Admin should see the Pending Invitations section
     await expect(page.locator('body')).toContainText('Pending Invitations');
 
-    // The member list should include the superadmin (owner) and the admin user
+    // The member list should include the owner (the shared root user) and the
+    // admin this spec invited.
     const memberList = page.locator('#member-list');
-    await expect(memberList).toContainText(superadminUser.name);
+    await expect(memberList).toContainText(rootSession().user.name);
     await expect(memberList).toContainText(adminUser.name);
   });
 
   test('org admin can invite new members', async ({ page }) => {
-    await useSession(page, rootCookies);
+    // As the ORG ADMIN, not the owner.
+    await useSession(page, adminCookies);
 
     await page.goto(`/orgs/${ORG_SLUG}/settings`);
     await page.waitForLoadState('networkidle');
 
-    // Re-invite the removed member user to verify admin has invite capability
-    await page.fill('input[name="email"]', memberUser.email);
-    await page.selectOption('select[name="role"]', 'member');
-    await page.click('button:has-text("Invite")');
+    // Re-invite the removed member user to verify admin has invite capability.
+    // Scoped to the invite form for the same reason as the test above.
+    const inviteForm = page.locator('form').filter({ has: page.locator('button:has-text("Invite")') });
+    await inviteForm.locator('input[name="email"]').fill(memberUser.email);
+    await inviteForm.locator('select[name="role"]').selectOption('member');
+    await inviteForm.locator('button:has-text("Invite")').click();
     await page.waitForLoadState('networkidle');
 
     // Verify success

--- a/e2e/tests/08-account-settings.spec.js
+++ b/e2e/tests/08-account-settings.spec.js
@@ -1,10 +1,20 @@
-// Sessions come from global setup: the app allows exactly one registration
-// ever (first-user-only), and logging in per test would replay a TOTP code
-// inside its 30s step, which ValidateTOTPOnce rejects (#136).
-let rootCookies = [];
-
 const { test, expect } = require('@playwright/test');
-const { useSession, rootSession, generateTOTP } = require('./helpers');
+const {
+  useSession,
+  rootSession,
+  inviteAndRegisterUser,
+  loginUser,
+  verify2FA,
+  awaitNextTOTPWindow,
+  generateTOTP,
+} = require('./helpers');
+
+// This spec CHANGES a password and an email, and the application invalidates
+// every session for a user whose password changes. Doing that to the shared
+// root identity would sign every other spec out mid-run, so this one gets a
+// throwaway account of its own via the invite flow (#136).
+let ownCookies = [];
+let ownTotpSecret = '';
 
 const testUser = {
   name: 'Account Settings User',
@@ -13,23 +23,34 @@ const testUser = {
 };
 const newPassword = 'NewPassword456!!';
 const newEmail = 'e2e-account-new@forgedesk.test';
-let totpSecret = '';
+// The root session carries its own TOTP secret; nothing here needs to derive
+// one. The guards that referenced a never-assigned local are gone — they made
+// every test in this file skip silently (#136).
+
 
 test.describe.serial('Account Settings', () => {
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-    // Shared root session: see the note at the top of this file (#136).
+    await useSession(page, rootSession().cookies);
 
-    rootCookies = rootSession().cookies;
+    // An org to invite into, then the disposable account this spec mutates.
+    await page.request.post('/orgs', { form: { name: 'Account Settings Org' } });
+    const own = await inviteAndRegisterUser(page, {
+      orgSlug: 'account-settings-org',
+      email: testUser.email,
+      name: testUser.name,
+      password: testUser.password,
+      role: 'member',
+    });
+    ownCookies = own.cookies;
+    ownTotpSecret = own.secret;
 
-    await useSession(page, rootCookies);
     await page.close();
   });
 
   test('account settings page renders', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
 
-    await useSession(page, rootCookies);
+    await useSession(page, ownCookies);
     await page.goto('/account/settings');
     await page.waitForLoadState('networkidle');
 
@@ -43,9 +64,8 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('change password - wrong old password shows error', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
 
-    await useSession(page, rootCookies);
+    await useSession(page, ownCookies);
     await page.goto('/account/settings');
     await page.waitForLoadState('networkidle');
 
@@ -64,9 +84,8 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('change password - too short new password shows error', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
 
-    await useSession(page, rootCookies);
+    await useSession(page, ownCookies);
     await page.goto('/account/settings');
     await page.waitForLoadState('networkidle');
 
@@ -84,9 +103,8 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('change password - success', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
 
-    await useSession(page, rootCookies);
+    await useSession(page, ownCookies);
     await page.goto('/account/settings');
     await page.waitForLoadState('networkidle');
 
@@ -103,11 +121,10 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('login with new password works', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
 
     // Login with the new password
     await loginUser(page, { email: testUser.email, password: newPassword });
-    await verify2FA(page, totpSecret);
+    await verify2FA(page, ownTotpSecret);
 
     // Should reach a page that is not login or verify-2fa
     await page.waitForURL(url => !url.href.includes('verify-2fa') && !url.href.includes('login'), { timeout: 5000 });
@@ -116,10 +133,9 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('change email - success', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
 
     // Login with the new password (changed in the previous test)
-    await useSession(page, rootCookies);
+    await useSession(page, ownCookies);
     await page.goto('/account/settings');
     await page.waitForLoadState('networkidle');
 
@@ -133,10 +149,13 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('login with new email works', async ({ page }) => {
-    test.skip(!totpSecret, 'TOTP secret not available');
+    // The previous test already signed in; reusing its TOTP code inside the
+    // same 30s step is refused as a replay, which would fail here for a reason
+    // that has nothing to do with the email change (#136).
+    await awaitNextTOTPWindow(page);
 
     await loginUser(page, { email: newEmail, password: newPassword });
-    await verify2FA(page, totpSecret);
+    await verify2FA(page, ownTotpSecret);
 
     await page.waitForURL(url => !url.href.includes('verify-2fa') && !url.href.includes('login'), { timeout: 5000 });
     const currentUrl = page.url();

--- a/e2e/tests/11-debate.spec.js
+++ b/e2e/tests/11-debate.spec.js
@@ -83,7 +83,6 @@ test.describe('Feature Debate Mode', () => {
   }
 
   test('empty state renders Start button on fresh feature', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
     // New UI: empty-state card with "Refine with AI" start button.
@@ -92,7 +91,6 @@ test.describe('Feature Debate Mode', () => {
   });
 
   test('non-feature ticket type is rejected from the debate route', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     // Verify the positive case: a feature ticket's debate page is accessible.
     // The non-feature type guard is exercised at the handler level; creating a
@@ -102,7 +100,6 @@ test.describe('Feature Debate Mode', () => {
   });
 
   test('golden path: start → suggest → accept → approve', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
 
@@ -209,7 +206,6 @@ test.describe('Feature Debate Mode', () => {
   });
 
   test('abandon path: start → suggest → dismiss → abandon → ticket unchanged', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
 

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -207,6 +207,7 @@ async function fullLogin(page, { email, password, totpSecret }) {
 }
 
 module.exports = {
+  awaitNextTOTPWindow,
   rootSession,
   inviteAndRegisterUser,
   useSession,
@@ -240,4 +241,19 @@ function rootSession() {
     throw new Error('root session file contains no cookies');
   }
   return state;
+}
+
+/**
+ * Wait until the current TOTP window rolls over.
+ *
+ * ValidateTOTPOnce (migration 000027) refuses a code already used inside its
+ * 30-second step, so two logins seconds apart fail on the second — for a reason
+ * that looks nothing like the thing under test. Tests that genuinely must sign
+ * in twice call this between them (#136).
+ */
+async function awaitNextTOTPWindow(page) {
+  const period = 30_000;
+  const msIntoWindow = Date.now() % period;
+  // +1s of slack so we are comfortably inside the next step, not on its edge.
+  await page.waitForTimeout(period - msIntoWindow + 1000);
 }

--- a/templates/components/member_list.html
+++ b/templates/components/member_list.html
@@ -3,7 +3,10 @@
 {{$orgSlug := .OrgSlug}}
 
 {{range .Members}}
-<div class="flex items-center justify-between py-3 px-4 border-b border-base-300 last:border-b-0"
+{{/* member-row is a stable E2E landmark kept alongside the Tailwind classes,
+     same convention as comment-body (#37); the suite scopes per-member
+     assertions to it. It had drifted out while nothing could run (#136). */}}
+<div class="member-row flex items-center justify-between py-3 px-4 border-b border-base-300 last:border-b-0"
      id="member-{{.User.ID}}">
     <div class="min-w-0">
         <p class="font-medium text-sm truncate">{{.User.Name}}</p>

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -24,7 +24,8 @@
                 <a href="/" class="text-lg font-semibold tracking-tight">ForgeDesk</a>
             </div>
 
-            <nav class="flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1 text-sm">
+            {{/* sidebar-nav: stable E2E landmark (#136), see comment-body (#37). */}}
+            <nav class="sidebar-nav flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1 text-sm">
                 {{if .Orgs}}
                 {{if and .User (or (eq .User.Role "superadmin") (eq .User.Role "staff"))}}
                 {{if gt (len .Orgs) 1}}


### PR DESCRIPTION
Fourth instalment on #136. **Does not close it** — two specs remain.

## 07-org-management: 18/18

**Three of its tests had lost their intended identity** in the bulk migration
two PRs ago. That regex replaced every `fullLogin(...)` with the root session —
including the member's and the org admin's. Two of the affected tests exist
*precisely* to prove a **non-owner** org admin can access settings and invite
members; running them as the owner made them assert nothing at all.

I recovered the original identities from the pre-migration file and re-checked
every test by hand. **That is twice now** that a mechanical rewrite has quietly
inverted an authorization test (`05-admin` was the first). They need reading,
not regexing — worth remembering before the next bulk edit.

The inline invite registrations also broke because the same migration stripped
`setup2FA` from the imports. Those tests genuinely exercise the invite
registration page, so the import is back and the resulting sessions are captured
for the tests that must act as those users.

Two more landmarks restored, both absent from the markup and therefore
unassertable: `sidebar-nav` and `member-row`.

## 11-debate: 4/4

Green once its skip guards were removed. They had been masking nothing since the
bootstrap was fixed — they just made a working spec look optional.

## 08-account-settings: given a disposable account

This one is a genuine trap. 08 **changes a password and an email**, and this
application invalidates every session for a user whose password changes. Pointed
at the shared root identity, it would have signed every other spec out mid-run —
a failure that would have surfaced somewhere else entirely.

It now creates its own throwaway account through the invite flow. Its seven skip
guards referenced a local the earlier migration had left permanently empty, so
every test in the file had been skipping silently.

## New helper: `awaitNextTOTPWindow`

For the few tests that must genuinely sign in twice. `ValidateTOTPOnce` refuses
a code reused inside its 30-second step, so the second login fails for a reason
that has nothing to do with the thing under test.

## Result

**99 tests, ten specs, one invocation, zero skips.** CI runs all ten.

| | |
|---|---|
| 01, 02, 03, 04, 05, 06, 07, 09, 11, 12 | ✅ in CI — 99 tests |
| 08-account-settings | 6/7, out of CI — see below |
| 10-image-modal | real failures, out of CI |
| 13-debate-real-ai | needs provider keys (legitimate opt-in) |

## What remains, stated plainly

**08's final test** (`login with new email works`) still fails. The TOTP code is
rejected even after waiting a full window — I added the wait, confirmed it
happens, and the code is still refused. I did not get to the bottom of it, so
the spec stays out of CI at 6/7 rather than being marked green or having the
test quietly skipped.

**10-image-modal** has real failures and is slow; it needs its own triage pass.

Progress across #136 so far: 0 → 42 → 77 → **99** tests actually executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)