### PR TITLE
test(e2e): finish the migration — every spec runs, 122 tests, zero skips (#136)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,8 +54,8 @@ jobs:
       # its session, so specs no longer compete for that one slot and no
       # longer need a database reset between them (#136).
       #
-      # Specs not listed here are not yet migrated off self-registration and
-      # would fail; they are tracked in #136 rather than silently skipped.
+      # Every spec except 13-debate-real-ai, which needs real provider API keys
+      # and is a declared opt-in rather than a silent skip.
       - name: Run migrated e2e specs
         working-directory: e2e
         env:
@@ -69,7 +69,9 @@ jobs:
             05-admin.spec.js \
             06-ticket-detail.spec.js \
             07-org-management.spec.js \
+            08-account-settings.spec.js \
             09-rbac-journeys.spec.js \
+            10-image-modal.spec.js \
             11-debate.spec.js \
             12-debate-fake.spec.js
 

--- a/e2e/tests/04-tickets.spec.js
+++ b/e2e/tests/04-tickets.spec.js
@@ -39,7 +39,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('create feature ticket', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
 
@@ -58,7 +57,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('create bug ticket', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
 
@@ -77,7 +75,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('features page shows features', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
     await page.goto('/orgs/ticket-org/projects/ticket-project/features');
@@ -87,7 +84,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('bugs page shows bugs', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
     await page.goto('/orgs/ticket-org/projects/ticket-project/bugs');
@@ -97,7 +93,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('ticket detail page renders', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
     await page.goto('/orgs/ticket-org/projects/ticket-project/features');
@@ -114,7 +109,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('post comment on ticket via HTMX', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
     await page.goto('/orgs/ticket-org/projects/ticket-project/features');
@@ -146,7 +140,6 @@ test.describe('Tickets & Comments', () => {
   // by the tests above: a guard like that turns a missing ticket into a
   // silent pass, and this test exists to catch a rendering regression.
   test('comment author name survives a reload', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
     await page.goto('/orgs/ticket-org/projects/ticket-project/features');
@@ -179,7 +172,6 @@ test.describe('Tickets & Comments', () => {
   });
 
   test('update ticket status', async ({ page }) => {
-    test.skip(!projectId, 'Project ID not found');
 
     await useSession(page, rootCookies);
     await page.goto('/orgs/ticket-org/projects/ticket-project/features');

--- a/e2e/tests/08-account-settings.spec.js
+++ b/e2e/tests/08-account-settings.spec.js
@@ -5,7 +5,7 @@ const {
   inviteAndRegisterUser,
   loginUser,
   verify2FA,
-  awaitNextTOTPWindow,
+  awaitTOTPReuseWindow,
   generateTOTP,
 } = require('./helpers');
 
@@ -149,10 +149,10 @@ test.describe.serial('Account Settings', () => {
   });
 
   test('login with new email works', async ({ page }) => {
-    // The previous test already signed in; reusing its TOTP code inside the
-    // same 30s step is refused as a replay, which would fail here for a reason
-    // that has nothing to do with the email change (#136).
-    await awaitNextTOTPWindow(page);
+    // The previous test signed in; the server refuses ANY 2FA verification
+    // within 30s of the last one (not just the same code), so wait it out —
+    // otherwise this fails for a reason unrelated to the email change (#136).
+    await awaitTOTPReuseWindow(page);
 
     await loginUser(page, { email: newEmail, password: newPassword });
     await verify2FA(page, ownTotpSecret);

--- a/e2e/tests/10-image-modal.spec.js
+++ b/e2e/tests/10-image-modal.spec.js
@@ -80,7 +80,6 @@ test.describe('Image Insert Modal', () => {
 
   test.describe('Brief editor', () => {
     test('image toolbar button opens modal', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -101,7 +100,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('modal has Upload and AI Generate tabs', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -122,7 +120,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('tab switching works', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -151,7 +148,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('modal closes on Cancel button', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -169,7 +165,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('modal closes on X button', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -187,7 +182,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('modal closes on backdrop click', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -205,7 +199,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('modal closes on ESC key', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -222,7 +215,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('upload tab shows drop zone', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -238,7 +230,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('file upload via picker works and inserts markdown', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       const testImagePath = createTestImage();
 
       await useSession(page, rootCookies);
@@ -275,7 +266,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('AI generate tab shows prompt textarea', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -298,7 +288,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('AI generate button enables when prompt is entered', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -316,7 +305,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('AI generate shows error when service unavailable', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -337,7 +325,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('old generate-image toolbar button is removed', async ({ page }) => {
-      test.skip(!projectId, 'Project ID not found');
       await useSession(page, rootCookies);
       await page.goto('/orgs/image-org/projects/image-project/brief');
       await page.waitForLoadState('networkidle');
@@ -368,13 +355,14 @@ test.describe('Image Insert Modal', () => {
       await page.waitForLoadState('networkidle');
 
       // Find the ticket link href so we can navigate directly
-      const ticketLink = page.locator('a:has-text("Image Test Ticket")');
+      // .first(): the ticket appears as a card link and again in sub-item /
+      // listing markup, so a bare text match resolves to several elements.
+      const ticketLink = page.locator('a:has-text("Image Test Ticket")').first();
       ticketUrl = await ticketLink.getAttribute('href');
       await page.close();
     });
 
     test('image toolbar button opens modal on ticket detail', async ({ page }) => {
-      test.skip(!ticketUrl, 'Ticket URL not found');
       await useSession(page, rootCookies);
 
       // Full page load ensures EasyMDE script in page_head is loaded
@@ -399,7 +387,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('file upload works on ticket editor', async ({ page }) => {
-      test.skip(!ticketUrl, 'Ticket URL not found');
       const testImagePath = createTestImage();
 
       await useSession(page, rootCookies);
@@ -433,7 +420,6 @@ test.describe('Image Insert Modal', () => {
     });
 
     test('upload another button resets for new upload', async ({ page }) => {
-      test.skip(!ticketUrl, 'Ticket URL not found');
       const testImagePath = createTestImage();
 
       await useSession(page, rootCookies);

--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -77,7 +77,6 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
   }
 
   test('reject (dismiss) leaves current text unchanged and pre-fills feedback', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
     await ensureComposer(page);
@@ -110,7 +109,6 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
   });
 
   test('a suggestion with empty feedback still works', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
     await ensureComposer(page);
@@ -129,7 +127,6 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
   });
 
   test('undo cascade: accept 3 rounds then restore v1 removes v2 and v3', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
     await ensureComposer(page);
@@ -162,7 +159,6 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
   });
 
   test('feedback draft is auto-saved to localStorage and restored after reload', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
     await ensureComposer(page);
@@ -185,7 +181,6 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
   });
 
   test('a successful suggestion clears the saved feedback draft', async ({ page }) => {
-    test.skip(!ticketID, 'ticket id not resolved in beforeAll');
 
     await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
     await ensureComposer(page);

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -196,6 +196,8 @@ async function verify2FA(page, secret) {
   await page.fill('input[name="code"]', code);
   await page.click('button[type="submit"]');
   await page.waitForLoadState('networkidle');
+  // Record when, so awaitTOTPReuseWindow can wait out the server's 30s guard.
+  lastTOTPVerifyAt = Date.now();
 }
 
 /**
@@ -207,7 +209,7 @@ async function fullLogin(page, { email, password, totpSecret }) {
 }
 
 module.exports = {
-  awaitNextTOTPWindow,
+  awaitTOTPReuseWindow,
   rootSession,
   inviteAndRegisterUser,
   useSession,
@@ -243,17 +245,29 @@ function rootSession() {
   return state;
 }
 
+// When 2FA was last verified successfully, so awaitTOTPReuseWindow knows how
+// long to wait. Set by verify2FA.
+let lastTOTPVerifyAt = 0;
+
 /**
- * Wait until the current TOTP window rolls over.
+ * Wait out the server's TOTP reuse guard.
  *
- * ValidateTOTPOnce (migration 000027) refuses a code already used inside its
- * 30-second step, so two logins seconds apart fail on the second — for a reason
- * that looks nothing like the thing under test. Tests that genuinely must sign
- * in twice call this between them (#136).
+ * ValidateTOTPOnce (internal/auth/totp.go) rejects on ELAPSED TIME, not on the
+ * code:
+ *
+ *     if lastUsedAt != nil && time.Since(*lastUsedAt) < 30*time.Second
+ *
+ * so ANY verification within 30 seconds of the last successful one is refused,
+ * even with a different code. Waiting for the next TOTP window boundary is not
+ * enough — that can be a second later. Tests that must sign in twice wait here
+ * instead (#136).
  */
-async function awaitNextTOTPWindow(page) {
-  const period = 30_000;
-  const msIntoWindow = Date.now() % period;
-  // +1s of slack so we are comfortably inside the next step, not on its edge.
-  await page.waitForTimeout(period - msIntoWindow + 1000);
+async function awaitTOTPReuseWindow(page) {
+  const guard = 30_000;
+  const slack = 1_500;
+  const elapsed = Date.now() - lastTOTPVerifyAt;
+  if (lastTOTPVerifyAt === 0 || elapsed >= guard + slack) {
+    return;
+  }
+  await page.waitForTimeout(guard + slack - elapsed);
 }

--- a/templates/components/image_modal.html
+++ b/templates/components/image_modal.html
@@ -4,14 +4,18 @@
      @keydown.escape.window="open && closeModal()"
      @open-image-modal.window="openModal($event.detail.editor, $event.detail.projectID)"
      aria-modal="true" role="dialog">
-    <div class="absolute inset-0 bg-black/50" @click="closeModal()"></div>
-    <div class="relative bg-base-100 border border-base-300 rounded-lg shadow-xl
+    {{/* modal-backdrop / modal-card / btn-close / modal-tab are stable E2E
+         landmarks kept alongside the Tailwind and DaisyUI classes, the same
+         convention as comment-body (#37). They had drifted out of the markup
+         while the suite could not run (#136). */}}
+    <div class="modal-backdrop absolute inset-0 bg-black/50" @click="closeModal()"></div>
+    <div class="modal-card relative bg-base-100 border border-base-300 rounded-lg shadow-xl
                 w-full max-w-2xl max-h-[85vh] overflow-y-auto p-6"
          @click.stop>
         <!-- Header -->
         <div class="flex items-center justify-between mb-4">
             <h3 class="text-lg font-semibold">Insert Image</h3>
-            <button @click="closeModal()" class="btn btn-ghost btn-xs btn-square" aria-label="Close">
+            <button @click="closeModal()" class="btn-close btn btn-ghost btn-xs btn-square" aria-label="Close">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
                      fill="none" stroke="currentColor" stroke-width="2"
                      stroke-linecap="round" stroke-linejoin="round">
@@ -23,7 +27,7 @@
         <!-- Tabs -->
         <div role="tablist" class="tabs tabs-bordered mb-4">
             <button role="tab"
-                    class="tab gap-1.5"
+                    class="modal-tab tab gap-1.5"
                     :class="{ 'tab-active': activeTab === 'upload' }"
                     @click="switchTab('upload')">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
@@ -36,7 +40,7 @@
                 Upload
             </button>
             <button role="tab"
-                    class="tab gap-1.5"
+                    class="modal-tab tab gap-1.5"
                     :class="{ 'tab-active': activeTab === 'generate' }"
                     @click="switchTab('generate')">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
@@ -52,7 +56,7 @@
         <div x-show="activeTab === 'upload'" class="min-h-48">
             <!-- Drop zone (before file selected) -->
             <div x-show="!file && !uploadedUrl"
-                 class="border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors"
+                 class="drop-zone border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors"
                  :class="dragover ? 'border-primary bg-primary/5' : 'border-base-300 hover:border-base-content/30'"
                  @dragover.prevent="dragover = true"
                  @dragleave.prevent="dragover = false"
@@ -138,7 +142,7 @@
         </div>
 
         <!-- Error -->
-        <div x-show="error" class="alert alert-error alert-sm mt-3">
+        <div x-show="error" class="text-danger alert alert-error alert-sm mt-3">
             <span x-text="error"></span>
         </div>
 


### PR DESCRIPTION
Final instalment on #136. **This one closes it.**

Closes #136.

## 08-account-settings: green, and the diagnosis was in the server

Its last failure looked like a TOTP replay, and my first fix — waiting for the
next TOTP window — didn't help. The reason is in `internal/auth/totp.go:53`:

```go
if lastUsedAt != nil && time.Since(*lastUsedAt) < 30*time.Second {
    return false
}
```

The guard rejects on **elapsed time, not on the code**. Any 2FA verification
within 30 seconds of the last successful one is refused, even with a different
code — so waiting for a window boundary, which can be a second later, changes
nothing. `awaitTOTPReuseWindow` now waits out the guard itself, timed from when
`verify2FA` last succeeded.

**Worth a look independently:** the comment above that function says *"the same
code was used within the last 30s"*, but the implementation refuses **any** code
in that window. The behaviour is stricter than the comment claims. I have not
changed it — it is defensible as written — but the comment is misleading, and it
cost me a round of wrong diagnosis.

## 10-image-modal: green

It expected six landmarks that were absent from the markup — `modal-backdrop`,
`modal-card`, `btn-close`, `modal-tab`, `drop-zone`, `text-danger`. The modal
opened, then every assertion after it failed, each burning a 120-second timeout,
which is why this spec alone took minutes to report anything.

## Every remaining skip guard is gone

04 and 12 still carried thirteen `test.skip(!x)` guards. They no longer fired —
**which is exactly why they were worth deleting.** A guard that cannot fire is
indistinguishable from one that is hiding something, and guards of this shape are
what reported a completely dead suite as a green run for six months.

The only `test.skip` left in the tree is in `13-debate-real-ai`, which needs real
provider API keys: a declared opt-in, which is the one legitimate use.

## Result

**122 tests, twelve specs, one invocation, zero skips.** CI runs all twelve.

| | before #136 | now |
|---|---|---|
| specs that execute | 1 of 13 | **12 of 13** (13th needs provider keys) |
| tests that execute | 6 | **122** |
| runtime skips | 85 guards | **0** |
| database resets in CI | 1 per spec | none |

Trajectory across the four PRs: **0 → 42 → 77 → 99 → 122**.

## What this cost, in case it is useful later

Almost none of the work was writing tests. It was: three stacked bootstrap
causes (rate limiter, first-user-only registration, TOTP replay), one shared
session to stop specs competing for the single registration, and then per-spec
triage of six months of drift that nothing could catch — roughly twenty
landmark classes missing from templates, stale copy, stale counts, assertions
that only worked when each spec had a private user, and **two authorization
tests silently inverted by my own bulk migration**.

That last one is the lesson I would carry forward: a regex that swaps a login
helper does not know which identity a test intended, and an auth test that runs
as the wrong role still passes. Both times it was caught by reading, not by the
suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)