### PR TITLE
feat(debate): let the user edit the AI's text before accepting it (#66)

### DIFF
--- a/e2e/tests/12-debate-fake.spec.js
+++ b/e2e/tests/12-debate-fake.spec.js
@@ -285,4 +285,56 @@ test.describe('Feature Debate Mode — fake refiner branches', () => {
     // The whole point of the feature: not the default provider.
     expect(chipText, `effort chip text was: ${chipText}`).not.toContain('via Gemini');
   });
+  // Placed LAST on purpose: these accept rounds, and the tests above count
+  // versions on the shared debate. Adding accepted rounds earlier shifts that
+  // state and breaks the undo-cascade test (#66).
+  // #66: correct the AI before accepting, rather than paying for another round.
+  test('edit the AI suggestion before accepting it', async ({ page }) => {
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    await page.fill('[data-testid="debate-feedback"]', 'Please improve this');
+    await page.click('[data-testid="debate-suggest"]');
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+
+    // The Edit tab holds the AI's proposal, ready to correct.
+    await page.click('[data-testid="debate-tab-edit"]');
+    const textarea = page.locator('[data-testid="debate-edit-textarea"]');
+    await expect(textarea).toBeVisible();
+    const aiProposal = await textarea.inputValue();
+    expect(aiProposal).toContain('added by fake refiner');
+
+    const corrected = `${aiProposal}\n\nHand-written correction that the AI did not produce.`;
+    await textarea.fill(corrected);
+
+    await page.click('[data-testid="debate-accept"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+
+    // The document is the CORRECTED text — this is the whole feature.
+    const doc = page.locator('[data-testid="debate-current-text"]');
+    await expect(doc).toContainText('Hand-written correction that the AI did not produce.');
+    await expect(doc).toContainText('added by fake refiner');
+  });
+
+  // The textarea is always in the DOM (the tab only hides it), so it is
+  // submitted on every accept. Accepting without touching it must not be
+  // recorded as an edit, and must ship the AI's text unchanged.
+  test('accepting without opening the Edit tab ships the AI text unchanged', async ({ page }) => {
+    await authenticatedDebatePage(page, `/tickets/${ticketID}/debate`);
+    await ensureComposer(page);
+
+    await page.fill('[data-testid="debate-feedback"]', 'Another improvement');
+    await page.click('[data-testid="debate-suggest"]');
+    await expect(page.locator('[data-testid="debate-suggestion"]')).toBeVisible();
+
+    const proposed = await page.locator('[data-testid="debate-edit-textarea"]').inputValue();
+
+    await page.click('[data-testid="debate-accept"]');
+    await expect(page.locator('[data-testid="debate-composer"]')).toBeVisible({ timeout: 8000 });
+
+    await expect(page.locator('[data-testid="debate-current-text"]')).toContainText(
+      proposed.split('\n')[0].trim(),
+    );
+  });
+
 });

--- a/internal/handlers/debate.go
+++ b/internal/handlers/debate.go
@@ -739,7 +739,32 @@ func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	round, err := h.acceptRoundUnderLock(r.Context(), deb.ID, roundID)
+	// Optional user correction of the AI's text (#66). Absent field means
+	// "accepted as-is"; a present-but-blank one is a validation error, not a
+	// silent no-op, because shipping it would empty the brief.
+	//
+	// ParseForm explicitly: r.Form is nil until something parses, and Has() on
+	// a nil map returns false without complaining — so without this the edit
+	// would be silently ignored on every request.
+	if parseErr := r.ParseForm(); parseErr != nil {
+		h.renderWorkspaceUpdate(w, r, dctx, "Could not read the submitted form.")
+		return
+	}
+	var editedText *string
+	if r.Form.Has("edited_text") {
+		// Browsers normalise textarea newlines to CRLF on submit, while the
+		// stored text uses LF. Without folding them back, text the user never
+		// touched would differ from output_text and EVERY accept would record a
+		// spurious edit — wrong data that looks fine until someone queries it.
+		v := strings.ReplaceAll(r.FormValue("edited_text"), "\r\n", "\n")
+		editedText = &v
+	}
+
+	round, err := h.acceptRoundUnderLock(r.Context(), deb.ID, roundID, editedText)
+	if errors.Is(err, models.ErrEmptyEdit) {
+		h.renderWorkspaceUpdate(w, r, dctx, "The edited text is empty — nothing was accepted.")
+		return
+	}
 	if err != nil {
 		h.writeAcceptError(w, r, err)
 		return
@@ -758,11 +783,16 @@ func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
 	// while the result is still associated with this round's ID. The
 	// direct-pass path guarantees scorer input == round output.
 	//
+	// ShippedText(), not OutputText: when the user corrected the AI's text, the
+	// effort estimate must describe what will actually be built (#66). The
+	// no-reread rationale above is unchanged — the value is still passed by
+	// value, just the right value.
+	//
 	// The provider lookup happens inside the goroutine, not here: it is a
 	// database round-trip and the accept response must not wait on it.
 	if len(h.scorers) > 0 {
 		go h.scoreAfterAccept(context.WithoutCancel(r.Context()),
-			deb.ID, round.ID, dctx.ticket.ProjectID, round.OutputText)
+			deb.ID, round.ID, dctx.ticket.ProjectID, round.ShippedText())
 	}
 
 	h.renderWorkspaceUpdate(w, r, dctx, "")
