### PR TITLE
fix(storage): name the real env var in the storage-disabled log

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -109,7 +109,11 @@ func main() {
 	// (#153).
 	engine.StorageEnabled = s3Client != nil
 	if s3Client == nil {
-		log.Printf("S3 storage DISABLED (no S3_ENDPOINT/S3_BUCKET) — " +
+		// Name the ACTUAL env vars. The bucket is read from S3_PUBLIC_BUCKET,
+		// not S3_BUCKET — an earlier version of this line said the latter, and
+		// it would send whoever is configuring storage looking for a variable
+		// that does not exist.
+		log.Printf("S3 storage DISABLED (set S3_ENDPOINT and S3_PUBLIC_BUCKET to enable) — " +
 			"file upload and attachment routes are not registered, and the UI hides them")
 	}
 


### PR DESCRIPTION
The startup line said `no S3_ENDPOINT/S3_BUCKET`. The bucket is actually read
from **`S3_PUBLIC_BUCKET`** (`internal/config/config.go:295`), so anyone
following that message would go looking for a variable that does not exist.

Found while configuring Hetzner Object Storage for production — which is
precisely the situation that message exists to guide, so it got a real test and
failed it.

It now names both real variables:

```
S3 storage DISABLED (set S3_ENDPOINT and S3_PUBLIC_BUCKET to enable) —
file upload and attachment routes are not registered, and the UI hides them
```

Full `./internal/...` suite green, lint 0 issues.

## Context: production now has storage

Configured against Hetzner Object Storage (`fsn1`, bucket
`smart-project-manager`) and verified in this order:

1. **Credentials, before touching production** — a scratch program using the
   app's own `internal/storage` package did a full upload → get → delete round
   trip, with contents compared. Deleted afterwards; never committed.
2. **Secret patched**, values piped from the gitignored `.secrets` and never
   printed. Note the rename: `.secrets` stores `S3_ACCESS_KEY`/`S3_SECRET_KEY`,
   the app reads `S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY`.
3. **Startup signal flipped** — `S3 storage enabled (bucket: smart-project-manager)`.
4. **Routes now registered** — `/api/upload-file` and `/api/upload-image` return
   303 (redirect to login, i.e. registered and protected) and `/files/*` returns
   405 for POST, against a **404** control on a genuinely nonexistent path.
   Before this they were 404 like the control.
5. **Egress from inside the cluster**, not just from the dev VM — DNS resolves
   and HTTPS reaches Hetzner from a running pod. The startup line alone only
   proves the client was constructed, not that it can reach anything.

That closes the product half of #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)