### PR TITLE
deploy: pin server & orchestrator images to v0.8.1

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.8.0
+          image: registry.k3s.vlah.sh/smartpm:v0.8.1
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.8.0
+          image: registry.k3s.vlah.sh/smartpm:v0.8.1
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for v0.8.1, already deployed. No migration; schema stays **37**.

## Shipped

| PR | |
|---|---|
| #151 | dependency security bumps — `govulncheck` **3 reachable → 0** |
| #152 | routine bumps (chroma, goldmark, anthropic-sdk-go, genai, aws, x/crypto) |

## Deploy record

- Tag `v0.8.1` → `66ec867`; digest
  `sha256:a89bc9f8900719bcbc8b5f52573d33f9dd481613a352b2184854b6fad2de0e69`
- All 3 pods digest-verified, **0 restarts**
- Startup clean: `Feature Debate Mode wired (3 refiners, 3 scorers)`, no
  unpriced-model warning. `/login` and `/health` 200.
- Schema untouched at 37, `dirty=false`

## The riskiest bump, checked

`aws-sdk-go-v2/service/s3` was the only bump with application code calling
directly into it, so I checked what it could affect in production — and found
the path is never exercised, because **S3 is not configured there at all**: the
`forgedesk-env` secret has no `S3_*` keys and the `S3 storage enabled` startup
line is absent.

That makes the bump risk-free here, and it surfaced a separate pre-existing
problem: the upload UI is still offered while the storage client is nil, so an
upload should panic into a 500. Filed as **#153** — traced from the code, not
observed against production, since testing it would write real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)