@@ -771,7 +801,9 @@ func (h *DebateHandler) AcceptRound(w http.ResponseWriter, r *http.Request) {
 // acceptRoundUnderLock runs the accept transaction: lock debate row,
 // lock round row, verify status == 'active' at the debate level,
 // update round + current_text, commit.
-func (h *DebateHandler) acceptRoundUnderLock(ctx context.Context, debateID, roundID string) (*models.DebateRound, error) {
+func (h *DebateHandler) acceptRoundUnderLock(
+	ctx context.Context, debateID, roundID string, editedText *string,
+) (*models.DebateRound, error) {
 	tx, err := h.db.Pool.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -791,7 +823,7 @@ func (h *DebateHandler) acceptRoundUnderLock(ctx context.Context, debateID, roun
 		return nil, models.ErrDebateNotActive
 	}
 
-	round, err := h.db.AcceptRoundTx(ctx, tx, debateID, roundID)
+	round, err := h.db.AcceptRoundTx(ctx, tx, debateID, roundID, editedText)
 	if err != nil {
 		return nil, err
 	}
@@ -982,6 +1014,9 @@ func (h *DebateHandler) retryOneEffortScore(ctx context.Context, d models.StaleE
 		return
 	}
 
+	// d.OutputText here is already the SHIPPED text — ClaimStaleEffortScores
+	// coalesces the edit in its query, so the retry path and the immediate
+	// path score the same thing (#66).
 	res, err := scorer.Score(callCtx, d.OutputText)
 	if err != nil {
 		log.Printf("debate RetryStaleEffortScores: scorer %q failed for debate %s round %s: %v",
@@ -1376,7 +1411,9 @@ func (h *DebateHandler) ShowVersion(w http.ResponseWriter, r *http.Request) {
 			if rd.Status == roundStatusAccepted {
 				label++
 				if rd.ID == roundID {
-					viewing = &ViewingVersion{Label: label, Text: rd.OutputText, RestoreFrom: rd.RoundNumber + 1}
+					// ShippedText(): history must show what the document
+					// actually was, not the AI draft behind an edit (#66).
+					viewing = &ViewingVersion{Label: label, Text: rd.ShippedText(), RestoreFrom: rd.RoundNumber + 1}
 					break
 				}
 			}

--- a/internal/handlers/debate_edit_test.go
+++ b/internal/handlers/debate_edit_test.go
@@ -1,0 +1,187 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// postAcceptWithEdit submits the accept button with an edited_text field,
+// exactly as the Edit tab's textarea does via hx-include.
+func postAcceptWithEdit(t *testing.T, r *chi.Mux, cookie *http.Cookie, ticketID, roundID, edited string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"edited_text": {edited}}
+	req := httptest.NewRequest(http.MethodPost,
+		"/tickets/"+ticketID+"/debate/rounds/"+roundID+"/accept",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Hx-Request", "true")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestAcceptTreatsCRLFAsUnedited pins a trap in the HTML form layer.
+//
+// The Edit textarea is always in the DOM — the tab only hides it — so its
+// content is submitted on EVERY accept, even when the user never opened it.
+// Browsers normalise textarea newlines to CRLF while the stored text uses LF,
+// so without folding them back, untouched multi-line text would differ from
+// output_text and every accept would be recorded as hand-edited. That is wrong
+// data that looks perfectly fine until someone queries it.
+func TestAcceptTreatsCRLFAsUnedited(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ctx := context.Background()
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	const aiText = "line one\nline two\nline three"
+	deb, round := insertInReviewRound(t, db, cookie, r, ticket.ID, aiText)
+
+	// Exactly what a browser sends back for content the user never touched.
+	rec := postAcceptWithEdit(t, r, cookie, ticket.ID, round.ID, "line one\r\nline two\r\nline three")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("accept = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var edited *string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT edited_text FROM feature_debate_rounds WHERE id = $1`, round.ID).Scan(&edited); err != nil {
+		t.Fatalf("reading edited_text: %v", err)
+	}
+	if edited != nil {
+		t.Errorf("edited_text = %q; CRLF-normalised untouched text must not count as an edit", *edited)
+	}
+
+	var current string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT current_text FROM feature_debates WHERE id = $1`, deb.ID).Scan(&current); err != nil {
+		t.Fatalf("reading current_text: %v", err)
+	}
+	if strings.Contains(current, "\r") {
+		t.Errorf("current_text kept CRLF line endings: %q", current)
+	}
+	if current != aiText {
+		t.Errorf("current_text = %q, want the untouched AI text", current)
+	}
+}
+
+// TestAcceptWithRealEditShipsItEndToEnd drives the whole path the Edit tab
+// uses: the textarea posts through hx-include, the edit is stored, and the
+// document becomes the edited text while output_text keeps the AI's original.
+func TestAcceptWithRealEditShipsItEndToEnd(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ctx := context.Background()
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	const aiText = "The AI wrote this with a typoo."
+	const userText = "The AI wrote this with a typo, now fixed."
+	deb, round := insertInReviewRound(t, db, cookie, r, ticket.ID, aiText)
+
+	rec := postAcceptWithEdit(t, r, cookie, ticket.ID, round.ID, userText)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("accept = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var output string
+	var edited *string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT output_text, edited_text FROM feature_debate_rounds WHERE id = $1`,
+		round.ID).Scan(&output, &edited); err != nil {
+		t.Fatalf("reading round: %v", err)
+	}
+	if output != aiText {
+		t.Errorf("output_text = %q; the AI's original must survive editing", output)
+	}
+	if edited == nil || *edited != userText {
+		t.Errorf("edited_text = %v, want %q", edited, userText)
+	}
+
+	var current string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT current_text FROM feature_debates WHERE id = $1`, deb.ID).Scan(&current); err != nil {
+		t.Fatalf("reading current_text: %v", err)
+	}
+	if current != userText {
+		t.Errorf("current_text = %q, want the edited text", current)
+	}
+}
+
+// TestAcceptRefusesEmptyEditOverHTTP: a blank edit must be refused rather than
+// silently emptying the brief.
+func TestAcceptRefusesEmptyEditOverHTTP(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ctx := context.Background()
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	const aiText = "Text that must survive a refused empty edit."
+	deb, round := insertInReviewRound(t, db, cookie, r, ticket.ID, aiText)
+
+	var before string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT current_text FROM feature_debates WHERE id = $1`, deb.ID).Scan(&before); err != nil {
+		t.Fatalf("reading current_text: %v", err)
+	}
+
+	postAcceptWithEdit(t, r, cookie, ticket.ID, round.ID, "   \n  ")
+
+	var after, status string
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT current_text FROM feature_debates WHERE id = $1`, deb.ID).Scan(&after); err != nil {
+		t.Fatalf("reading current_text: %v", err)
+	}
+	if err := db.Pool.QueryRow(ctx,
+		`SELECT status FROM feature_debate_rounds WHERE id = $1`, round.ID).Scan(&status); err != nil {
+		t.Fatalf("reading status: %v", err)
+	}
+
+	if after != before {
+		t.Errorf("current_text changed to %q after a refused empty edit", after)
+	}
+	if status == "accepted" {
+		t.Error("round was accepted despite an empty edit")
+	}
+}
+
+// TestShowVersionRendersTheEditedText guards the version-history viewer.
+//
+// Found by sweeping every read of output_text for "does this mean the AI's
+// draft, or what shipped?" — this one means shipped, and neither code review
+// caught it. Without it, opening a hand-edited version in the history renders
+// the AI's draft: the history would quietly disagree with what the document
+// actually was at that point.
+func TestShowVersionRendersTheEditedText(t *testing.T) {
+	r, db, sessions := setupDebateTestEnv(t)
+	ticket, cookie := seedAuthedFeatureTicket(t, db, sessions)
+
+	const aiText = "AI version of the brief"
+	const userText = "Hand-corrected version of the brief"
+	_, round := insertInReviewRound(t, db, cookie, r, ticket.ID, aiText)
+
+	if rec := postAcceptWithEdit(t, r, cookie, ticket.ID, round.ID, userText); rec.Code != http.StatusOK {
+		t.Fatalf("accept = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/tickets/"+ticket.ID+"/debate/versions/"+round.ID, http.NoBody)
+	req.Header.Set("Hx-Request", "true")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ShowVersion = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Hand-corrected") {
+		t.Errorf("version history does not show the edited text; body: %s", body)
+	}
+	if strings.Contains(body, "AI version of the brief") {
+		t.Errorf("version history shows the AI draft instead of what shipped")
+	}
+}

--- a/internal/handlers/debate_view.go
+++ b/internal/handlers/debate_view.go
@@ -56,7 +56,7 @@ type DebateView struct {
 // (the seed text).
 type ViewingVersion struct {
 	Label       int    // 0 means "Original"
-	Text        string // the version's full text (output_text or seed)
+	Text        string // the version's full text: what SHIPPED (edit or AI output), or the seed
 	RestoreFrom int    // undo ?from= that restores this version
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type User struct {
 	CreatedAt          time.Time `db:"created_at"`
@@ -307,21 +310,42 @@ type FeatureDebate struct {
 }
 
 type DebateRound struct {
-	CreatedAt        time.Time  `db:"created_at"`
-	DecidedAt        *time.Time `db:"decided_at"`
-	Feedback         *string    `db:"feedback"`
-	DiffUnified      *string    `db:"diff_unified"`
-	InputTokens      *int       `db:"input_tokens"`
-	OutputTokens     *int       `db:"output_tokens"`
-	CostMicros       *int64     `db:"cost_micros"`
-	ScorerCostMicros *int64     `db:"scorer_cost_micros"`
-	ID               string     `db:"id"`
-	DebateID         string     `db:"debate_id"`
-	Provider         string     `db:"provider"` // claude | gemini | openai
-	Model            string     `db:"model"`
-	TriggeredBy      string     `db:"triggered_by"`
-	InputText        string     `db:"input_text"`
-	OutputText       string     `db:"output_text"`
-	Status           string     `db:"status"` // in_review | accepted | rejected
-	RoundNumber      int        `db:"round_number"`
+	CreatedAt   time.Time  `db:"created_at"`
+	DecidedAt   *time.Time `db:"decided_at"`
+	Feedback    *string    `db:"feedback"`
+	DiffUnified *string    `db:"diff_unified"`
+	// EditedText is the user's correction of the AI's proposal, NULL when they
+	// accepted it as-is. Never read it directly to decide what shipped — use
+	// ShippedText(), which is the single definition of that (#66).
+	EditedText       *string `db:"edited_text"`
+	InputTokens      *int    `db:"input_tokens"`
+	OutputTokens     *int    `db:"output_tokens"`
+	CostMicros       *int64  `db:"cost_micros"`
+	ScorerCostMicros *int64  `db:"scorer_cost_micros"`
+	ID               string  `db:"id"`
+	DebateID         string  `db:"debate_id"`
+	Provider         string  `db:"provider"` // claude | gemini | openai
+	Model            string  `db:"model"`
+	TriggeredBy      string  `db:"triggered_by"`
+	InputText        string  `db:"input_text"`
+	OutputText       string  `db:"output_text"`
+	Status           string  `db:"status"` // in_review | accepted | rejected
+	RoundNumber      int     `db:"round_number"`
+}
+
+// ShippedText is the text this round actually contributed to the document: the
+// user's edit when they made one, otherwise the AI's output.
+//
+// This exists so the COALESCE is written once. Five separate places need it —
+// accept, the undo recompute, both scorer paths and the version-history viewer
+// — and each one that forgets it fails silently, showing or scoring the AI's
+// draft instead of what shipped (#66).
+func (r *DebateRound) ShippedText() string {
+	// A blank edit is treated as no edit. The handler refuses one and a CHECK
+	// constraint backs that up, so this is the third line of defense — but it
+	// is the cheapest, and shipping "" would blank the brief.
+	if r.EditedText != nil && strings.TrimSpace(*r.EditedText) != "" {
+		return *r.EditedText
+	}
+	return r.OutputText
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -336,6 +336,13 @@ type DebateRound struct {
 // ShippedText is the text this round actually contributed to the document: the
 // user's edit when they made one, otherwise the AI's output.
 //
+// The SQL in UndoRoundsFromTx and ClaimStaleEffortScores implements the same
+// rule and MUST agree with this to the byte. It uses CASE WHEN btrim(...) <> ”
+// rather than NULLIF(btrim(...), ”) for that reason: NULLIF returns the
+// TRIMMED value, which silently rewrote the user's text and made undo disagree
+// with this function. The trim answers "is this blank?" — it never alters what
+// ships. TestShippedTextAgreesBetweenGoAndSQL pins the two together.
+//
 // This exists so the COALESCE is written once. Five separate places need it —
 // accept, the undo recompute, both scorer paths and the version-history viewer
 // — and each one that forgets it fails silently, showing or scoring the AI's

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -22,10 +22,13 @@ const DebateStatusActive = "active"
 // Task 7+) use errors.Is to route each distinct case to the correct
 // HTTP status per the spec §3.3 error discipline table.
 var (
-	ErrDebateNotActive     = errors.New("debate not active")
-	ErrInFlightAIRequest   = errors.New("AI request already in flight")
-	ErrSeedFrozen          = errors.New("seed frozen after first round")
-	ErrStaleAIInput        = errors.New("current_text changed during AI call")
+	ErrDebateNotActive   = errors.New("debate not active")
+	ErrInFlightAIRequest = errors.New("AI request already in flight")
+	ErrSeedFrozen        = errors.New("seed frozen after first round")
+	ErrStaleAIInput      = errors.New("current_text changed during AI call")
+	// ErrEmptyEdit: accepting a blank edit would set current_text to nothing
+	// and destroy the brief (#66).
+	ErrEmptyEdit           = errors.New("edited text is empty")
 	ErrInReviewRoundExists = errors.New("an in-review round already exists")
 	ErrDescriptionLocked   = errors.New("ticket description locked: active debate exists")
 	ErrRoundNotInReview    = errors.New("round is not in review state")
@@ -2550,7 +2553,7 @@ func (db *DB) GetLatestRound(ctx context.Context, debateID string) (*DebateRound
 	r := &DebateRound{}
 	err := db.Pool.QueryRow(ctx, `
 		SELECT id, debate_id, round_number, provider, model, triggered_by,
-		       feedback, input_text, output_text, diff_unified, status,
+		       feedback, input_text, output_text, edited_text, diff_unified, status,
 		       input_tokens, output_tokens, cost_micros, scorer_cost_micros,
 		       created_at, decided_at
 		  FROM feature_debate_rounds
@@ -2558,7 +2561,7 @@ func (db *DB) GetLatestRound(ctx context.Context, debateID string) (*DebateRound
 		 ORDER BY round_number DESC LIMIT 1`, debateID,
 	).Scan(
 		&r.ID, &r.DebateID, &r.RoundNumber, &r.Provider, &r.Model, &r.TriggeredBy,
-		&r.Feedback, &r.InputText, &r.OutputText, &r.DiffUnified, &r.Status,
+		&r.Feedback, &r.InputText, &r.OutputText, &r.EditedText, &r.DiffUnified, &r.Status,
 		&r.InputTokens, &r.OutputTokens, &r.CostMicros, &r.ScorerCostMicros,
 		&r.CreatedAt, &r.DecidedAt,
 	)
@@ -2572,7 +2575,7 @@ func (db *DB) GetLatestRound(ctx context.Context, debateID string) (*DebateRound
 func (db *DB) GetDebateRounds(ctx context.Context, debateID string) ([]DebateRound, error) {
 	rows, err := db.Pool.Query(ctx, `
 		SELECT id, debate_id, round_number, provider, model, triggered_by,
-		       feedback, input_text, output_text, diff_unified, status,
+		       feedback, input_text, output_text, edited_text, diff_unified, status,
 		       input_tokens, output_tokens, cost_micros, scorer_cost_micros,
 		       created_at, decided_at
 		  FROM feature_debate_rounds
@@ -2587,7 +2590,7 @@ func (db *DB) GetDebateRounds(ctx context.Context, debateID string) ([]DebateRou
 		var r DebateRound
 		if err := rows.Scan(
 			&r.ID, &r.DebateID, &r.RoundNumber, &r.Provider, &r.Model, &r.TriggeredBy,
-			&r.Feedback, &r.InputText, &r.OutputText, &r.DiffUnified, &r.Status,
+			&r.Feedback, &r.InputText, &r.OutputText, &r.EditedText, &r.DiffUnified, &r.Status,
 			&r.InputTokens, &r.OutputTokens, &r.CostMicros, &r.ScorerCostMicros,
 			&r.CreatedAt, &r.DecidedAt,
 		); err != nil {
@@ -2756,7 +2759,7 @@ func (db *DB) InsertDebateRoundTx(
 			 input_tokens, output_tokens, cost_micros)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'in_review', $10, $11, $12)
 		RETURNING id, debate_id, round_number, provider, model, triggered_by,
-		          feedback, input_text, output_text, diff_unified, status,
+		          feedback, input_text, output_text, edited_text, diff_unified, status,
 		          input_tokens, output_tokens, cost_micros, scorer_cost_micros,
 		          created_at, decided_at`,
 		in.DebateID, maxRound+1, in.Provider, in.Model, in.TriggeredBy, feedbackParam,
@@ -2764,7 +2767,7 @@ func (db *DB) InsertDebateRoundTx(
 		in.InputTokens, in.OutputTokens, in.CostMicros,
 	).Scan(
 		&r.ID, &r.DebateID, &r.RoundNumber, &r.Provider, &r.Model, &r.TriggeredBy,
-		&r.Feedback, &r.InputText, &r.OutputText, &r.DiffUnified, &r.Status,
+		&r.Feedback, &r.InputText, &r.OutputText, &r.EditedText, &r.DiffUnified, &r.Status,
 		&r.InputTokens, &r.OutputTokens, &r.CostMicros, &r.ScorerCostMicros,
 		&r.CreatedAt, &r.DecidedAt,
 	)
@@ -2806,13 +2809,13 @@ func (db *DB) getRoundWithTx(ctx context.Context, tx pgx.Tx, roundID string) (*D
 	r := &DebateRound{}
 	err := tx.QueryRow(ctx, `
 		SELECT id, debate_id, round_number, provider, model, triggered_by,
-		       feedback, input_text, output_text, diff_unified, status,
+		       feedback, input_text, output_text, edited_text, diff_unified, status,
 		       input_tokens, output_tokens, cost_micros, scorer_cost_micros,
 		       created_at, decided_at
 		  FROM feature_debate_rounds WHERE id = $1`, roundID,
 	).Scan(
 		&r.ID, &r.DebateID, &r.RoundNumber, &r.Provider, &r.Model, &r.TriggeredBy,
-		&r.Feedback, &r.InputText, &r.OutputText, &r.DiffUnified, &r.Status,
+		&r.Feedback, &r.InputText, &r.OutputText, &r.EditedText, &r.DiffUnified, &r.Status,
 		&r.InputTokens, &r.OutputTokens, &r.CostMicros, &r.ScorerCostMicros,
 		&r.CreatedAt, &r.DecidedAt,
 	)
@@ -2833,7 +2836,17 @@ func (db *DB) getRoundWithTx(ctx context.Context, tx pgx.Tx, roundID string) (*D
 // Returns pgx.ErrNoRows if the round doesn't exist under this debate,
 // ErrRoundNotInReview if the round is not in_review (already accepted
 // or rejected — stale client view).
-func (db *DB) AcceptRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID string) (*DebateRound, error) {
+// AcceptRoundTx accepts a round, optionally recording a user edit of the AI's
+// text, and makes the SHIPPED text the debate's current version.
+//
+// editedText is the raw submission; it is stored only when it differs from
+// output_text, so opening the edit tab and changing nothing is not an edit
+// (#66). No staleness token is needed: output_text is written once at insert
+// and never updated, so the status check below is the only "has this round
+// moved on" question there is.
+func (db *DB) AcceptRoundTx(
+	ctx context.Context, tx pgx.Tx, debateID, roundID string, editedText *string,
+) (*DebateRound, error) {
 	var status, outputText string
 	err := tx.QueryRow(ctx, `
 		SELECT status, output_text FROM feature_debate_rounds
@@ -2850,18 +2863,35 @@ func (db *DB) AcceptRoundTx(ctx context.Context, tx pgx.Tx, debateID, roundID st
 		return nil, ErrRoundNotInReview
 	}
 
+	// Normalise before deciding: blank is not an edit, and neither is the AI's
+	// own text handed back unchanged.
+	var toStore *string
+	if editedText != nil {
+		trimmed := strings.TrimSpace(*editedText)
+		if trimmed == "" {
+			return nil, ErrEmptyEdit
+		}
+		if *editedText != outputText {
+			toStore = editedText
+		}
+	}
+
 	if _, err = tx.Exec(ctx, `
 		UPDATE feature_debate_rounds
-		   SET status = 'accepted', decided_at = now()
-		 WHERE id = $1`, roundID,
+		   SET status = 'accepted', decided_at = now(), edited_text = $2
+		 WHERE id = $1`, roundID, toStore,
 	); err != nil {
 		return nil, err
 	}
 
+	shipped := outputText
+	if toStore != nil {
+		shipped = *toStore
+	}
 	if _, err = tx.Exec(ctx, `
 		UPDATE feature_debates
 		   SET current_text = $1, updated_at = now()
-		 WHERE id = $2`, outputText, debateID,
+		 WHERE id = $2`, shipped, debateID,
 	); err != nil {
 		return nil, err
 	}
@@ -2932,7 +2962,7 @@ func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, 
 	var newCurrentText string
 	if scanErr := tx.QueryRow(ctx, `
 		SELECT COALESCE(
-			(SELECT output_text FROM feature_debate_rounds
+			(SELECT COALESCE(NULLIF(btrim(edited_text), ''), output_text) FROM feature_debate_rounds
 			  WHERE debate_id = $1 AND status = 'accepted'
 			  ORDER BY round_number DESC LIMIT 1),
 			(SELECT seed_description FROM feature_debates WHERE id = $1)
@@ -3109,7 +3139,7 @@ func (db *DB) ClaimStaleEffortScores(
 		    -- does not affect the FOR UPDATE SKIP LOCKED semantics that
 		    -- keep two replicas from double-billing the same debate.
 		    (SELECT p.scorer_provider FROM projects p WHERE p.id = fd.project_id),
-		    (SELECT r.output_text FROM feature_debate_rounds r
+		    (SELECT COALESCE(NULLIF(btrim(r.edited_text), ''), r.output_text) FROM feature_debate_rounds r
 		      WHERE r.debate_id = fd.id AND r.status = 'accepted'
 		      ORDER BY r.round_number DESC LIMIT 1)`,
 		now, now.Add(-minAge), limit, baseBackoff.Seconds(), maxBackoff.Seconds(),

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -2871,7 +2871,12 @@ func (db *DB) AcceptRoundTx(
 		if trimmed == "" {
 			return nil, ErrEmptyEdit
 		}
-		if *editedText != outputText {
+		// Compare TRIMMED, for the same reason CRLF is folded in the handler:
+		// a difference the user cannot see should not be recorded as an edit.
+		// Someone who opens the tab and fatfingers a trailing space has not
+		// edited the brief. Whitespace-only differences therefore collapse to
+		// "unedited", and the AI's text ships.
+		if trimmed != strings.TrimSpace(outputText) {
 			toStore = editedText
 		}
 	}
@@ -2962,7 +2967,7 @@ func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, 
 	var newCurrentText string
 	if scanErr := tx.QueryRow(ctx, `
 		SELECT COALESCE(
-			(SELECT COALESCE(NULLIF(btrim(edited_text, E' \t\n\r\f\v'), ''), output_text) FROM feature_debate_rounds
+			(SELECT CASE WHEN btrim(edited_text, E' \t\n\r\f\v') <> '' THEN edited_text ELSE output_text END FROM feature_debate_rounds
 			  WHERE debate_id = $1 AND status = 'accepted'
 			  ORDER BY round_number DESC LIMIT 1),
 			(SELECT seed_description FROM feature_debates WHERE id = $1)
@@ -3139,7 +3144,7 @@ func (db *DB) ClaimStaleEffortScores(
 		    -- does not affect the FOR UPDATE SKIP LOCKED semantics that
 		    -- keep two replicas from double-billing the same debate.
 		    (SELECT p.scorer_provider FROM projects p WHERE p.id = fd.project_id),
-		    (SELECT COALESCE(NULLIF(btrim(r.edited_text, E' \t\n\r\f\v'), ''), r.output_text) FROM feature_debate_rounds r
+		    (SELECT CASE WHEN btrim(r.edited_text, E' \t\n\r\f\v') <> '' THEN r.edited_text ELSE r.output_text END FROM feature_debate_rounds r
 		      WHERE r.debate_id = fd.id AND r.status = 'accepted'
 		      ORDER BY r.round_number DESC LIMIT 1)`,
 		now, now.Add(-minAge), limit, baseBackoff.Seconds(), maxBackoff.Seconds(),

--- a/internal/models/queries.go
+++ b/internal/models/queries.go
@@ -2962,7 +2962,7 @@ func (db *DB) UndoRoundsFromTx(ctx context.Context, tx pgx.Tx, debateID string, 
 	var newCurrentText string
 	if scanErr := tx.QueryRow(ctx, `
 		SELECT COALESCE(
-			(SELECT COALESCE(NULLIF(btrim(edited_text), ''), output_text) FROM feature_debate_rounds
+			(SELECT COALESCE(NULLIF(btrim(edited_text, E' \t\n\r\f\v'), ''), output_text) FROM feature_debate_rounds
 			  WHERE debate_id = $1 AND status = 'accepted'
 			  ORDER BY round_number DESC LIMIT 1),
 			(SELECT seed_description FROM feature_debates WHERE id = $1)
@@ -3139,7 +3139,7 @@ func (db *DB) ClaimStaleEffortScores(
 		    -- does not affect the FOR UPDATE SKIP LOCKED semantics that
 		    -- keep two replicas from double-billing the same debate.
 		    (SELECT p.scorer_provider FROM projects p WHERE p.id = fd.project_id),
-		    (SELECT COALESCE(NULLIF(btrim(r.edited_text), ''), r.output_text) FROM feature_debate_rounds r
+		    (SELECT COALESCE(NULLIF(btrim(r.edited_text, E' \t\n\r\f\v'), ''), r.output_text) FROM feature_debate_rounds r
 		      WHERE r.debate_id = fd.id AND r.status = 'accepted'
 		      ORDER BY r.round_number DESC LIMIT 1)`,
 		now, now.Add(-minAge), limit, baseBackoff.Seconds(), maxBackoff.Seconds(),

--- a/internal/models/queries_accept_edit_test.go
+++ b/internal/models/queries_accept_edit_test.go
@@ -159,3 +159,28 @@ func TestAcceptRefusesAnEmptyEdit(t *testing.T) {
 		})
 	}
 }
+
+// TestWhitespaceOnlyDifferenceIsNotAnEdit makes an untested choice deliberate.
+//
+// The user opens the Edit tab, adds a stray trailing space, and accepts. That
+// is not an edit of the brief, and recording one would make every later "was
+// this hand-edited?" answer wrong — the same concern that motivates folding
+// CRLF in the handler: a difference nobody can see must not become data.
+func TestWhitespaceOnlyDifferenceIsNotAnEdit(t *testing.T) {
+	db := NewDB(testutil.SetupTestDB(t))
+	const aiText = "The AI's proposal."
+
+	deb, userID := newDebate(t, db)
+	roundID := seedPendingRound(t, db, deb.ID, userID, 1, aiText)
+
+	round, err := acceptWith(t, db, deb.ID, roundID, strptr(aiText+"   \n"))
+	if err != nil {
+		t.Fatalf("AcceptRoundTx: %v", err)
+	}
+	if round.EditedText != nil {
+		t.Errorf("edited_text = %q; a whitespace-only difference is not an edit", *round.EditedText)
+	}
+	if got := currentText(t, db, deb.ID); got != aiText {
+		t.Errorf("current_text = %q, want the AI text unchanged", got)
+	}
+}

--- a/internal/models/queries_accept_edit_test.go
+++ b/internal/models/queries_accept_edit_test.go
@@ -1,0 +1,161 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// acceptWith runs AcceptRoundTx in its own transaction and returns the round.
+func acceptWith(t *testing.T, db *DB, debateID, roundID string, edited *string) (*DebateRound, error) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	round, acceptErr := db.AcceptRoundTx(ctx, tx, debateID, roundID, edited)
+	if acceptErr != nil {
+		_ = tx.Rollback(ctx)
+		return nil, acceptErr
+	}
+	if cErr := tx.Commit(ctx); cErr != nil {
+		t.Fatalf("Commit: %v", cErr)
+	}
+	return round, nil
+}
+
+// seedPendingRound inserts an in_review round ready to be accepted.
+func seedPendingRound(t *testing.T, db *DB, debateID, userID string, num int, output string) string {
+	t.Helper()
+	var id string
+	if err := db.Pool.QueryRow(context.Background(),
+		`INSERT INTO feature_debate_rounds (
+			debate_id, round_number, provider, model, triggered_by,
+			input_text, output_text, status
+		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', $4, 'in_review')
+		RETURNING id`,
+		debateID, num, userID, output,
+	).Scan(&id); err != nil {
+		t.Fatalf("seedPendingRound: %v", err)
+	}
+	return id
+}
+
+func newDebate(t *testing.T, db *DB) (debate *FeatureDebate, userID string) {
+	t.Helper()
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "seed text")
+	deb, err := db.StartDebate(context.Background(), ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+	return deb, userID
+}
+
+func currentText(t *testing.T, db *DB, debateID string) string {
+	t.Helper()
+	var s string
+	if err := db.Pool.QueryRow(context.Background(),
+		`SELECT current_text FROM feature_debates WHERE id = $1`, debateID).Scan(&s); err != nil {
+		t.Fatalf("reading current_text: %v", err)
+	}
+	return s
+}
+
+// TestAcceptWithEditShipsTheEditAndKeepsTheAIText is the core of #66.
+//
+// The edited text becomes the document; output_text still holds what the AI
+// produced. That separation is the point: the cost columns and the scorer bill
+// for the AI's text, so overwriting it would destroy the record of what the
+// money bought.
+func TestAcceptWithEditShipsTheEditAndKeepsTheAIText(t *testing.T) {
+	db := NewDB(testutil.SetupTestDB(t))
+	deb, userID := newDebate(t, db)
+
+	const aiText = "AI draft with a typo"
+	const userText = "AI draft, corrected"
+	roundID := seedPendingRound(t, db, deb.ID, userID, 1, aiText)
+
+	round, err := acceptWith(t, db, deb.ID, roundID, strptr(userText))
+	if err != nil {
+		t.Fatalf("AcceptRoundTx: %v", err)
+	}
+
+	if got := currentText(t, db, deb.ID); got != userText {
+		t.Errorf("current_text = %q, want the edited text %q", got, userText)
+	}
+	if round.OutputText != aiText {
+		t.Errorf("output_text = %q; the AI's original must survive editing", round.OutputText)
+	}
+	if round.EditedText == nil || *round.EditedText != userText {
+		t.Errorf("edited_text = %v, want %q", round.EditedText, userText)
+	}
+	if got := round.ShippedText(); got != userText {
+		t.Errorf("ShippedText() = %q, want %q", got, userText)
+	}
+}
+
+// TestAcceptWithoutEditLeavesEditedTextNull covers both "did not open the tab"
+// and "opened it and changed nothing". The second is the subtle one: handing
+// back the AI's own text is not an edit, and recording it as one would make
+// every later "was this hand-edited?" answer wrong.
+func TestAcceptWithoutEditLeavesEditedTextNull(t *testing.T) {
+	db := NewDB(testutil.SetupTestDB(t))
+	const aiText = "AI draft, untouched"
+
+	for _, tc := range []struct {
+		name   string
+		edited *string
+	}{
+		{"field absent entirely", nil},
+		{"field present but identical to the AI text", strptr(aiText)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deb, userID := newDebate(t, db)
+			roundID := seedPendingRound(t, db, deb.ID, userID, 1, aiText)
+
+			round, err := acceptWith(t, db, deb.ID, roundID, tc.edited)
+			if err != nil {
+				t.Fatalf("AcceptRoundTx: %v", err)
+			}
+			if round.EditedText != nil {
+				t.Errorf("edited_text = %q, want NULL — nothing was edited", *round.EditedText)
+			}
+			if got := currentText(t, db, deb.ID); got != aiText {
+				t.Errorf("current_text = %q, want %q", got, aiText)
+			}
+		})
+	}
+}
+
+// TestAcceptRefusesAnEmptyEdit: shipping a blank would set current_text to
+// nothing and destroy the brief, so it is a validation error rather than a
+// silent no-op.
+func TestAcceptRefusesAnEmptyEdit(t *testing.T) {
+	db := NewDB(testutil.SetupTestDB(t))
+	const aiText = "AI draft"
+
+	// Subtests, not a bare loop: seedFeatureTicket keys its user's email off
+	// t.Name(), so repeating it inside one test collides on the unique index.
+	for name, blank := range map[string]string{
+		"empty string":    "",
+		"spaces":          "   ",
+		"newline and tab": "\n\t ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			deb, userID := newDebate(t, db)
+			roundID := seedPendingRound(t, db, deb.ID, userID, 1, aiText)
+			before := currentText(t, db, deb.ID)
+
+			_, err := acceptWith(t, db, deb.ID, roundID, strptr(blank))
+			if !errors.Is(err, ErrEmptyEdit) {
+				t.Errorf("accept with %q = %v, want ErrEmptyEdit", blank, err)
+			}
+			if got := currentText(t, db, deb.ID); got != before {
+				t.Errorf("current_text changed to %q after a refused empty edit", got)
+			}
+		})
+	}
+}

--- a/internal/models/queries_edited_round_test.go
+++ b/internal/models/queries_edited_round_test.go
@@ -137,3 +137,60 @@ func TestCheckConstraintRejectsWhitespaceOnlyEdit(t *testing.T) {
 		})
 	}
 }
+
+// TestShippedTextAgreesBetweenGoAndSQL pins the one thing this design is for:
+// there must be exactly ONE answer to "what shipped".
+//
+// The Go helper and the SQL used by undo and the retry sweep are two
+// implementations of the same rule, and they diverged: NULLIF(btrim(x), ”)
+// returns the TRIMMED value, so SQL shipped "text" where Go shipped "text  ".
+// The trim is only meant to answer "is this blank?", never to alter the text.
+//
+// The visible consequence: undo would silently reformat the document, and the
+// retry scorer would score different text from the immediate scorer.
+func TestShippedTextAgreesBetweenGoAndSQL(t *testing.T) {
+	db := NewDB(testutil.SetupTestDB(t))
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "seed")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	// Trailing whitespace the user legitimately typed and we must not silently
+	// rewrite.
+	const aiText = "AI text"
+	const userText = "Hand-edited text with trailing spaces   "
+	seedAcceptedRound(t, db, deb.ID, userID, 1, aiText, strptr(userText))
+	seedAcceptedRound(t, db, deb.ID, userID, 2, "second round", nil)
+
+	// The Go answer.
+	round := &DebateRound{OutputText: aiText, EditedText: strptr(userText)}
+	goAnswer := round.ShippedText()
+
+	// The SQL answer, via the undo recompute.
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if uErr := db.UndoRoundsFromTx(ctx, tx, deb.ID, 2); uErr != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("UndoRoundsFromTx: %v", uErr)
+	}
+	if cErr := tx.Commit(ctx); cErr != nil {
+		t.Fatalf("Commit: %v", cErr)
+	}
+	var sqlAnswer string
+	if sErr := db.Pool.QueryRow(ctx,
+		`SELECT current_text FROM feature_debates WHERE id = $1`, deb.ID).Scan(&sqlAnswer); sErr != nil {
+		t.Fatalf("reading current_text: %v", sErr)
+	}
+
+	if goAnswer != sqlAnswer {
+		t.Errorf("Go and SQL disagree about what shipped:\n  Go:  %q\n  SQL: %q", goAnswer, sqlAnswer)
+	}
+	if sqlAnswer != userText {
+		t.Errorf("SQL rewrote the user's text: %q, want %q", sqlAnswer, userText)
+	}
+}

--- a/internal/models/queries_edited_round_test.go
+++ b/internal/models/queries_edited_round_test.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/testutil"
+)
+
+// seedAcceptedRound inserts an accepted round directly, optionally edited, so
+// these tests can build a version history without driving the whole AI flow.
+func seedAcceptedRound(t *testing.T, db *DB, debateID, userID string, num int, output string, edited *string) string {
+	t.Helper()
+	var id string
+	if err := db.Pool.QueryRow(context.Background(),
+		`INSERT INTO feature_debate_rounds (
+			debate_id, round_number, provider, model, triggered_by,
+			input_text, output_text, edited_text, status, decided_at
+		) VALUES ($1, $2, 'claude', 'claude-test', $3, 'in', $4, $5, 'accepted', now())
+		RETURNING id`,
+		debateID, num, userID, output, edited,
+	).Scan(&id); err != nil {
+		t.Fatalf("seedAcceptedRound: %v", err)
+	}
+	return id
+}
+
+func strptr(s string) *string { return &s }
+
+// TestUndoPreservesAnEarlierRoundsEdit pins the data-loss bug in #66.
+//
+// UndoRoundsFromTx recomputes current_text from the largest REMAINING accepted
+// round. If that round was hand-edited, recomputing from output_text silently
+// reverts the document to the AI's draft — discarding the user's correction
+// while the row still records that it was edited. The round is not deleted, so
+// nothing looks wrong; the text just quietly changes underneath.
+func TestUndoPreservesAnEarlierRoundsEdit(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := NewDB(pool)
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "seed text")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+
+	// Round 1 was corrected by hand before being accepted.
+	const aiText = "AI wrote this, with a typo"
+	const userText = "AI wrote this, corrected by hand"
+	seedAcceptedRound(t, db, deb.ID, userID, 1, aiText, strptr(userText))
+	// Round 2 accepted as-is, and is what we undo.
+	seedAcceptedRound(t, db, deb.ID, userID, 2, "second round text", nil)
+
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if uErr := db.UndoRoundsFromTx(ctx, tx, deb.ID, 2); uErr != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("UndoRoundsFromTx: %v", uErr)
+	}
+	if cErr := tx.Commit(ctx); cErr != nil {
+		t.Fatalf("Commit: %v", cErr)
+	}
+
+	var current string
+	if sErr := db.Pool.QueryRow(ctx,
+		`SELECT current_text FROM feature_debates WHERE id = $1`, deb.ID,
+	).Scan(&current); sErr != nil {
+		t.Fatalf("reading current_text: %v", sErr)
+	}
+
+	if current == aiText {
+		t.Fatalf("undo reverted to the AI's draft and lost the user's edit:\n  got:  %q\n  want: %q", current, userText)
+	}
+	if current != userText {
+		t.Fatalf("current_text = %q, want the edited text %q", current, userText)
+	}
+}
+
+// TestShippedTextPrefersTheEdit is the single definition of "what shipped",
+// used by accept, undo, both scorer paths and the version-history viewer. Each
+// of those fails silently if it reads output_text directly, so this pins the
+// helper they all go through.
+func TestShippedTextPrefersTheEdit(t *testing.T) {
+	unedited := &DebateRound{OutputText: "ai text"}
+	if got := unedited.ShippedText(); got != "ai text" {
+		t.Errorf("unedited round shipped %q, want the AI text", got)
+	}
+
+	edited := &DebateRound{OutputText: "ai text", EditedText: strptr("human text")}
+	if got := edited.ShippedText(); got != "human text" {
+		t.Errorf("edited round shipped %q, want the human text", got)
+	}
+
+	// An empty edit must never be treated as the shipped text — the CHECK
+	// constraint and the handler both refuse it, and if one ever let it
+	// through, shipping "" would blank the brief.
+	blank := &DebateRound{OutputText: "ai text", EditedText: strptr("")}
+	if got := blank.ShippedText(); got == "" {
+		t.Error("an empty edit was treated as the shipped text; that would blank the document")
+	}
+}

