### PR TITLE
ci: bring test.yml and e2e.yml onto the same action versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
     # runner indefinitely (the per-step health wait only covers startup).
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Build + start the full stack (postgres, minio, migrate, app) with
       # DEBATE_REFINER_MODE=fake (set in docker-compose.test.yml), so the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     # it is not fast. Cap the job so a hung container cannot hold the runner.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
Follow-up to the five Dependabot Actions bumps merged just now (#2, #3, #4, #6,
#106).

Those PRs were filed in **March**, when `codeql.yml` and `lint.yml` were the only
workflows. `test.yml` (added with #138 yesterday) and `e2e.yml`'s checkout were
never in their diffs, so after merging them the repo ran `actions/checkout` at
**both v4 and v6** and `actions/setup-go` at **both v5 and v6**.

| File | |
|---|---|
| `test.yml` | checkout v4 → v6, setup-go v5 → v6 |
| `e2e.yml` | checkout v4 → v6 |

Nothing was broken — action versions are independent per workflow — but the
split is the kind of thing that makes a later failure confusing: *"checkout
works in lint but not in test"* reads as a mystery rather than a version
difference.

All workflows now use one version of each action.

## Note on the merge order

Each of the five was updated onto current `main` before merging, so its CI run
exercised the new action version against the real workflows rather than against
a six-month-old base.

The `golangci-lint-action` v7→v9 bump (#3) was the one worth watching: its
original diff still carried `version: v2.11`, the **floating** pin that #120
replaced with an exact version read from `.golangci-version`. Rebasing onto main
resolved that correctly, and I confirmed from the run log that v9 honours the
exact pin:

```
version: v2.11.4
Installing golangci-lint binary v2.11.4...
```

A green lint check alone would not have shown that — it would pass just as
happily on a floating version, which is precisely the failure #120 existed to
stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)