### PR TITLE
deploy: pin server & orchestrator images to v0.8.0

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.7.1
+          image: registry.k3s.vlah.sh/smartpm:v0.8.0
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.7.1
+          image: registry.k3s.vlah.sh/smartpm:v0.8.0
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for v0.8.0, already deployed.

## Shipped

| PR | Issue | |
|---|---|---|
| #149 | #66 | edit the AI's proposed text before accepting it |

Schema **36 → 37** via migration `000037_round_edited_text` (additive: nullable
column plus a CHECK), applied **before** the rollout so v0.7.1 kept serving
through it.

## Deploy record

- Tag `v0.8.0` → `85f8b72`; digest
  `sha256:874050a93cf522316bfd49d0b1ee78d97cd9ed40cab9a6e65f5853be845329e9`
- All 3 pods digest-verified, **0 restarts**
- Migration applied in 517ms; all 3 existing rounds correctly have
  `edited_text` NULL, and the CHECK constraint is present
- Startup clean: `Feature Debate Mode wired (3 refiners, 3 scorers)`, no
  unpriced-model warning. `/login` and `/health` 200.

## Feature verified against production

Rather than assume the migration's guarantees held, I probed them — every write
inside a transaction that was rolled back, so nothing changed:

| Probe | Result |
|---|---|
| whitespace-only edit (`"  \t\n "`) | **refused** — `violates check constraint "feature_debate_rounds_edited_text_check"` |
| a genuine correction | accepted (`UPDATE 1`), then rolled back |
| rows actually modified | **0** — 3 rounds, 0 with `edited_text` |
| Edit tab markup in the running image | present |

That confirms the backstop I strengthened during review (Postgres `btrim(x)`
with one argument strips only spaces, so the original constraint would have let
tab- and newline-only text through) is doing its job on the live database.

Client-visible behaviour is unchanged until someone opens the new Edit tab on a
pending suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)