--- a/internal/models/queries_edited_round_test.go
+++ b/internal/models/queries_edited_round_test.go
@@ -102,3 +102,38 @@ func TestShippedTextPrefersTheEdit(t *testing.T) {
 		t.Error("an empty edit was treated as the shipped text; that would blank the document")
 	}
 }
+
+// TestCheckConstraintRejectsWhitespaceOnlyEdit guards the database backstop.
+//
+// The handler refuses a blank edit first; this CHECK is what catches anything
+// that bypasses it. It nearly did not: btrim(x) with ONE argument strips only
+// SPACES, so a tab- or newline-only value survived it and read as non-empty —
+// leaving the backstop weaker than the guard it backs up, precisely in the case
+// it exists for. The explicit character set fixes that, and this test pins it.
+func TestCheckConstraintRejectsWhitespaceOnlyEdit(t *testing.T) {
+	db := NewDB(testutil.SetupTestDB(t))
+	ctx := context.Background()
+
+	orgID, userID, projID, ticketID := seedFeatureTicket(t, db, "seed")
+	deb, err := db.StartDebate(ctx, ticketID, projID, orgID, userID)
+	if err != nil {
+		t.Fatalf("StartDebate: %v", err)
+	}
+	roundID := seedAcceptedRound(t, db, deb.ID, userID, 1, "ai text", nil)
+
+	for name, blank := range map[string]string{
+		"spaces":  "   ",
+		"tab":     "\t",
+		"newline": "\n",
+		"mixed":   " \t\n\r ",
+		"empty":   "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := db.Pool.Exec(ctx,
+				`UPDATE feature_debate_rounds SET edited_text = $1 WHERE id = $2`, blank, roundID)
+			if err == nil {
+				t.Errorf("the database accepted a whitespace-only edit (%q); shipping it would blank the brief", blank)
+			}
+		})
+	}
+}

