### PR TITLE
fix(storage): hide upload controls and say so when storage is unconfigured (#153)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -103,6 +103,16 @@ func main() {
 		}
 	}
 
+	// Say so when storage is OFF, not only when it is on. The absence of a
+	// startup line is not something anyone reads, which is how a deployment ran
+	// for months offering upload controls whose routes were never registered
+	// (#153).
+	engine.StorageEnabled = s3Client != nil
+	if s3Client == nil {
+		log.Printf("S3 storage DISABLED (no S3_ENDPOINT/S3_BUCKET) — " +
+			"file upload and attachment routes are not registered, and the UI hides them")
+	}
+
 	// Handlers
 	secureCookie := strings.HasPrefix(cfg.BaseURL, "https")
 	mailer := mail.NewMailer(cfg.SMTPHost, cfg.SMTPPort, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.SMTPSSL)

--- a/internal/handlers/storage_gating_test.go
+++ b/internal/handlers/storage_gating_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/models"
+)
+
+// TestUploadControlsHiddenWhenStorageDisabled pins #153.
+//
+// With no object store configured, cmd/server/main.go does not register the
+// upload routes at all — so a page that still offers Upload, Insert Image or
+// the attachments card is offering controls that 404. Production ran in exactly
+// that state, and nothing said so.
+//
+// The template must therefore gate on StorageEnabled, and this asserts both
+// directions: a bare {{if}} that is never true would pass a one-sided test.
+func TestUploadControlsHiddenWhenStorageDisabled(t *testing.T) {
+	r, db, sessions, engine := setupTestRouter(t)
+	ctx := context.Background()
+	cookie := createAuthenticatedUser(t, db, sessions, "storagegate@test.com", "superadmin")
+
+	user, err := db.GetUserByEmail(ctx, "storagegate@test.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	org, err := db.CreateOrg(ctx, "Storage Org", "storage-org")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	proj, err := db.CreateProject(ctx, org.ID, "Storage Proj", "storage-proj")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	tk := &models.Ticket{
+		ProjectID: proj.ID, Type: "task", Title: "Storage gate task",
+		Status: "backlog", Priority: "medium", CreatedBy: user.ID,
+	}
+	if err := db.CreateTicket(ctx, tk); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	ticket := tk.ID
+
+	get := func() string {
+		req := httptest.NewRequest(http.MethodGet, "/tickets/"+ticket, http.NoBody)
+		req.AddCookie(cookie)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("ticket page = %d: %s", rec.Code, rec.Body.String())
+		}
+		return rec.Body.String()
+	}
+
+	engine.StorageEnabled = false
+	off := get()
+	for _, marker := range []string{"Upload File", "insert-image", "Attachments"} {
+		if strings.Contains(off, marker) {
+			t.Errorf("with storage disabled the page still offers %q, whose route is not registered", marker)
+		}
+	}
+
+	engine.StorageEnabled = true
+	on := get()
+	for _, marker := range []string{"Upload File", "insert-image", "Attachments"} {
+		if !strings.Contains(on, marker) {
+			t.Errorf("with storage enabled the page is missing %q — the gate hides it unconditionally", marker)
+		}
+	}
+}
+
+// TestTicketPageRendersToCompletion guards the failure that hid the bug above.
+//
+// A template execution error — a missing field on the wrong dot, say — makes
+// html/template stop writing mid-page. Handlers discard the error
+// (`_ = h.engine.Render(...)`), so the response is still 200 with plausible
+// content and the tail is simply gone. That is indistinguishable from a
+// complete page unless something asserts on what should be at the END.
+//
+// This repo has hit it before (PR #80, a conditional `selected` attribute), and
+// again in #153, where everything after line 353 vanished while the page still
+// returned 32KB and a 200.
+func TestTicketPageRendersToCompletion(t *testing.T) {
+	r, db, sessions, engine := setupTestRouter(t)
+	ctx := context.Background()
+	cookie := createAuthenticatedUser(t, db, sessions, "completion@test.com", "superadmin")
+
+	user, err := db.GetUserByEmail(ctx, "completion@test.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	org, err := db.CreateOrg(ctx, "Completion Org", "completion-org")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	proj, err := db.CreateProject(ctx, org.ID, "Completion", "completion-proj")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	tk := &models.Ticket{
+		ProjectID: proj.ID, Type: "task", Title: "Completion task",
+		Status: "backlog", Priority: "medium", CreatedBy: user.ID,
+	}
+	if err := db.CreateTicket(ctx, tk); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	engine.StorageEnabled = true
+
+	req := httptest.NewRequest(http.MethodGet, "/tickets/"+tk.ID, http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	// Markers from progressively later in the template. The last ones are what
+	// a mid-page abort silently removes.
+	for _, marker := range []string{
+		"Attachments",      // early
+		"imageInsertModal", // the modal include, near the end
+		"ticketEditor",     // the editor script
+		"toolbar",          // inside that script
+		"</html>",          // the very end of the layout
+	} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("page is missing %q — rendering aborted before the end (status was %d, %d bytes, so it looks fine)",
+				marker, rec.Code, len(body))
+		}
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -42,6 +42,10 @@ const (
 type Engine struct {
 	templates        map[string]*template.Template
 	AssistantEnabled bool
+	// StorageEnabled is false when no object store is configured. The upload
+	// routes are not even registered in that case (cmd/server/main.go), so
+	// templates must not offer controls that would 404 (#153).
+	StorageEnabled bool
 }
 
 // PageData holds common data passed to every template.
@@ -60,6 +64,7 @@ type PageData struct {
 	Projects         []models.Project
 	Orgs             []models.Organization
 	AssistantEnabled bool
+	StorageEnabled   bool
 }
 
 // staticFuncMap returns template helpers that are pure functions with
@@ -449,6 +454,7 @@ func (e *Engine) Render(w http.ResponseWriter, r *http.Request, name string, dat
 		return fmt.Errorf("template %q not found", name)
 	}
 	data.AssistantEnabled = e.AssistantEnabled
+	data.StorageEnabled = e.StorageEnabled
 	// filippo.io/csrf/gorilla uses header-based CSRF (Origin /
 	// Sec-Fetch-Site); Token/TemplateField are shim no-ops kept for
 	// source compatibility. Removing these call sites would also

--- a/templates/pages/project_brief.html
+++ b/templates/pages/project_brief.html
@@ -133,7 +133,7 @@
     {{end}}
 </div>
 
-{{template "image_modal" .}}
+{{if $.StorageEnabled}}{{template "image_modal" $}}{{end}}
 
 <script>
 var _imageGenProjectID = '{{.Project.ID}}';
@@ -157,6 +157,7 @@ function briefEditor() {
                             'bold', 'italic', 'heading', '|',
                             'unordered-list', 'ordered-list', '|',
                             'link',
+                            {{if $.StorageEnabled}}
                             {
                                 name: 'insert-image',
                                 action: function(editor) {
@@ -168,6 +169,7 @@ function briefEditor() {
                                 className: 'fa fa-image',
                                 title: 'Insert Image',
                             },
+                            {{end}}
                             '|', 'code', 'quote', '|',
                             'preview', 'side-by-side', '|',
                             'guide'

--- a/templates/pages/ticket_detail.html
+++ b/templates/pages/ticket_detail.html
@@ -189,6 +189,10 @@
     </div>
 
     {{/* Attachments */}}
+    {{/* Storage-gated (#153). With no object store configured, main.go does not
+         register the upload routes at all, so offering these controls means
+         offering something that 404s. */}}
+    {{if $.StorageEnabled}}
     <div class="card bg-base-100 border border-base-300 shadow-sm">
         <div class="card-body p-6 gap-3">
             <div class="flex items-center justify-between flex-wrap gap-3">
@@ -311,6 +315,8 @@
         </div>
     </div>
 
+    {{end}}
+
     {{/* Comments */}}
     <div class="card bg-base-100 border border-base-300 shadow-sm">
         <div class="card-body p-6 gap-4">
@@ -344,7 +350,10 @@
     </div>
 </div>
 
-{{template "image_modal" .}}
+{{/* $ , not . : inside {{with .Data}} a bare .StorageEnabled is a
+     missing field, which aborts execution and SILENTLY TRUNCATES everything
+     after it (#153, same trap as PR #80). */}}
+{{if $.StorageEnabled}}{{template "image_modal" $}}{{end}}
 
 <script>
 var _imageGenProjectID = '{{.Ticket.ProjectID}}';
@@ -369,6 +378,7 @@ function ticketEditor() {
                             'bold', 'italic', 'heading', '|',
                             'unordered-list', 'ordered-list', '|',
                             'link',
+                            {{if $.StorageEnabled}}
                             {
                                 name: 'insert-image',
                                 action: function(editor) {
@@ -380,6 +390,7 @@ function ticketEditor() {
                                 className: 'fa fa-image',
                                 title: 'Insert Image',
                             },
+                            {{end}}
                             '|', 'code', 'quote', '|',
                             'preview', 'side-by-side', '|',
                             'guide'


### PR DESCRIPTION
Addresses the code half of #153. **Leaves #153 open** for the product question.

## What was wrong

With no object store configured, `cmd/server/main.go` does not register the
upload, attachment or file-serving routes at all — but the UI kept offering
**Upload File**, **Insert Image** and the **attachments card**. Those controls
404. Production has been running in exactly that state.

## Correcting my own report

I originally wrote in #153 that uploads would **panic into a 500**. They do not.
Both route registration sites are already guarded (`main.go:266` and `:387`), so
the routes are absent rather than broken, and requests 404.

I had followed the nil client into the handler without checking whether anything
could reach it. The severity in the original report was overstated; I've
corrected the issue itself too.

## The fix

Follows the existing `AssistantEnabled` precedent — a `StorageEnabled` flag on
the render engine, stamped onto every `PageData`, with templates gating on it.

The server now also logs when storage is **disabled**, not only when it is
enabled. The absence of a startup line is not something anyone reads, which is
precisely how this went unnoticed for months.

## What this turned up along the way

My first version of the gate wrote `{{if .StorageEnabled}}` at a point inside
`{{with .Data}}`, where the dot is the page's data struct and that field does
not exist. **A missing field on a struct aborts execution and `html/template`
stops writing** — so the modal, the editor script and the entire tail of the
page vanished, while the response was still **200 with 32KB of plausible
content**. Handlers discard the render error (`_ = h.engine.Render(...)`), so
nothing said a word.

This repo has hit the same silent truncation before — PR #80, a conditional
`selected` attribute.

`TestTicketPageRendersToCompletion` now asserts markers from progressively later
in the template, ending at `</html>`, so a mid-page abort fails loudly. When I
mutation-tested by reintroducing the wrong dot, it reported:

```
page is missing "imageInsertModal" — rendering aborted before the end
(status was 200, 32504 bytes, so it looks fine)
```

That is the whole problem with this failure mode in one line.

## Evidence

| Mutation | Result |
|---|---|
| reintroduce the wrong dot (silent truncation) | RED — both tests |
| gate always false (hidden even when storage works) | RED |
| gate always true (shown when storage is off) | RED |
| restored | green |

The gating test asserts **both** directions deliberately: a gate that is never
true would pass a one-sided test while hiding a working feature.

Full `./internal/...` suite green, `bash scripts/lint.sh` 0 issues.

## Deliberately not done

**Whether S3 should be configured in production** so attachments work at all is
a product decision, not a bug — it needs MinIO or Ceph RGW per the stack
conventions, and someone deciding that clients should have attachments. #153
stays open for that; this PR only ensures the app is honest about the state it
is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)