### PR TITLE
deploy: pin server & orchestrator images to v0.8.2

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: server
-          image: registry.k3s.vlah.sh/smartpm:v0.8.1
+          image: registry.k3s.vlah.sh/smartpm:v0.8.2
           imagePullPolicy: IfNotPresent
           command: ["forgedesk"]
           ports:

--- a/deploy/k8s/orchestrator-deployment.yaml
+++ b/deploy/k8s/orchestrator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: registry-credentials
       containers:
         - name: orchestrator
-          image: registry.k3s.vlah.sh/smartpm:v0.8.1
+          image: registry.k3s.vlah.sh/smartpm:v0.8.2
           imagePullPolicy: IfNotPresent
           command: ["orchestrator"]
           envFrom:


### PR DESCRIPTION
Manifest sync for v0.8.2, already deployed. No migration; schema stays **37**.

## Shipped

| PR | Issue | |
|---|---|---|
| #155 | #153 | hide upload controls, and log, when object storage is unconfigured |

## Deploy record

- Tag `v0.8.2` → `3be8e19`; digest
  `sha256:0c83fcce3e0e75c301cb7e004cb9ca041948f90489fa5ff6d9317d0fa6902e64`
- All 3 pods digest-verified, **0 restarts**
- `/login` and `/health` 200

## Verified: production now states its own configuration

The signal this release exists to provide is present:

```
S3 storage DISABLED (no S3_ENDPOINT/S3_BUCKET) — file upload and attachment
routes are not registered, and the UI hides them
```

Previously the app announced storage only when it was **on**, so the off case
was silence — and silence reads as fine. That is why a deployment offering
upload controls whose routes were never registered went unnoticed for months.

## #153 stays open

The remaining question is a product decision, not a bug: **should S3 be
configured in production** so attachments and image uploads work at all? That
needs MinIO or Ceph RGW per the stack conventions, and a call on whether clients
should have attachments.

Until then the app is honest about the state it is in rather than offering
controls that 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)