--- a/migrations/000037_round_edited_text.down.sql
+++ b/migrations/000037_round_edited_text.down.sql
@@ -1,0 +1,4 @@
+-- Dropping this loses the user's corrections on every edited round; the text
+-- that actually shipped exists nowhere else, since output_text deliberately
+-- holds the AI's original.
+ALTER TABLE feature_debate_rounds DROP COLUMN IF EXISTS edited_text;

--- a/migrations/000037_round_edited_text.up.sql
+++ b/migrations/000037_round_edited_text.up.sql
@@ -1,0 +1,18 @@
+-- Lets a user correct the AI's proposed text before accepting it (#66).
+--
+-- WHY A SEPARATE COLUMN RATHER THAN OVERWRITING output_text:
+-- output_text keeps its meaning — what the AI produced. The cost columns and
+-- the effort scorer bill for that text, so overwriting it would destroy the
+-- only record of what the money bought. edited_text holds the user's version
+-- when they changed something, NULL otherwise, and what ships is
+-- COALESCE(edited_text, output_text).
+--
+-- No accompanying `edited_by_user` boolean, deliberately: a boolean beside the
+-- text is a second source of truth that can drift from it, which is exactly
+-- what #129 was in this same table. The column's presence IS the flag.
+--
+-- The CHECK stops an empty edit from silently emptying the brief; the handler
+-- rejects it first, and this is the backstop.
+ALTER TABLE feature_debate_rounds
+  ADD COLUMN edited_text TEXT
+  CHECK (edited_text IS NULL OR btrim(edited_text) <> '');

