### PR TITLE
fix(clientip): derive the client IP from a trusted source, not a raw header

### DIFF
--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/madalin/forgedesk/internal/clientip"
 )
 
 const (
@@ -45,10 +47,9 @@ func (s *SessionStore) CreateSession(ctx context.Context, userID string, mustSet
 	rawToken := hex.EncodeToString(tokenBytes)
 	tokenHash := hashToken(rawToken)
 
-	ip := r.RemoteAddr
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		ip = fwd
-	}
+	// sessions.ip_address is the audit trail. Deriving it from a raw
+	// header let the caller write whatever they liked into that column.
+	ip := clientip.From(r)
 
 	_, err := s.db.Exec(ctx,
 		`INSERT INTO sessions (token_hash, user_id, must_setup_2fa, ip_address, user_agent, expires_at)

--- a/internal/clientip/clientip.go
+++ b/internal/clientip/clientip.go
@@ -47,12 +47,23 @@ const cloudflareHeader = "Cf-Connecting-Ip"
 // peer. It never returns a caller-controlled value that has not been
 // parsed as an IP address.
 func From(r *http.Request) string {
-	if v := strings.TrimSpace(r.Header.Get(cloudflareHeader)); v != "" {
-		// Parse rather than pass through: the return value becomes a map
-		// key and a database column, so it must be a real address and not
-		// an arbitrary caller-supplied string of arbitrary length.
-		if ip := net.ParseIP(v); ip != nil {
-			return ip.String()
+	// Values, not Get: Get returns the FIRST value, and Cloudflare's public
+	// documentation does not state whether a client-supplied header is
+	// overwritten or appended to. If it is ever appended, the edge's value
+	// is the last one and a forged first value must not win. Reading the
+	// last element is correct under either behavior and costs nothing.
+	values := r.Header.Values(cloudflareHeader)
+	if len(values) > 0 {
+		if v := strings.TrimSpace(values[len(values)-1]); v != "" {
+			// Parse rather than pass through: the return value becomes a
+			// map key and a database column, so it must be a real address
+			// and not an arbitrary caller-supplied string of arbitrary
+			// length. The net.IP round-trip also canonicalizes, so two
+			// spellings of one address cannot become two rate-limit
+			// buckets — do not "simplify" this by returning v directly.
+			if ip := net.ParseIP(v); ip != nil {
+				return ip.String()
+			}
 		}
 	}
 

--- a/internal/clientip/clientip.go
+++ b/internal/clientip/clientip.go
@@ -1,0 +1,67 @@
+// Package clientip derives the address a request should be attributed to,
+// for rate limiting and for the session audit trail.
+//
+// It exists because both call sites previously did this:
+//
+//	ip := r.RemoteAddr
+//	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+//		ip = xff
+//	}
+//
+// X-Forwarded-For is appended to by each hop, so the left-hand part of it
+// is whatever the client typed. Taking the whole header as a value made it
+// entirely caller-controlled, and the rate limiter used that value as its
+// per-visitor map key — so varying the header per request produced a fresh
+// limiter every time and the /login limit could not fire. The same value
+// was written to sessions.ip_address, making the audit trail caller-writable.
+//
+// This package lives outside internal/auth because internal/middleware
+// already imports internal/auth; putting it there would be an import cycle.
+package clientip
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// cloudflareHeader carries the true client address as seen by Cloudflare.
+// Cloudflare overwrites any value the caller supplies, so unlike
+// X-Forwarded-For it cannot be forged by a client whose traffic actually
+// passes through the edge.
+//
+// This is deliberately NOT X-Forwarded-For. In this deployment the pod's
+// RemoteAddr is always the in-cluster Traefik address, so without this
+// header every visitor would share a single rate-limit bucket.
+//
+// Caveat worth knowing before relying on it: a caller who reaches the
+// origin directly, bypassing Cloudflare, can set this header themselves.
+// Closing that requires restricting the ingress to Cloudflare's published
+// ranges, which is an infrastructure change and not done here.
+// Spelled in Go's canonical form. net/http canonicalizes header keys on
+// both Get and Set, so this matches the "CF-Connecting-IP" sent on the wire.
+const cloudflareHeader = "Cf-Connecting-Ip"
+
+// From returns the address to attribute the request to. It prefers the
+// Cloudflare-supplied client IP and otherwise falls back to the immediate
+// peer. It never returns a caller-controlled value that has not been
+// parsed as an IP address.
+func From(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get(cloudflareHeader)); v != "" {
+		// Parse rather than pass through: the return value becomes a map
+		// key and a database column, so it must be a real address and not
+		// an arbitrary caller-supplied string of arbitrary length.
+		if ip := net.ParseIP(v); ip != nil {
+			return ip.String()
+		}
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr is normally "host:port", but not every transport sets
+		// a port. Fall back to the raw value rather than returning "",
+		// which would collapse every caller into one bucket.
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/clientip/clientip_test.go
+++ b/internal/clientip/clientip_test.go
@@ -82,3 +82,45 @@ func TestFromHandlesIPv6RemoteAddr(t *testing.T) {
 		t.Errorf("From() = %q, want %q", got, "2001:db8::1")
 	}
 }
+
+// Header.Get returns only the FIRST value. The security premise of this
+// package is that Cloudflare's value cannot be forged — but Cloudflare's
+// public documentation does not actually state whether a client-supplied
+// CF-Connecting-IP is overwritten or appended to. If it were ever appended,
+// the first value would be the caller's and the bypass would be back. Taking
+// the last value is correct under either behavior.
+func TestFromUsesTheLastCloudflareConnectingIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	r.RemoteAddr = "10.42.1.5:41234"
+	r.Header.Add("Cf-Connecting-Ip", "203.0.113.9")  // as a caller might forge it
+	r.Header.Add("Cf-Connecting-Ip", "198.51.100.7") // as the edge appends it
+
+	if got := clientip.From(r); got != "198.51.100.7" {
+		t.Errorf("From() = %q, want the last value %q — a forged first value must not win",
+			got, "198.51.100.7")
+	}
+}
+
+// One address must produce one rate-limit bucket however it is spelled.
+// Without the net.IP round-trip, two spellings of the same client become
+// two keys and the limiter is partially bypassable.
+func TestFromCanonicalizesEquivalentSpellings(t *testing.T) {
+	key := func(v string) string {
+		r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+		r.RemoteAddr = "10.42.1.5:41234"
+		r.Header.Set("Cf-Connecting-Ip", v)
+		return clientip.From(r)
+	}
+
+	for _, tc := range []struct{ name, a, b string }{
+		{"ipv4-mapped ipv6", "203.0.113.9", "::ffff:203.0.113.9"},
+		{"ipv4-mapped uppercase", "203.0.113.9", "::FFFF:203.0.113.9"},
+		{"expanded ipv6", "2001:db8::1", "2001:0db8:0000:0000:0000:0000:0000:0001"},
+		{"ipv6 case", "2001:db8::1", "2001:DB8::1"},
+	} {
+		if got, want := key(tc.b), key(tc.a); got != want {
+			t.Errorf("%s: From(%q) = %q, want %q — same client, two buckets",
+				tc.name, tc.b, got, want)
+		}
+	}
+}

--- a/internal/clientip/clientip_test.go
+++ b/internal/clientip/clientip_test.go
@@ -1,0 +1,84 @@
+package clientip_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/clientip"
+)
+
+// The bug this package exists to fix: the rate limiter used the raw
+// X-Forwarded-For header as its per-visitor key, so a caller who varied
+// the header on every request got a fresh limiter every time and was
+// never rate limited at all.
+func TestFromIgnoresClientSuppliedXForwardedFor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	r.RemoteAddr = "10.42.1.5:41234"
+	r.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+	if got := clientip.From(r); got != "10.42.1.5" {
+		t.Errorf("From() = %q, want %q — X-Forwarded-For must not be trusted", got, "10.42.1.5")
+	}
+}
+
+// The regression test for the bypass itself, stated as the property that
+// actually matters: the same peer must map to the same key no matter what
+// headers it sends. If this fails, the rate limiter can be evaded.
+func TestFromIsStableAcrossSpoofedHeaders(t *testing.T) {
+	key := func(xff string) string {
+		r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+		r.RemoteAddr = "10.42.1.5:41234"
+		r.Header.Set("X-Forwarded-For", xff)
+		return clientip.From(r)
+	}
+
+	first, second := key("1.1.1.1"), key("2.2.2.2, 3.3.3.3")
+	if first != second {
+		t.Errorf("From() varied with X-Forwarded-For: %q vs %q — limiter is bypassable", first, second)
+	}
+	// Stability alone is satisfied by any constant, including "", so pin
+	// the value too: the key must be the real peer, not just consistent.
+	if first != "10.42.1.5" {
+		t.Errorf("From() = %q, want the peer address %q", first, "10.42.1.5")
+	}
+}
+
+func TestFromPrefersCloudflareConnectingIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	r.RemoteAddr = "10.42.1.5:41234"
+	r.Header.Set("Cf-Connecting-Ip", "198.51.100.7")
+	r.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+	if got := clientip.From(r); got != "198.51.100.7" {
+		t.Errorf("From() = %q, want the CF-Connecting-IP value", got)
+	}
+}
+
+func TestFromRejectsMalformedCloudflareConnectingIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	r.RemoteAddr = "10.42.1.5:41234"
+	r.Header.Set("Cf-Connecting-Ip", "not-an-ip")
+
+	if got := clientip.From(r); got != "10.42.1.5" {
+		t.Errorf("From() = %q, want fallback to RemoteAddr for an unparseable header", got)
+	}
+}
+
+func TestFromStripsPortFromRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.RemoteAddr = "192.0.2.4:55555"
+
+	if got := clientip.From(r); got != "192.0.2.4" {
+		t.Errorf("From() = %q, want %q", got, "192.0.2.4")
+	}
+}
+
+func TestFromHandlesIPv6RemoteAddr(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.RemoteAddr = "[2001:db8::1]:44321"
+
+	if got := clientip.From(r); got != "2001:db8::1" {
+		t.Errorf("From() = %q, want %q", got, "2001:db8::1")
+	}
+}

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/madalin/forgedesk/internal/clientip"
 )
 
 // RateLimiter provides per-IP rate limiting.
@@ -63,11 +65,10 @@ func (rl *RateLimiter) cleanup() {
 // Limit returns middleware that rate-limits requests by IP.
 func (rl *RateLimiter) Limit(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := r.RemoteAddr
-		// Use X-Forwarded-For if behind a proxy
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			ip = xff
-		}
+		// Keyed on the derived client address, never on a raw header.
+		// Using X-Forwarded-For verbatim here meant a caller could mint a
+		// fresh limiter per request and never be throttled.
+		ip := clientip.From(r)
 
 		limiter := rl.getVisitor(ip)
 		if !limiter.Allow() {

--- a/internal/middleware/ratelimit_spoof_test.go
+++ b/internal/middleware/ratelimit_spoof_test.go
@@ -1,0 +1,71 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/madalin/forgedesk/internal/middleware"
+)
+
+// The /login rate limiter is the mitigation that bounds password guessing.
+// It previously keyed on the raw X-Forwarded-For header, so a caller that
+// changed the header on each request was handed a brand new limiter every
+// time and was never limited. This asserts the property that matters: one
+// peer gets one bucket, whatever headers it sends.
+func TestLimitCountsSpoofedXForwardedForAsOneVisitor(t *testing.T) {
+	rl := middleware.NewRateLimiter(0.1, 2) // burst of 2, then throttled
+	h := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	const attempts = 10
+	limited := 0
+	for i := range attempts {
+		r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+		r.RemoteAddr = "10.42.1.5:41234"
+		// A different forged value on every request — the bypass.
+		r.Header.Set("X-Forwarded-For", "203.0.113."+strconv.Itoa(i))
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, r)
+		if rec.Code == http.StatusTooManyRequests {
+			limited++
+		}
+	}
+
+	if limited == 0 {
+		t.Fatalf("all %d spoofed requests were allowed — the rate limiter is bypassable "+
+			"by varying X-Forwarded-For", attempts)
+	}
+	if want := attempts - 2; limited < want {
+		t.Errorf("limited %d of %d requests, want at least %d (burst is 2)", limited, attempts, want)
+	}
+}
+
+// Distinct real clients must still get their own buckets, or the fix would
+// turn the limiter into a global lock that one caller could use to lock
+// everyone else out.
+func TestLimitKeepsDistinctCloudflareClientsSeparate(t *testing.T) {
+	rl := middleware.NewRateLimiter(0.1, 1)
+	h := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	call := func(clientIP string) int {
+		r := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+		r.RemoteAddr = "10.42.1.5:41234"
+		r.Header.Set("Cf-Connecting-Ip", clientIP)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, r)
+		return rec.Code
+	}
+
+	if code := call("198.51.100.1"); code != http.StatusOK {
+		t.Fatalf("first client got %d, want 200", code)
+	}
+	if code := call("198.51.100.2"); code != http.StatusOK {
+		t.Errorf("second, different client got %d, want 200 — buckets are not per-client", code)
+	}
+}


### PR DESCRIPTION
## The bug

`internal/middleware/ratelimit.go` and `internal/auth/session.go` both did this:

```go
ip := r.RemoteAddr
if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
    ip = xff   // the ENTIRE header, as one value
}
```

`X-Forwarded-For` gains one entry per proxy hop, so its left-hand portion is
whatever the client typed. The real path here is Cloudflare → HAProxy (`10.0.0.6`)
→ Traefik → pod, and Traefik trusts forwarded headers from HAProxy — which is
exactly why this was exploitable end to end rather than theoretically.

**1. The login rate limiter was bypassable with one header.** That string was the
limiter's per-visitor map key, so a different `X-Forwarded-For` per request meant a
fresh `rate.Limiter` per request and the 0.5 req/s limit on `/login` could never
fire. That limiter is what bounds password guessing.

Scope, precisely: this does **not** reopen #142's OOM — that was closed by the
global Argon2 semaphore, which no header can touch. It reopens unthrottled
credential stuffing, and since prod requests carry no deadline, unlimited attempts
saturate every hash slot and legitimate logins queue behind them.

**2. The audit trail was caller-writable.** The same value went into
`sessions.ip_address` (`TEXT`, no length constraint) — personal data under GDPR,
and the column you reach for during incident response. A caller could store ~1 MB
of arbitrary text per session row.

## The fix

New `internal/clientip`. `From(r)` takes the **last** `CF-Connecting-IP` value,
parses it as an IP, and otherwise falls back to the `RemoteAddr` host.

`X-Forwarded-For` is dropped entirely rather than parsed from the right: with
Cloudflare, HAProxy and Traefik all appending, the client's real index in that
header is deployment-dependent and breaks the moment a hop changes.

Three deliberate details, each load-bearing:

- **`Header.Values`, not `Header.Get`.** `Get` returns the *first* value.
  Cloudflare's published documentation does not state whether a client-supplied
  `CF-Connecting-IP` is overwritten or appended. If it were ever appended, the
  forged first value would win and the bypass would be back. Reading the last
  element is correct either way, so this no longer depends on undocumented vendor
  behavior.
- **Parsed, not passed through.** The value becomes a map key and a database
  column, so it must be a real address — not arbitrary caller-supplied text.
- **`net.IP` round-trip for canonicalization.** `::ffff:203.0.113.9` and
  `203.0.113.9` are one client; without it they'd be two rate-limit buckets.

The package sits outside `internal/auth` because `internal/middleware` already
imports `internal/auth` — putting it there is an import cycle.

### Residual risk, stated precisely

A caller who reaches the origin **directly**, bypassing Cloudflare, can set
`CF-Connecting-IP` themselves. That has two consequences, not one:

1. they can evade the limiter with a fresh value per request, and
2. they can **deny `/login` to a chosen victim** by forging that victim's IP at
   >0.5 rps — the victim gets 429 on `/login`, `/verify-2fa`, `/setup-2fa` and
   `/register` for as long as it runs.

Both close by restricting HAProxy to Cloudflare's published ranges. That's
infrastructure and out of scope here; it is documented in the package doc so the
next reader doesn't assume more than the code delivers.

Also worth knowing for that follow-up: `/invite/{token}` is not inside the
rate-limited group. Pre-existing, unchanged by this PR.

## Evidence — what would be true if this were broken, and what I ran

Written **test-first**. Before the fix the middleware test failed with:

```
all 10 spoofed requests were allowed — the rate limiter is bypassable
by varying X-Forwarded-For
```

That message is the exploit as an executable assertion. Written after the fix it
would have passed immediately and proved nothing.

**Mutation-tested, by the reviewer and then by me.** Six mutants of `clientip.From`:

| Mutant | Result |
|---|---|
| return `r.RemoteAddr` raw | killed (7 tests) |
| return CF header unparsed | killed |
| return trimmed CF header unparsed | killed |
| ignore CF entirely | killed |
| the original bug (raw XFF) | killed (5 tests) |
| validate but return raw spelling | **survived → now killed** by `TestFromCanonicalizesEquivalentSpellings` |

The last row is the point of the second commit. That test guards behavior that
already worked, so it could not have a RED — instead I re-introduced the mutant,
watched all four spellings fail, restored, and confirmed the file was byte-clean. A
test never observed failing is a claim, not a check.

| Check | Result |
|---|---|
| Tests | 10 new — 8 in `internal/clientip`, 2 in `internal/middleware` |
| Full suite | 25 packages, **0 failures, 0 skips**, `internal/handlers` 18.5s |
| `bash scripts/lint.sh` (pinned 2.11.4) | **0 issues** |
| Pre-existing tests modified | **none** |

`TestLimitKeepsDistinctCloudflareClientsSeparate` guards the opposite failure: the
fix must not collapse into one global limiter a single caller could use to lock
everyone out. The middleware tests drive the real `Limit` middleware through
`ServeHTTP` rather than injecting a key by hand.

One test was strengthened mid-cycle: `TestFromIsStableAcrossSpoofedHeaders` passed
against a stub returning `""` — any constant satisfies "stable" — so it now pins the
expected value too.

### Coverage note worth acting on separately

The suite stayed green across a change that alters what both call sites produce
(`192.0.2.1` rather than `192.0.2.1:1234`), because **no test anywhere asserts on
`sessions.ip_address`**. That column has been untested since it was introduced.
Not fixed here; flagging it.

## Post-deploy verification

`CF-Connecting-IP` is always set on Cloudflare-proxied requests, but that assumption
is cheap to prove rather than trust:

1. Log in through Cloudflare sending `-H 'CF-Connecting-IP: 203.0.113.9'`, then
   `SELECT ip_address FROM sessions ORDER BY created_at DESC LIMIT 1` — it must show
   your real public IP, not `203.0.113.9` and not `10.42.x.x`.
2. Hit `/login` seven times with a different forged value each time — it must 429 on
   the sixth.

If either fails, the `Header.Values` change is no longer belt-and-braces.

Note: if Cloudflare proxying were ever switched to grey-cloud, every visitor
collapses to one bucket and one caller could lock out `/login` for everyone. That's
an operator action rather than an attacker capability, but it's a new consequence of
dropping `X-Forwarded-For` and worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYdZ22AYw7Ha4jgDpMd6Bb