--- a/migrations/000037_round_edited_text.up.sql
+++ b/migrations/000037_round_edited_text.up.sql
@@ -13,6 +13,10 @@
 --
 -- The CHECK stops an empty edit from silently emptying the brief; the handler
 -- rejects it first, and this is the backstop.
+-- btrim(x) with ONE argument strips only SPACES, so a tab- or newline-only
+-- value survives it and reads as non-empty. Go's strings.TrimSpace rejects
+-- those, so the explicit character set is what keeps this backstop as strict
+-- as the handler it backs up (#66).
 ALTER TABLE feature_debate_rounds
   ADD COLUMN edited_text TEXT
-  CHECK (edited_text IS NULL OR btrim(edited_text) <> '');
+  CHECK (edited_text IS NULL OR btrim(edited_text, E' \t\n\r\f\v') <> '');

--- a/templates/components/debate_suggestion.html
+++ b/templates/components/debate_suggestion.html
@@ -13,12 +13,35 @@
       <button type="button" role="tab" class="tab" :class="tab === 'changes' && 'tab-active'"
               :aria-selected="tab === 'changes' ? 'true' : 'false'" aria-controls="debate-pane-changes"
               @click="tab = 'changes'" data-testid="debate-tab-changes">What changed</button>
+      <button type="button" role="tab" class="tab" :class="tab === 'edit' && 'tab-active'"
+              :aria-selected="tab === 'edit' ? 'true' : 'false'" aria-controls="debate-pane-edit"
+              @click="tab = 'edit'" data-testid="debate-tab-edit">Edit</button>
     </div>
     <div x-show="tab === 'preview'" id="debate-pane-preview" role="tabpanel" class="prose prose-sm max-w-none py-3" data-testid="debate-preview-pane">
       {{markdown .Pending.OutputText}}
     </div>
     <div x-show="tab === 'changes'" x-cloak id="debate-pane-changes" role="tabpanel" class="py-3 text-sm" data-testid="debate-changes-pane">
+      {{/* Always the AI's proposal against the previous version, even after an
+           edit — the label says so, because it no longer describes what will
+           ship once the text below has been changed (#66). */}}
+      <p class="text-xs text-base-content/60 mb-2">What the AI proposed, compared with the current version.</p>
       {{renderInlineDiff .Pending.InputText .Pending.OutputText}}
+    </div>
+    {{/* Correct the AI before accepting (#66). Accept sends this via
+         hx-include, so the panel keeps its deliberate no-<form> design and the
+         global CSRF header injection in init.js still applies.
+
+         The text is client-side only: there is no draft persistence, so
+         anything that swaps #debate-stage discards it. Nothing does that in the
+         background — the effort chip polls into its own element — so only the
+         user's own navigation can lose it. */}}
+    <div x-show="tab === 'edit'" x-cloak id="debate-pane-edit" role="tabpanel" class="py-3" data-testid="debate-edit-pane">
+      <label class="label pb-1" for="debate-edit-text">
+        <span class="label-text text-xs">Edit before accepting. Leave it alone to accept the AI's version as-is.</span>
+      </label>
+      <textarea id="debate-edit-text" name="edited_text"
+                class="textarea textarea-bordered w-full font-mono text-sm"
+                rows="14" data-testid="debate-edit-textarea">{{.Pending.OutputText}}</textarea>
     </div>
   </div>
   {{/* Bare hx-post buttons (no <form>): CSRF is covered globally — init.js
@@ -27,6 +50,7 @@
   <div class="flex gap-2 px-4 py-3 border-t border-base-300 bg-base-100">
     <button class="btn btn-success btn-sm" data-testid="debate-accept"
             hx-post="/tickets/{{.TicketID}}/debate/rounds/{{.Pending.RoundID}}/accept"
+            hx-include="#debate-edit-text"
             hx-target="#debate-stage" hx-swap="innerHTML">
       Accept — make this version {{.Pending.NextVersion}}
     </button>


### PR DESCRIPTION
Closes #66.

Lets a user correct a nearly-right AI proposal instead of dismissing it and
paying for another round.

## Design, including where I disagreed with the issue

One nullable column, `edited_text`, and an Edit tab. `output_text` keeps its
meaning — **what the AI produced** — because the cost columns and the effort
scorer bill for that text; overwriting it would destroy the only record of what
the money bought. Accept ships `COALESCE(edited_text, output_text)`.

**No `edited_by_user` boolean, against the issue's wording.** A boolean beside
the text is a second source of truth that can drift from it — which is exactly
what #129 was, in this same table. The column's presence is the flag.

## The column is the easy part

Five reads of `output_text` mean "what shipped", and **each one fails silently
if missed**. All five now go through `DebateRound.ShippedText()` or its SQL twin:

| Site | Consequence if missed |
|---|---|
| `AcceptRoundTx` | the edit never takes effect |
| `UndoRoundsFromTx` recompute | **data loss** — undoing a *later* round reverted an earlier edited round to the AI's text while the row still recorded the edit |
| `scoreAfterAccept` | effort estimated for text nobody will build |
| retry sweep | same, and inconsistent with the immediate path |
| version-history viewer | **history lied** — an old version rendered the AI draft |

The undo case was raised by both reviewers. The version-history case came from
my own sweep; neither review found it, and its mutation initially survived my
tests, so I added one.

Reads that legitimately still mean "the AI's text" are unchanged: `diff_unified`,
the cost columns and spend ledger, and the What-changed tab — which now says so
in its caption, since after an edit it no longer describes what will ship.

## Three traps worth recording

**CRLF.** Browsers normalise textarea newlines to CRLF while stored text uses
LF, and the textarea is always in the DOM because the tab only hides it — so
without folding CRLF back, untouched multi-line text would differ from
`output_text` and **every accept would be recorded as hand-edited**. Wrong data
that looks fine until someone queries it.

**`r.Form.Has()` on a nil map** returns false without complaining unless
`ParseForm` has run — which would have silently ignored every edit.

**Postgres `btrim(x)` with one argument strips only spaces.** A tab- or
newline-only value survived it, so the CHECK constraint accepted whitespace that
Go's `TrimSpace` rejects — the backstop was weaker than the guard it backs up,
in exactly the case it exists for.

## Two things I got wrong, caught in review

**`NULLIF(btrim(x), '')` returns the TRIMMED value.** So the SQL used by undo
and the retry sweep shipped `"text"` where `ShippedText()` shipped `"text  "` —
two implementations of "what shipped" disagreeing, which is precisely what this
design exists to prevent, introduced in the expression meant to enforce it. Undo
would have silently reformatted the document. Now `CASE WHEN btrim(...) <> ''
THEN edited_text ELSE output_text END`: the trim answers "is this blank?" and
never alters what ships.

**Whitespace-only differences were an untested choice.** Now deliberate and
pinned: adding a stray trailing space is not an edit, for the same reason CRLF
is folded — a difference nobody can see must not become data.

## Deliberately unchanged

**No staleness token.** `output_text` is written once at insert and never
updated, so the existing `status = 'in_review'` check under `FOR UPDATE` already
covers every "has this round moved on" case. Both reviews proposed a hash; both
agreed it was unnecessary once that was verified.

**Authorization.** Review argued this lets clients author brief text for the
first time. It does not: `UpdateTicket` has no role check and assigns
`DescriptionMarkdown` straight from a form value, and `ApproveDebateTx` writes
`current_text` into that same field — the capability already exists by a shorter
path.

## Evidence

Tests written first; the undo test reproduced the data loss before the fix.

| Mutation | Result |
|---|---|
| undo recompute reads `output_text` | RED |
| drop CRLF normalisation | RED |
| store an identical edit | RED |
| allow an empty edit | RED |
| version viewer reads `output_text` | RED *(survived at first — test added)* |
| one-argument `btrim` in the CHECK | RED |
| restore `NULLIF` (Go/SQL divergence) | RED |
| compare untrimmed | RED |

Full `./internal/...` suite green, `bash scripts/lint.sh` 0 issues, migration
applies and reverts cleanly.

**E2E**: two tests added to `12-debate-fake` — editing a suggestion before
accepting, and accepting without opening the tab. Placed last in the file
deliberately: they accept rounds, and the tests above count versions on the
shared debate. **Whole suite: 124 passed, zero skips.**

## Deploying

Needs migration **000037** (additive, nullable column plus a CHECK) before the
image rollout, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)